### PR TITLE
Removed ExpReal::evaluate().

### DIFF
--- a/vhdlpp/expression.cc
+++ b/vhdlpp/expression.cc
@@ -307,12 +307,6 @@ ExpReal::~ExpReal()
 {
 }
 
-bool ExpReal::evaluate(ScopeBase*, double&val) const
-{
-      val = value_;
-      return true;
-}
-
 ExpLogical::ExpLogical(ExpLogical::fun_t ty, Expression*op1, Expression*op2)
 : ExpBinary(op1, op2), fun_(ty)
 {

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -519,7 +519,6 @@ class ExpReal : public Expression {
       int emit(ostream&out, Entity*ent, Architecture*arc);
       int emit_package(std::ostream&out);
       bool is_primary(void) const;
-      bool evaluate(ScopeBase*scope, double&val) const;
       void dump(ostream&out, int indent = 0) const;
       virtual ostream& dump_inline(ostream&out) const;
 


### PR DESCRIPTION
As remarked by Cary, I removed the confusing method. evaluate() seems to be used for ranges that are not expected to be real type. Thank you for the review.
