### PR TITLE
Update

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -1000,6 +1000,9 @@ class PECastType  : public PExpr {
       void dump(ostream &out) const;
 
       virtual NetExpr*elaborate_expr(Design*des, NetScope*scope,
+				     ivl_type_t type, unsigned flags) const;
+
+      virtual NetExpr*elaborate_expr(Design*des, NetScope*scope,
 				     unsigned expr_wid, unsigned flags) const;
 
       virtual unsigned test_width(Design*des, NetScope*scope,

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -2536,7 +2536,7 @@ unsigned PECastType::test_width(Design*des, NetScope*scope, width_mode_t&wid)
 	    expr_width_ = t->packed_width();
       }
 
-      signed_flag_= t->get_signed();
+      signed_flag_ = t->get_signed();
       min_width_ = expr_width_;
       return expr_width_;
 }

--- a/pform.cc
+++ b/pform.cc
@@ -2354,6 +2354,11 @@ void pform_module_define_port(const struct vlltype&li,
 	    signed_flag = false;
 	    prange = 0;
 
+      } else if (enum_type_t*enum_type = dynamic_cast<enum_type_t*>(vtype)) {
+	    data_type = enum_type->base_type;
+	    signed_flag = enum_type->signed_flag;
+	    prange = enum_type->range.get();
+
       } else if (vtype) {
 	    VLerror(li, "sorry: Given type %s not supported here (%s:%d).",
 		    typeid(*vtype).name(), __FILE__, __LINE__);

--- a/tgt-vvp/eval_object.c
+++ b/tgt-vvp/eval_object.c
@@ -129,12 +129,15 @@ static int eval_darray_new(ivl_expr_t ex)
 	    unsigned wid;
 	    switch (ivl_type_base(element_type)) {
 		case IVL_VT_BOOL:
+		case IVL_VT_LOGIC:
 		  wid = width_of_packed_type(element_type);
-		  draw_eval_vec4(init_expr);
-		  resize_vec4_wid(init_expr, wid);
 		  for (idx = 0 ; idx < cnt ; idx += 1) {
-			fprintf(vvp_out, "    %%ix/load 3, %ld, 0;\n", idx);
+			draw_eval_vec4(init_expr);
+			fprintf(vvp_out, "    %%parti/%c %d, %ld, 6;\n",
+                                ivl_expr_signed(init_expr) ? 's' : 'u', wid, idx * wid);
+			fprintf(vvp_out, "    %%ix/load 3, %ld, 0;\n", cnt - idx - 1);
 			fprintf(vvp_out, "    %%set/dar/obj/vec4 3;\n");
+			fprintf(vvp_out, "    %%pop/vec4 1;\n");
 		  }
 		  break;
 		case IVL_VT_REAL:

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -444,9 +444,18 @@ static int show_stmt_assign_vector(ivl_statement_t net)
 	    fprintf(vvp_out, "    %%cvt/vr %u;\n", wid);
 
       } else if (ivl_expr_value(rval) == IVL_VT_STRING) {
-	    /* Special case: vector to string casting */
+	    /* Special case: string to vector casting */
 	    ivl_lval_t lval = ivl_stmt_lval(net, 0);
 	    fprintf(vvp_out, "    %%vpi_call %u %u \"$ivl_string_method$to_vec\", v%p_0, v%p_0 {0 0 0};\n",
+		ivl_file_table_index(ivl_stmt_file(net)), ivl_stmt_lineno(net),
+		ivl_expr_signal(rval), ivl_lval_sig(lval));
+	    if (slices) free(slices);
+            return 0;
+
+      } else if (ivl_expr_value(rval) == IVL_VT_DARRAY) {
+	    /* Special case: dynamic array to vector casting */
+	    ivl_lval_t lval = ivl_stmt_lval(net, 0);
+	    fprintf(vvp_out, "    %%vpi_call %u %u \"$ivl_darray_method$to_vec\", v%p_0, v%p_0 {0 0 0};\n",
 		ivl_file_table_index(ivl_stmt_file(net)), ivl_stmt_lineno(net),
 		ivl_expr_signal(rval), ivl_lval_sig(lval));
 	    if (slices) free(slices);

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -455,9 +455,22 @@ static int show_stmt_assign_vector(ivl_statement_t net)
       } else if (ivl_expr_value(rval) == IVL_VT_DARRAY) {
 	    /* Special case: dynamic array to vector casting */
 	    ivl_lval_t lval = ivl_stmt_lval(net, 0);
+            void*rval_addr = NULL;
+
+            /* Even more special case: function call returning dynamic array */
+            if(ivl_expr_type(rval) == IVL_EX_UFUNC) {
+                rval_addr = ivl_scope_port(ivl_expr_def(rval), 0);
+                draw_ufunc_object(rval);
+                /* We do not need to store the result, it is going to be
+                   converted to vector quite soon. */
+                fprintf(vvp_out, "    %%pop/obj 1, 0; drop the result\n");
+            } else {
+                rval_addr = ivl_expr_signal(rval);
+            }
+
 	    fprintf(vvp_out, "    %%vpi_call %u %u \"$ivl_darray_method$to_vec\", v%p_0, v%p_0 {0 0 0};\n",
 		ivl_file_table_index(ivl_stmt_file(net)), ivl_stmt_lineno(net),
-		ivl_expr_signal(rval), ivl_lval_sig(lval));
+		rval_addr, ivl_lval_sig(lval));
 	    if (slices) free(slices);
             return 0;
 

--- a/vhdlpp/architec_elaborate.cc
+++ b/vhdlpp/architec_elaborate.cc
@@ -368,9 +368,16 @@ int SignalAssignment::elaborate(Entity*ent, Architecture*arc)
 	    return errors;
       }
 
-      for (list<Expression*>::const_iterator cur = rval_.begin()
+      for (list<Expression*>::iterator cur = rval_.begin()
 		 ; cur != rval_.end() ; ++cur) {
 	    (*cur)->elaborate_expr(ent, arc, lval_type);
+
+            // Handle functions that return unbounded arrays
+        if(ExpFunc*call = dynamic_cast<ExpFunc*>(*cur)) {
+                const VType*ret_type = call->func_ret_type();
+                if(ret_type && ret_type->is_unbounded())
+                    *cur = new ExpCast(*cur, get_global_typedef(lval_type));
+        }
       }
 
       return errors;

--- a/vhdlpp/architec_elaborate.cc
+++ b/vhdlpp/architec_elaborate.cc
@@ -373,11 +373,6 @@ int SignalAssignment::elaborate(Entity*ent, Architecture*arc)
 	    (*cur)->elaborate_expr(ent, arc, lval_type);
 
             // Handle functions that return unbounded arrays
-        if(ExpFunc*call = dynamic_cast<ExpFunc*>(*cur)) {
-                const VType*ret_type = call->func_ret_type();
-                if(ret_type && ret_type->is_unbounded())
-                    *cur = new ExpCast(*cur, get_global_typedef(lval_type));
-        }
       }
 
       return errors;

--- a/vhdlpp/architec_elaborate.cc
+++ b/vhdlpp/architec_elaborate.cc
@@ -369,7 +369,7 @@ int SignalAssignment::elaborate(Entity*ent, Architecture*arc)
 
       for (list<Expression*>::iterator cur = rval_.begin()
 		 ; cur != rval_.end() ; ++cur) {
-	    (*cur)->elaborate_expr(ent, arc, lval_type);
+	    errors += (*cur)->elaborate_expr(ent, arc, lval_type);
       }
 
       return errors;

--- a/vhdlpp/architec_elaborate.cc
+++ b/vhdlpp/architec_elaborate.cc
@@ -370,8 +370,6 @@ int SignalAssignment::elaborate(Entity*ent, Architecture*arc)
       for (list<Expression*>::iterator cur = rval_.begin()
 		 ; cur != rval_.end() ; ++cur) {
 	    (*cur)->elaborate_expr(ent, arc, lval_type);
-
-            // Handle functions that return unbounded arrays
       }
 
       return errors;

--- a/vhdlpp/architec_elaborate.cc
+++ b/vhdlpp/architec_elaborate.cc
@@ -98,9 +98,8 @@ int ComponentInstantiation::elaborate(Entity*ent, Architecture*arc)
 	      // exists in the component declaration
 	    const InterfacePort*iparm = base->find_generic(cur->first);
 	    if (iparm == 0) {
-		  cerr << get_fileline() << ": error: No generic " << cur->first
+		  cerr << get_fileline() << ": warning: No generic " << cur->first
 		       << " in component " << cname_ << "." << endl;
-		  errors += 1;
 		  continue;
 	    }
 

--- a/vhdlpp/architec_emit.cc
+++ b/vhdlpp/architec_emit.cc
@@ -70,12 +70,12 @@ int Architecture::emit(ostream&out, Entity*entity)
 	// of the full definition.
 
       typedef_context_t typedef_ctx;
-      for (map<perm_string,const VType*>::iterator cur = use_types_.begin()
-		 ; cur != use_types_.end() ; ++cur) {
+      //for (map<perm_string,const VType*>::iterator cur = use_types_.begin()
+		 //; cur != use_types_.end() ; ++cur) {
 
-	    if(const VTypeDef*def = dynamic_cast<const VTypeDef*>(cur->second))
-		errors += def->emit_typedef(out, typedef_ctx);
-      }
+	    //if(const VTypeDef*def = dynamic_cast<const VTypeDef*>(cur->second))
+		//errors += def->emit_typedef(out, typedef_ctx);
+      //}
       for (map<perm_string,const VType*>::iterator cur = cur_types_.begin()
 		 ; cur != cur_types_.end() ; ++cur) {
 

--- a/vhdlpp/architec_emit.cc
+++ b/vhdlpp/architec_emit.cc
@@ -103,7 +103,9 @@ int Architecture::emit(ostream&out, Entity*entity)
 
       for (map<perm_string,Subprogram*>::const_iterator cur = cur_subprograms_.begin()
 		 ; cur != cur_subprograms_.end() ; ++ cur) {
-	    errors += cur->second->emit_package(out);
+	    // Do not emit unbounded functions, we will just need fixed instances later
+	    if(!cur->second->unbounded())
+                errors += cur->second->emit_package(out);
       }
 
       for (list<Architecture::Statement*>::iterator cur = statements_.begin()

--- a/vhdlpp/expression.cc
+++ b/vhdlpp/expression.cc
@@ -494,6 +494,11 @@ ExpRelation::~ExpRelation()
 {
 }
 
+ExpShift::ExpShift(ExpShift::shift_t op, Expression*op1, Expression*op2)
+: ExpBinary(op1, op2), shift_(op)
+{
+}
+
 ExpString::ExpString(const char* value)
 : value_(strlen(value))
 {

--- a/vhdlpp/expression.cc
+++ b/vhdlpp/expression.cc
@@ -439,3 +439,12 @@ ExpCast::~ExpCast()
 {
 }
 
+ExpNew::ExpNew(Expression*size) :
+    size_(size)
+{
+}
+
+ExpNew::~ExpNew()
+{
+    delete size_;
+}

--- a/vhdlpp/expression.cc
+++ b/vhdlpp/expression.cc
@@ -423,3 +423,13 @@ ExpUNot::ExpUNot(Expression*op1)
 ExpUNot::~ExpUNot()
 {
 }
+
+ExpCast::ExpCast(Expression*base, const VType*type) :
+    base_(base), type_(type)
+{
+}
+
+ExpCast::~ExpCast()
+{
+}
+

--- a/vhdlpp/expression.cc
+++ b/vhdlpp/expression.cc
@@ -286,7 +286,7 @@ ExpFunc::~ExpFunc()
 
 const VType* ExpFunc::func_ret_type() const
 {
-    return def_->peek_return_type();
+    return def_ ? def_->peek_return_type() : NULL;
 }
 
 ExpInteger::ExpInteger(int64_t val)

--- a/vhdlpp/expression.cc
+++ b/vhdlpp/expression.cc
@@ -20,6 +20,7 @@
  */
 
 # include  "expression.h"
+# include  "subprogram.h"
 # include  "parse_types.h"
 # include  "scope.h"
 # include  <iostream>
@@ -281,6 +282,11 @@ ExpFunc::~ExpFunc()
 {
       for (size_t idx = 0 ; idx < argv_.size() ; idx += 1)
 	    delete argv_[idx];
+}
+
+const VType* ExpFunc::func_ret_type() const
+{
+    return def_->peek_return_type();
 }
 
 ExpInteger::ExpInteger(int64_t val)

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -692,6 +692,27 @@ class ExpRelation : public ExpBinary {
       fun_t fun_;
 };
 
+class ExpShift : public ExpBinary {
+    public:
+      enum shift_t { SRL, SLL, SRA, SLA, ROL, ROR };
+
+    public:
+      ExpShift(ExpShift::shift_t op, Expression*op1, Expression*op2);
+
+      Expression*clone() const {
+          return new ExpShift(shift_, peek_operand1()->clone(), peek_operand2()->clone());
+      }
+
+      int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
+      void write_to_stream(std::ostream&fd) const;
+      int emit(ostream&out, Entity*ent, ScopeBase*scope);
+      virtual bool evaluate(ScopeBase*scope, int64_t&val) const;
+      void dump(ostream&out, int indent = 0) const;
+
+    private:
+      shift_t shift_;
+};
+
 class ExpString : public Expression {
 
     public:

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -477,6 +477,7 @@ class ExpFunc : public Expression {
       inline perm_string func_name() const { return name_; }
       inline size_t func_args() const { return argv_.size(); }
       inline const Expression*func_arg(size_t idx) const { return argv_[idx]; }
+      const VType*func_ret_type() const;
 
     public: // Base methods
       int elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype);

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -696,4 +696,23 @@ class ExpCast : public Expression {
       const VType*type_;
 };
 
+/*
+ * Class that handles 'new' statement. VHDL is not capable of dynamic memory
+ * allocation, but it is useful for emitting some cases.
+ */
+class ExpNew : public Expression {
+
+    public:
+      ExpNew(Expression*size);
+      ~ExpNew();
+
+      // There is no 'new' in VHDL - do not emit anything
+      void write_to_stream(std::ostream&) {};
+      int emit(ostream&out, Entity*ent, Architecture*arc);
+      void dump(ostream&out, int indent = 0) const;
+
+    private:
+      Expression*size_;
+};
+
 #endif /* IVL_expression_H */

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -674,4 +674,25 @@ class ExpUNot : public ExpUnary {
       void dump(ostream&out, int indent = 0) const;
 };
 
+/*
+ * Class that wraps other expressions to cast them to other types.
+ */
+class ExpCast : public Expression {
+
+    public:
+      ExpCast(Expression*base, const VType*type);
+      ~ExpCast();
+
+      inline int elaborate_expr(Entity*ent, Architecture*arc, const VType*) {
+            return base_->elaborate_expr(ent, arc, type_);
+      }
+      void write_to_stream(std::ostream&fd);
+      int emit(ostream&out, Entity*ent, Architecture*arc);
+      void dump(ostream&out, int indent = 0) const;
+
+    private:
+      Expression*base_;
+      const VType*type_;
+};
+
 #endif /* IVL_expression_H */

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -501,7 +501,7 @@ class ExpInteger : public Expression {
       void write_to_stream(std::ostream&fd);
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       int emit_package(std::ostream&out);
-      bool is_primary(void) const;
+      bool is_primary(void) const { return true; }
       bool evaluate(ScopeBase*scope, int64_t&val) const;
       void dump(ostream&out, int indent = 0) const;
       virtual ostream& dump_inline(ostream&out) const;

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -87,7 +87,7 @@ class Expression : public LineInfo {
 	// This virtual method writes a VHDL-accurate representation
 	// of this expression to the designated stream. This is used
 	// for writing parsed types to library files.
-      virtual void write_to_stream(std::ostream&fd) =0;
+      virtual void write_to_stream(std::ostream&fd) const =0;
 
 	// The emit virtual method is called by architecture emit to
 	// output the generated code for the expression. The derived
@@ -163,7 +163,7 @@ class ExpUnary : public Expression {
       const VType*fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const;
 
     protected:
-      inline void write_to_stream_operand1(std::ostream&fd)
+      inline void write_to_stream_operand1(std::ostream&fd) const
       { operand1_->write_to_stream(fd); }
 
       int emit_operand1(ostream&out, Entity*ent, ScopeBase*scope);
@@ -197,9 +197,9 @@ class ExpBinary : public Expression {
       bool eval_operand1(ScopeBase*scope, int64_t&val) const;
       bool eval_operand2(ScopeBase*scope, int64_t&val) const;
 
-      inline void write_to_stream_operand1(std::ostream&out)
+      inline void write_to_stream_operand1(std::ostream&out) const
           { operand1_->write_to_stream(out); }
-      inline void write_to_stream_operand2(std::ostream&out)
+      inline void write_to_stream_operand2(std::ostream&out) const
           { operand2_->write_to_stream(out); }
 
       void dump_operands(ostream&out, int indent = 0) const;
@@ -297,7 +297,7 @@ class ExpAggregate : public Expression {
       const VType*probe_type(Entity*ent, ScopeBase*scope) const;
       const VType*fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -330,7 +330,7 @@ class ExpArithmetic : public ExpBinary {
       }
 
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       virtual bool evaluate(ScopeBase*scope, int64_t&val) const;
       void dump(ostream&out, int indent = 0) const;
@@ -355,7 +355,7 @@ class ExpAttribute : public Expression {
 
       const VType*probe_type(Entity*ent, ScopeBase*scope) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
 	// Some attributes can be evaluated at compile time
       bool evaluate(ScopeBase*scope, int64_t&val) const;
@@ -378,7 +378,7 @@ class ExpBitstring : public Expression {
 
       const VType*fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -398,7 +398,7 @@ class ExpCharacter : public Expression {
 
       const VType*fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       bool is_primary(void) const;
       void dump(ostream&out, int indent = 0) const;
@@ -426,7 +426,7 @@ class ExpConcat : public Expression {
       const VType*probe_type(Entity*ent, ScopeBase*scope) const;
       const VType*fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       virtual bool evaluate(ScopeBase*scope, int64_t&val) const;
       bool is_primary(void) const;
@@ -473,7 +473,7 @@ class ExpConditional : public Expression {
 
       const VType*probe_type(Entity*ent, ScopeBase*scope) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -500,7 +500,7 @@ class ExpEdge : public ExpUnary {
 
       inline fun_t edge_fun() const { return fun_; }
 
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -524,7 +524,7 @@ class ExpFunc : public Expression {
 
     public: // Base methods
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -545,7 +545,7 @@ class ExpInteger : public Expression {
 
       const VType*probe_type(Entity*ent, ScopeBase*scope) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       int emit_package(std::ostream&out);
       bool is_primary(void) const { return true; }
@@ -568,7 +568,7 @@ class ExpReal : public Expression {
 
       const VType*probe_type(Entity*ent, ScopeBase*scope) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       int emit_package(std::ostream&out);
       bool is_primary(void) const;
@@ -595,7 +595,7 @@ class ExpLogical : public ExpBinary {
       inline fun_t logic_fun() const { return fun_; }
 
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -628,7 +628,7 @@ class ExpName : public Expression {
       const VType* probe_type(Entity*ent, ScopeBase*scope) const;
       const VType* fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*host) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       bool is_primary(void) const;
       bool evaluate(ScopeBase*scope, int64_t&val) const;
@@ -684,7 +684,7 @@ class ExpRelation : public ExpBinary {
 
       const VType* probe_type(Entity*ent, ScopeBase*scope) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -703,7 +703,7 @@ class ExpString : public Expression {
 
       const VType*fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const;
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       bool is_primary(void) const;
       void dump(ostream&out, int indent = 0) const;
@@ -724,7 +724,7 @@ class ExpUAbs : public ExpUnary {
 
       Expression*clone() const { return new ExpUAbs(peek_operand()->clone()); }
 
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 };
@@ -738,7 +738,7 @@ class ExpUNot : public ExpUnary {
       Expression*clone() const { return new ExpUNot(peek_operand()->clone()); }
 
       int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 };
@@ -757,7 +757,7 @@ class ExpCast : public Expression {
       inline int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*) {
             return base_->elaborate_expr(ent, scope, type_);
       }
-      void write_to_stream(std::ostream&fd);
+      void write_to_stream(std::ostream&fd) const;
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 
@@ -779,7 +779,7 @@ class ExpNew : public Expression {
       Expression*clone() const { return new ExpNew(size_->clone()); }
 
       // There is no 'new' in VHDL - do not emit anything
-      void write_to_stream(std::ostream&) {};
+      void write_to_stream(std::ostream&) const {};
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent = 0) const;
 

--- a/vhdlpp/expression_debug.cc
+++ b/vhdlpp/expression_debug.cc
@@ -82,3 +82,33 @@ void ExpNew::dump(ostream&out, int indent) const
       out << "New dynamic array size: ";
       size_->dump(out, indent);
 }
+
+void ExpShift::dump(ostream&out, int indent) const
+{
+      const char*fun_name = "?";
+      switch (shift_) {
+	  case SRL:
+	    fun_name = "srl";
+	    break;
+	  case SLL:
+	    fun_name = "sll";
+	    break;
+	  case SLA:
+	    fun_name = "sla";
+	    break;
+	  case SRA:
+	    fun_name = "sra";
+	    break;
+	  case ROR:
+	    fun_name = "ror";
+	    break;
+	  case ROL:
+	    fun_name = "rol";
+	    break;
+      }
+
+      out << setw(indent) << "" << "Shift " << fun_name
+	  << " at " << get_fileline() << endl;
+      dump_operands(out, indent+4);
+}
+

--- a/vhdlpp/expression_debug.cc
+++ b/vhdlpp/expression_debug.cc
@@ -76,3 +76,9 @@ void ExpCast::dump(ostream&out, int indent) const
       out << " to ";
       type_->emit_def(out, empty_perm_string);
 }
+
+void ExpNew::dump(ostream&out, int indent) const
+{
+      out << "New dynamic array size: ";
+      size_->dump(out, indent);
+}

--- a/vhdlpp/expression_debug.cc
+++ b/vhdlpp/expression_debug.cc
@@ -68,3 +68,11 @@ void ExpConcat::dump(ostream&out, int indent) const
       operand1_->dump(out, indent);
       operand2_->dump(out, indent);
 }
+
+void ExpCast::dump(ostream&out, int indent) const
+{
+      out << "Casting ";
+      base_->dump(out, indent+4);
+      out << " to ";
+      type_->emit_def(out, empty_perm_string);
+}

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -594,6 +594,10 @@ const VType*ExpBitstring::fit_type(Entity*, ScopeBase*, const VTypeArray*atype) 
 int ExpBitstring::elaborate_expr(Entity*, ScopeBase*, const VType*)
 {
       int errors = 0;
+      std::vector<VTypeArray::range_t> range;
+      range.push_back(VTypeArray::range_t(new ExpInteger(value_.size() - 1), new ExpInteger(0)));
+      const VTypeArray*type = new VTypeArray(&primitive_STDLOGIC, range);
+      set_type(type);
       return errors;
 }
 

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -922,11 +922,85 @@ const VType* ExpName::fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*)co
       return probe_type(ent, scope);
 }
 
-int ExpName::elaborate_expr(Entity*, ScopeBase*, const VType*ltype)
+int ExpName::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
+      const VType*type = NULL;
+      Expression*exp = NULL;
+
       if (ltype) {
 	    ivl_assert(*this, ltype != 0);
 	    set_type(ltype);
+      }
+
+      // Currently constant arrays of vectors are flattened to single one-dimensional
+      // localparams. If the user wants to access a particular word, then it is
+      // necessary to extract the adequate part of the localparam.
+      // e.g.
+      // declarations:
+      // == VHDL ==
+      // type uns_array is array (natural range <>) of unsigned(7 downto 0);
+      // constant const_array : uns_array(2 downto 0) :=
+      //        (0 => "00110011", 1 => "101010101", 2=> "00001111");
+      // == SystemVerilog ==
+      // localparam const_array = { 8'b00110011, 8'b10101010, 8'b00001111 };
+      //
+      // access:
+      // == VHDL ==
+      // target_var := const_array(1);
+      // == SystemVerilog ==
+      // target_var = const_array[15:8];    // <- indices adjusted to pick the word
+
+      if(index_ && scope) {
+          if(!scope->find_constant(name_, type, exp))
+              return 0;
+
+          const VTypeArray*arr = dynamic_cast<const VTypeArray*>(type);
+          ivl_assert(*this, arr);    // if there is an index, it should be an array, right?
+
+          const VType*element = arr->element_type();
+          const VTypeArray*arr_element = dynamic_cast<const VTypeArray*>(element);
+          if(!arr_element) {
+              // index adjustments are not necessary, it is not an array of vectors
+              return 0;
+          }
+
+          ivl_assert(*this, arr_element->dimensions() == 1);
+          if(arr_element->dimensions() != 1) {
+              cerr << get_fileline() << ": Sorry, only one-dimensional constant arrays are handled." << endl;
+              return 1;
+          }
+
+          int64_t start_val;
+          bool start_rc = arr_element->dimension(0).msb()->evaluate(ent, scope, start_val);
+
+          int64_t finish_val;
+          bool finish_rc = arr_element->dimension(0).lsb()->evaluate(ent, scope, finish_val);
+
+          if(!start_rc || !finish_rc) {
+              cerr << get_fileline() << ": Could not evaluate the word size." << endl;
+              return 1;
+          }
+
+          int word_size = abs(start_val - finish_val) + 1;
+
+          ExpInteger*size = new ExpInteger(word_size);
+          Expression*new_index, *new_lsb;
+
+          // new indices = [index_ * word_size + word_size : lsb_ * word_size]
+          if(lsb_) {
+              ExpArithmetic*tmp = new ExpArithmetic(ExpArithmetic::MULT, index_->clone(), size->clone());
+              new_index = new ExpArithmetic(ExpArithmetic::PLUS, tmp, size->clone());
+              new_lsb = new ExpArithmetic(ExpArithmetic::MULT, lsb_->clone(), size->clone());
+          } else {
+              new_lsb = new ExpArithmetic(ExpArithmetic::MULT, index_->clone(), size->clone());
+              new_index = new ExpArithmetic(ExpArithmetic::PLUS, new_lsb->clone(), size->clone());
+          }
+          delete index_;
+          delete lsb_;
+          delete size;
+
+          index_ = new_index;
+          lsb_ = new_lsb;
       }
 
       return 0;

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -570,7 +570,7 @@ const VType* ExpAttribute::probe_type(Entity*ent, ScopeBase*scope) const
       base_->probe_type(ent, scope);
 
       if (name_ == "length" || name_ == "left" || name_ == "right") {
-	    return &primitive_INTEGER;
+	    return &primitive_NATURAL;
       }
 
       return 0;

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -513,7 +513,9 @@ int ExpAggregate::elaborate_expr_record_(Entity*ent, Architecture*arc, const VTy
             ivl_assert(*this, field);
 
             perm_string field_name = field->peek_name();
+            idx = -1;
             const VTypeRecord::element_t*el = ltype->element_by_name(field_name, &idx);
+            ivl_assert(*this, idx >= 0);
 
             aggregate_[idx] = tmp;
             errors += aggregate_[idx].expr->elaborate_expr(ent, arc, el->peek_type());

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -757,6 +757,8 @@ int ExpFunc::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*)
       ivl_assert(*this, def_==0);
       def_ = prog;
 
+      bool new_instance = false;
+
 	// Elaborate arguments
       for (size_t idx = 0 ; idx < argv_.size() ; idx += 1) {
 	    const VType*tmp = argv_[idx]->probe_type(ent, scope);
@@ -769,8 +771,13 @@ int ExpFunc::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*)
 
             // Type casting for unbounded arrays
             if(param_type && param_type->is_unbounded() /*&& !param_type->type_match(tmp)*/) {
-                argv_[idx] = new ExpCast(argv_[idx], get_global_typedef(param_type));
+                new_instance = true;    // we need a new instance
             }
+      }
+
+      if(new_instance) {
+            def_ = prog->make_instance(argv_, scope);
+            name_ = def_->name();
       }
 
       return errors;

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -33,20 +33,20 @@
 
 using namespace std;
 
-int Expression::elaborate_lval(Entity*, Architecture*, bool)
+int Expression::elaborate_lval(Entity*, ScopeBase*, bool)
 {
       cerr << get_fileline() << ": error: Expression is not a valid l-value." << endl;
       return 1;
 }
 
-const VType* Expression::probe_type(Entity*, Architecture*) const
+const VType* Expression::probe_type(Entity*, ScopeBase*) const
 {
       return 0;
 }
 
-const VType* Expression::fit_type(Entity*ent, Architecture*arc, const VTypeArray*) const
+const VType* Expression::fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*) const
 {
-      const VType*res = probe_type(ent,arc);
+      const VType*res = probe_type(ent,scope);
       if (res == 0) {
 	    cerr << get_fileline() << ": internal error: "
 		 << "fit_type for " << typeid(*this).name()
@@ -56,7 +56,7 @@ const VType* Expression::fit_type(Entity*ent, Architecture*arc, const VTypeArray
       return res;
 }
 
-const VType*ExpName::elaborate_adjust_type_with_range_(Entity*, Architecture*arc, const VType*type)
+const VType*ExpName::elaborate_adjust_type_with_range_(Entity*, ScopeBase*scope, const VType*type)
 {
 	// Unfold typedefs
       while (const VTypeDef*tdef = dynamic_cast<const VTypeDef*>(type)) {
@@ -75,9 +75,9 @@ const VType*ExpName::elaborate_adjust_type_with_range_(Entity*, Architecture*arc
 		  int64_t use_msb, use_lsb;
 		  bool flag;
 
-		  flag = index_->evaluate(arc, use_msb);
+		  flag = index_->evaluate(scope, use_msb);
 		  ivl_assert(*this, flag);
-		  flag = lsb_->evaluate(arc, use_lsb);
+		  flag = lsb_->evaluate(scope, use_lsb);
 		  ivl_assert(*this, flag);
 
 		  Expression*exp_msb = new ExpInteger(use_msb);
@@ -91,7 +91,7 @@ const VType*ExpName::elaborate_adjust_type_with_range_(Entity*, Architecture*arc
       return type;
 }
 
-int ExpName::elaborate_lval_(Entity*ent, Architecture*arc, bool is_sequ, ExpName*suffix)
+int ExpName::elaborate_lval_(Entity*ent, ScopeBase*scope, bool is_sequ, ExpName*suffix)
 {
       int errors = 0;
 
@@ -134,13 +134,13 @@ int ExpName::elaborate_lval_(Entity*ent, Architecture*arc, bool is_sequ, ExpName
 		 << ent->get_name() << "." << endl;
 	    return errors + 1;
 
-      } else if (Signal*sig = arc->find_signal(name_)) {
+      } else if (Signal*sig = scope->find_signal(name_)) {
 	      // Tell the target signal that this may be a sequential l-value.
 	    if (is_sequ) sig->count_ref_sequ();
 
 	    found_type = sig->peek_type();
 
-      } else if (Variable*var = arc->find_variable(name_)) {
+      } else if (Variable*var = scope->find_variable(name_)) {
 	      // Tell the target signal that this may be a sequential l-value.
 	    if (is_sequ) var->count_ref_sequ();
 
@@ -201,7 +201,7 @@ int ExpName::elaborate_lval_(Entity*ent, Architecture*arc, bool is_sequ, ExpName
 	    return errors;
       }
 
-      suffix_type = suffix->elaborate_adjust_type_with_range_(ent, arc, suffix_type);
+      suffix_type = suffix->elaborate_adjust_type_with_range_(ent, scope, suffix_type);
 
       ivl_assert(*this, suffix_type);
       suffix->set_type(suffix_type);
@@ -209,12 +209,12 @@ int ExpName::elaborate_lval_(Entity*ent, Architecture*arc, bool is_sequ, ExpName
       return errors;
 }
 
-int ExpName::elaborate_lval(Entity*ent, Architecture*arc, bool is_sequ)
+int ExpName::elaborate_lval(Entity*ent, ScopeBase*scope, bool is_sequ)
 {
       int errors = 0;
 
       if (prefix_.get()) {
-	    return prefix_->elaborate_lval_(ent, arc, is_sequ, this);
+	    return prefix_->elaborate_lval_(ent, scope, is_sequ, this);
       }
 
       const VType*found_type = 0;
@@ -238,13 +238,13 @@ int ExpName::elaborate_lval(Entity*ent, Architecture*arc, bool is_sequ)
 		 << ent->get_name() << "." << endl;
 	    return 1;
 
-      } else if (Signal*sig = arc->find_signal(name_)) {
+      } else if (Signal*sig = scope->find_signal(name_)) {
 	      // Tell the target signal that this may be a sequential l-value.
 	    if (is_sequ) sig->count_ref_sequ();
 
 	    found_type = sig->peek_type();
 
-      } else if (Variable*var = arc->find_variable(name_)) {
+      } else if (Variable*var = scope->find_variable(name_)) {
 	      // Tell the target signal that this may be a sequential l-value.
 	    if (is_sequ) var->count_ref_sequ();
 
@@ -257,13 +257,13 @@ int ExpName::elaborate_lval(Entity*ent, Architecture*arc, bool is_sequ)
 	    return errors + 1;
       }
 
-      found_type = elaborate_adjust_type_with_range_(ent, arc, found_type);
+      found_type = elaborate_adjust_type_with_range_(ent, scope, found_type);
 
       set_type(found_type);
       return errors;
 }
 
-int ExpName::elaborate_rval(Entity*ent, Architecture*arc, const InterfacePort*lval)
+int ExpName::elaborate_rval(Entity*ent, ScopeBase*scope, const InterfacePort*lval)
 {
       int errors = 0;
 
@@ -295,7 +295,7 @@ int ExpName::elaborate_rval(Entity*ent, Architecture*arc, const InterfacePort*lv
               default:
                 break;
         }
-      } else if (arc->find_signal(name_)) {
+      } else if (scope->find_signal(name_)) {
 	      /* OK */
 
       } else if (ent->find_generic(name_)) {
@@ -310,21 +310,21 @@ int ExpName::elaborate_rval(Entity*ent, Architecture*arc, const InterfacePort*lv
       return errors;
 }
 
-int ExpNameALL::elaborate_lval(Entity*ent, Architecture*arc, bool is_sequ)
+int ExpNameALL::elaborate_lval(Entity*ent, ScopeBase*scope, bool is_sequ)
 {
-      return Expression::elaborate_lval(ent, arc, is_sequ);
+      return Expression::elaborate_lval(ent, scope, is_sequ);
 }
 
-int Expression::elaborate_expr(Entity*, Architecture*, const VType*)
+int Expression::elaborate_expr(Entity*, ScopeBase*, const VType*)
 {
       cerr << get_fileline() << ": internal error: I don't know how to elaborate expression type=" << typeid(*this).name() << endl;
       return 1;
 }
 
-const VType* ExpBinary::probe_type(Entity*ent, Architecture*arc) const
+const VType* ExpBinary::probe_type(Entity*ent, ScopeBase*scope) const
 {
-      const VType*t1 = operand1_->probe_type(ent, arc);
-      const VType*t2 = operand2_->probe_type(ent, arc);
+      const VType*t1 = operand1_->probe_type(ent, scope);
+      const VType*t2 = operand2_->probe_type(ent, scope);
 
       if (t1 == 0)
 	    return t2;
@@ -351,12 +351,12 @@ const VType*ExpBinary::resolve_operand_types_(const VType*, const VType*) const
       return 0;
 }
 
-int ExpBinary::elaborate_exprs(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpBinary::elaborate_exprs(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
-      errors += operand1_->elaborate_expr(ent, arc, ltype);
-      errors += operand2_->elaborate_expr(ent, arc, ltype);
+      errors += operand1_->elaborate_expr(ent, scope, ltype);
+      errors += operand2_->elaborate_expr(ent, scope, ltype);
       return errors;
 }
 
@@ -365,17 +365,17 @@ int ExpBinary::elaborate_exprs(Entity*ent, Architecture*arc, const VType*ltype)
  * return the fit_type for the operand. The assumption is that the
  * operator doesn't change the type.
  */
-const VType*ExpUnary::fit_type(Entity*ent, Architecture*arc, const VTypeArray*atype) const
+const VType*ExpUnary::fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const
 {
-      return operand1_->fit_type(ent, arc, atype);
+      return operand1_->fit_type(ent, scope, atype);
 }
 
-const VType*ExpAggregate::probe_type(Entity*ent, Architecture*arc) const
+const VType*ExpAggregate::probe_type(Entity*ent, ScopeBase*scope) const
 {
-      return Expression::probe_type(ent, arc);
+      return Expression::probe_type(ent, scope);
 }
 
-const VType*ExpAggregate::fit_type(Entity*, Architecture*, const VTypeArray*host) const
+const VType*ExpAggregate::fit_type(Entity*, ScopeBase*, const VTypeArray*host) const
 {
       ivl_assert(*this, elements_.size() == 1);
       size_t choice_count = elements_[0]->count_choices();
@@ -401,7 +401,7 @@ const VType*ExpAggregate::fit_type(Entity*, Architecture*, const VTypeArray*host
       return res;
 }
 
-int ExpAggregate::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpAggregate::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       if (ltype == 0) {
 	    cerr << get_fileline() << ": error: Elaboration of aggregate types needs well known type context?" << endl;
@@ -415,10 +415,10 @@ int ExpAggregate::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype
       }
 
       if (const VTypeArray*larray = dynamic_cast<const VTypeArray*>(ltype)) {
-	    return elaborate_expr_array_(ent, arc, larray);
+	    return elaborate_expr_array_(ent, scope, larray);
       }
       else if(const VTypeRecord*lrecord = dynamic_cast<const VTypeRecord*>(ltype)) {
-            return elaborate_expr_record_(ent, arc, lrecord);
+            return elaborate_expr_record_(ent, scope, lrecord);
       }
 
       cerr << get_fileline() << ": internal error: I don't know how to elaborate aggregate expressions. type=" << typeid(*ltype).name() << endl;
@@ -430,7 +430,7 @@ int ExpAggregate::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype
  * expressions (the elements_ member) using the element type as the
  * ltype for the subexpression.
  */
-int ExpAggregate::elaborate_expr_array_(Entity*ent, Architecture*arc, const VTypeArray*ltype)
+int ExpAggregate::elaborate_expr_array_(Entity*ent, ScopeBase*scope, const VTypeArray*ltype)
 {
       const VType*element_type = ltype->element_type();
       int errors = 0;
@@ -476,7 +476,7 @@ int ExpAggregate::elaborate_expr_array_(Entity*ent, Architecture*arc, const VTyp
 	    if (aggregate_[idx].alias_flag)
 		  continue;
 
-	    errors += aggregate_[idx].expr->elaborate_expr(ent, arc, element_type);
+	    errors += aggregate_[idx].expr->elaborate_expr(ent, scope, element_type);
       }
 
 	// done with the obsolete elements_ vector.
@@ -485,7 +485,7 @@ int ExpAggregate::elaborate_expr_array_(Entity*ent, Architecture*arc, const VTyp
       return errors;
 }
 
-int ExpAggregate::elaborate_expr_record_(Entity*ent, Architecture*arc, const VTypeRecord*ltype)
+int ExpAggregate::elaborate_expr_record_(Entity*ent, ScopeBase*scope, const VTypeRecord*ltype)
 {
       int errors = 0;
 
@@ -518,7 +518,7 @@ int ExpAggregate::elaborate_expr_record_(Entity*ent, Architecture*arc, const VTy
             ivl_assert(*this, idx >= 0);
 
             aggregate_[idx] = tmp;
-            errors += aggregate_[idx].expr->elaborate_expr(ent, arc, el->peek_type());
+            errors += aggregate_[idx].expr->elaborate_expr(ent, scope, el->peek_type());
       }
 
 	// done with the obsolete elements_ vector.
@@ -537,16 +537,16 @@ void ExpAggregate::element_t::map_choices(ExpAggregate::choice_element*dst)
       }
 }
 
-int ExpArithmetic::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpArithmetic::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0) {
-	    ltype = probe_type(ent, arc);
+	    ltype = probe_type(ent, scope);
       }
 
       ivl_assert(*this, ltype != 0);
-      errors += elaborate_exprs(ent, arc, ltype);
+      errors += elaborate_exprs(ent, scope, ltype);
       return errors;
 }
 
@@ -565,9 +565,9 @@ const VType* ExpArithmetic::resolve_operand_types_(const VType*t1, const VType*t
       return 0;
 }
 
-const VType* ExpAttribute::probe_type(Entity*ent, Architecture*arc) const
+const VType* ExpAttribute::probe_type(Entity*ent, ScopeBase*scope) const
 {
-      base_->probe_type(ent, arc);
+      base_->probe_type(ent, scope);
 
       if (name_ == "length" || name_ == "left" || name_ == "right") {
 	    return &primitive_INTEGER;
@@ -576,42 +576,42 @@ const VType* ExpAttribute::probe_type(Entity*ent, Architecture*arc) const
       return 0;
 }
 
-int ExpAttribute::elaborate_expr(Entity*ent, Architecture*arc, const VType*)
+int ExpAttribute::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*)
 {
       int errors = 0;
-      const VType*sub_type = base_->probe_type(ent, arc);
-      errors += base_->elaborate_expr(ent, arc, sub_type);
+      const VType*sub_type = base_->probe_type(ent, scope);
+      errors += base_->elaborate_expr(ent, scope, sub_type);
       return errors;
 }
 
-const VType*ExpBitstring::fit_type(Entity*, Architecture*, const VTypeArray*atype) const
+const VType*ExpBitstring::fit_type(Entity*, ScopeBase*, const VTypeArray*atype) const
 {
 	// Really should check that this string can work with the
 	// array element type?
       return atype->element_type();
 }
 
-int ExpBitstring::elaborate_expr(Entity*, Architecture*, const VType*)
+int ExpBitstring::elaborate_expr(Entity*, ScopeBase*, const VType*)
 {
       int errors = 0;
       return errors;
 }
 
-const VType*ExpCharacter::fit_type(Entity*, Architecture*, const VTypeArray*atype) const
+const VType*ExpCharacter::fit_type(Entity*, ScopeBase*, const VTypeArray*atype) const
 {
 	// Really should check that this character can work with the
 	// array element type?
       return atype->element_type();
 }
 
-int ExpCharacter::elaborate_expr(Entity*, Architecture*, const VType*ltype)
+int ExpCharacter::elaborate_expr(Entity*, ScopeBase*, const VType*ltype)
 {
       ivl_assert(*this, ltype != 0);
       set_type(ltype);
       return 0;
 }
 
-const VType*ExpConcat::fit_type(Entity*ent, Architecture*arc, const VTypeArray*atype) const
+const VType*ExpConcat::fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*atype) const
 {
       Expression*operands[2] = {operand1_, operand2_};
       const VType*types[2] = {NULL, NULL};
@@ -619,7 +619,7 @@ const VType*ExpConcat::fit_type(Entity*ent, Architecture*arc, const VTypeArray*a
 
       // determine the type and size of concatenated expressions
       for(int i = 0; i < 2; ++i) {
-	    types[i] = operands[i]->fit_type(ent, arc, atype);
+	    types[i] = operands[i]->fit_type(ent, scope, atype);
 
 	    if(const VTypeArray*arr = dynamic_cast<const VTypeArray*>(types[i])) {
 		types[i] = arr->element_type();
@@ -647,62 +647,62 @@ const VType*ExpConcat::fit_type(Entity*ent, Architecture*arc, const VTypeArray*a
 /*
  * I don't know how to probe the type of a concatenation, quite yet.
  */
-const VType*ExpConcat::probe_type(Entity*, Architecture*) const
+const VType*ExpConcat::probe_type(Entity*, ScopeBase*) const
 {
       ivl_assert(*this, 0);
       return 0;
 }
 
-int ExpConcat::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpConcat::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0) {
-	    ltype = probe_type(ent, arc);
+	    ltype = probe_type(ent, scope);
       }
 
       ivl_assert(*this, ltype != 0);
 
       if (const VTypeArray*atype = dynamic_cast<const VTypeArray*>(ltype)) {
-	    errors += elaborate_expr_array_(ent, arc, atype);
+	    errors += elaborate_expr_array_(ent, scope, atype);
       } else {
-	    errors += operand1_->elaborate_expr(ent, arc, ltype);
-	    errors += operand2_->elaborate_expr(ent, arc, ltype);
+	    errors += operand1_->elaborate_expr(ent, scope, ltype);
+	    errors += operand2_->elaborate_expr(ent, scope, ltype);
       }
 
       return errors;
 }
 
-int ExpConcat::elaborate_expr_array_(Entity*ent, Architecture*arc, const VTypeArray*atype)
+int ExpConcat::elaborate_expr_array_(Entity*ent, ScopeBase*scope, const VTypeArray*atype)
 {
       int errors = 0;
 
 	// For now, only support single-dimension arrays here.
       ivl_assert(*this, atype->dimensions() == 1);
 
-      const VType*type1 = operand1_->fit_type(ent, arc, atype);
+      const VType*type1 = operand1_->fit_type(ent, scope, atype);
       ivl_assert(*this, type1);
 
-      const VType*type2 = operand2_->fit_type(ent, arc, atype);
+      const VType*type2 = operand2_->fit_type(ent, scope, atype);
       ivl_assert(*this, type2);
 
-      errors += operand1_->elaborate_expr(ent, arc, type1);
-      errors += operand2_->elaborate_expr(ent, arc, type2);
+      errors += operand1_->elaborate_expr(ent, scope, type1);
+      errors += operand2_->elaborate_expr(ent, scope, type2);
 
       return errors;
 }
 
-const VType* ExpConditional::probe_type(Entity*, Architecture*) const
+const VType* ExpConditional::probe_type(Entity*, ScopeBase*) const
 {
       return 0;
 }
 
-int ExpConditional::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpConditional::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0)
-	    ltype = probe_type(ent, arc);
+	    ltype = probe_type(ent, scope);
 
       ivl_assert(*this, ltype);
 
@@ -710,42 +710,42 @@ int ExpConditional::elaborate_expr(Entity*ent, Architecture*arc, const VType*lty
 
 	/* Note that the type for the condition expression need not
 	   have anything to do with the type of this expression. */
-      errors += cond_->elaborate_expr(ent, arc, 0);
+      errors += cond_->elaborate_expr(ent, scope, 0);
 
       for (list<Expression*>::const_iterator cur = true_clause_.begin()
 		 ; cur != true_clause_.end() ; ++cur) {
-	    errors += (*cur)->elaborate_expr(ent, arc, ltype);
+	    errors += (*cur)->elaborate_expr(ent, scope, ltype);
       }
 
       for (list<else_t*>::const_iterator cur = else_clause_.begin()
 		 ; cur != else_clause_.end() ; ++cur) {
-	    errors += (*cur)->elaborate_expr(ent, arc, ltype);
+	    errors += (*cur)->elaborate_expr(ent, scope, ltype);
       }
 
       return errors;
 }
 
-int ExpConditional::else_t::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpConditional::else_t::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (cond_)
-	    errors += cond_->elaborate_expr(ent, arc, 0);
+	    errors += cond_->elaborate_expr(ent, scope, 0);
 
       for (list<Expression*>::const_iterator cur = true_clause_.begin()
 		 ; cur != true_clause_.end() ; ++cur) {
-	    errors += (*cur)->elaborate_expr(ent, arc, ltype);
+	    errors += (*cur)->elaborate_expr(ent, scope, ltype);
       }
 
       return errors;
 }
 
-int ExpFunc::elaborate_expr(Entity*ent, Architecture*arc, const VType*)
+int ExpFunc::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*)
 {
       int errors = 0;
 
-      ivl_assert(*this, arc);
-      Subprogram*prog = arc->find_subprogram(name_);
+      ivl_assert(*this, scope);
+      Subprogram*prog = scope->find_subprogram(name_);
 
       if(!prog)
             prog = library_find_subprogram(name_);
@@ -755,13 +755,13 @@ int ExpFunc::elaborate_expr(Entity*ent, Architecture*arc, const VType*)
 
 	// Elaborate arguments
       for (size_t idx = 0 ; idx < argv_.size() ; idx += 1) {
-	    const VType*tmp = argv_[idx]->probe_type(ent, arc);
+	    const VType*tmp = argv_[idx]->probe_type(ent, scope);
 	    const VType*param_type = prog ? prog->peek_param_type(idx) : NULL;
 
 	    if(!tmp && param_type)
 	        tmp = param_type;
 
-	    errors += argv_[idx]->elaborate_expr(ent, arc, tmp);
+	    errors += argv_[idx]->elaborate_expr(ent, scope, tmp);
 
             // Type casting for unbounded arrays
             if(param_type && param_type->is_unbounded() /*&& !param_type->type_match(tmp)*/) {
@@ -772,17 +772,17 @@ int ExpFunc::elaborate_expr(Entity*ent, Architecture*arc, const VType*)
       return errors;
 }
 
-const VType* ExpInteger::probe_type(Entity*, Architecture*) const
+const VType* ExpInteger::probe_type(Entity*, ScopeBase*) const
 {
       return &primitive_INTEGER;
 }
 
-int ExpInteger::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpInteger::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0) {
-	    ltype = probe_type(ent, arc);
+	    ltype = probe_type(ent, scope);
       }
 
       ivl_assert(*this, ltype != 0);
@@ -790,17 +790,17 @@ int ExpInteger::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
       return errors;
 }
 
-const VType* ExpReal::probe_type(Entity*, Architecture*) const
+const VType* ExpReal::probe_type(Entity*, ScopeBase*) const
 {
       return &primitive_REAL;
 }
 
-int ExpReal::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpReal::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0) {
-        ltype = probe_type(ent, arc);
+        ltype = probe_type(ent, scope);
       }
 
       ivl_assert(*this, ltype != 0);
@@ -808,27 +808,27 @@ int ExpReal::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
       return errors;
 }
 
-int ExpLogical::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpLogical::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0) {
-	    ltype = probe_type(ent, arc);
+	    ltype = probe_type(ent, scope);
       }
 
       ivl_assert(*this, ltype != 0);
-      errors += elaborate_exprs(ent, arc, ltype);
+      errors += elaborate_exprs(ent, scope, ltype);
       return errors;
 }
 
-const VType* ExpName::probe_prefix_type_(Entity*ent, Architecture*arc) const
+const VType* ExpName::probe_prefix_type_(Entity*ent, ScopeBase*scope) const
 {
       if (prefix_.get()) {
 	    cerr << get_fileline() << ": sorry: I do not know how to support nested prefix parts." << endl;
 	    return 0;
       }
 
-      const VType*type = probe_type(ent, arc);
+      const VType*type = probe_type(ent, scope);
       return type;
 }
 
@@ -837,10 +837,10 @@ const VType* ExpName::probe_prefix_type_(Entity*ent, Architecture*arc) const
  * that have prefix parts. In this case we try to get the type of the
  * prefix and interpret the name in that context.
  */
-const VType* ExpName::probe_prefixed_type_(Entity*ent, Architecture*arc) const
+const VType* ExpName::probe_prefixed_type_(Entity*ent, ScopeBase*scope) const
 {
 	// First, get the type of the prefix.
-      const VType*prefix_type = prefix_->probe_prefix_type_(ent, arc);
+      const VType*prefix_type = prefix_->probe_prefix_type_(ent, scope);
       if (prefix_type == 0) {
 	    return 0;
       }
@@ -868,34 +868,40 @@ const VType* ExpName::probe_prefixed_type_(Entity*ent, Architecture*arc) const
       return 0;
 }
 
-const VType* ExpName::probe_type(Entity*ent, Architecture*arc) const
+const VType* ExpName::probe_type(Entity*ent, ScopeBase*scope) const
 {
       if (prefix_.get())
-	    return probe_prefixed_type_(ent, arc);
+	    return probe_prefixed_type_(ent, scope);
 
-      if (const InterfacePort*cur = ent->find_port(name_)) {
-	    ivl_assert(*this, cur->type);
-	    return cur->type;
+      if(ent) {
+        if (const InterfacePort*cur = ent->find_port(name_)) {
+                ivl_assert(*this, cur->type);
+                return cur->type;
+        }
+
+        if (const InterfacePort*cur = ent->find_generic(name_)) {
+                ivl_assert(*this, cur->type);
+                return cur->type;
+        }
       }
 
-      if (const InterfacePort*cur = ent->find_generic(name_)) {
-	    ivl_assert(*this, cur->type);
-	    return cur->type;
-      }
+      if(scope) {
+        if (Signal*sig = scope->find_signal(name_))
+                return sig->peek_type();
 
-      if (Signal*sig = arc->find_signal(name_))
-	    return sig->peek_type();
+        if (Variable*var = scope->find_variable(name_))
+                return var->peek_type();
 
-      if (Variable*var = arc->find_variable(name_))
-	    return var->peek_type();
+        const VType*ctype = 0;
+        Expression*cval = 0;
+        if (scope->find_constant(name_, ctype, cval))
+                return ctype;
 
-      const VType*ctype = 0;
-      Expression*cval = 0;
-      if (arc->find_constant(name_, ctype, cval))
-	    return ctype;
-
-      if (const VType*gtype = arc->probe_genvar_type(name_)) {
-	    return gtype;
+        const VType*gtype = 0;
+        Architecture*arc = dynamic_cast<Architecture*>(scope);
+        if (arc && (gtype = arc->probe_genvar_type(name_))) {
+                return gtype;
+        }
       }
 
       cerr << get_fileline() << ": error: Signal/variable " << name_
@@ -903,12 +909,12 @@ const VType* ExpName::probe_type(Entity*ent, Architecture*arc) const
       return 0;
 }
 
-const VType* ExpName::fit_type(Entity*ent, Architecture*arc, const VTypeArray*)const
+const VType* ExpName::fit_type(Entity*ent, ScopeBase*scope, const VTypeArray*)const
 {
-      return probe_type(ent, arc);
+      return probe_type(ent, scope);
 }
 
-int ExpName::elaborate_expr(Entity*, Architecture*, const VType*ltype)
+int ExpName::elaborate_expr(Entity*, ScopeBase*, const VType*ltype)
 {
       if (ltype) {
 	    ivl_assert(*this, ltype != 0);
@@ -918,22 +924,22 @@ int ExpName::elaborate_expr(Entity*, Architecture*, const VType*ltype)
       return 0;
 }
 
-const VType* ExpNameALL::probe_type(Entity*, Architecture*) const
+const VType* ExpNameALL::probe_type(Entity*, ScopeBase*) const
 {
       return 0;
 }
 
-const VType* ExpRelation::probe_type(Entity*, Architecture*) const
+const VType* ExpRelation::probe_type(Entity*, ScopeBase*) const
 {
       return &primitive_BOOLEAN;
 }
 
-int ExpRelation::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int ExpRelation::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
 
       if (ltype == 0) {
-	    ltype = probe_type(ent, arc);
+	    ltype = probe_type(ent, scope);
       }
 
       ivl_assert(*this, ltype != 0);
@@ -941,8 +947,8 @@ int ExpRelation::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
 	// The type of the operands must match, but need not match the
 	// type for the ExpRelation itself. So get the operand type
 	// separately.
-      const VType*otype = ExpBinary::probe_type(ent, arc);
-      errors += elaborate_exprs(ent, arc, otype);
+      const VType*otype = ExpBinary::probe_type(ent, scope);
+      errors += elaborate_exprs(ent, scope, otype);
 
       return errors;
 }
@@ -952,7 +958,7 @@ int ExpRelation::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
  * string is an array with the same element type of the concatenation,
  * but with elements for each character of the string.
  */
-const VType*ExpString::fit_type(Entity*, Architecture*, const VTypeArray*atype) const
+const VType*ExpString::fit_type(Entity*, ScopeBase*, const VTypeArray*atype) const
 {
       vector<VTypeArray::range_t> range (atype->dimensions());
 
@@ -968,14 +974,14 @@ const VType*ExpString::fit_type(Entity*, Architecture*, const VTypeArray*atype) 
       return type;
 }
 
-int ExpString::elaborate_expr(Entity*, Architecture*, const VType*ltype)
+int ExpString::elaborate_expr(Entity*, ScopeBase*, const VType*ltype)
 {
       ivl_assert(*this, ltype != 0);
       set_type(ltype);
       return 0;
 }
 
-int ExpUNot::elaborate_expr(Entity*, Architecture*, const VType*ltype)
+int ExpUNot::elaborate_expr(Entity*, ScopeBase*, const VType*ltype)
 {
       ivl_assert(*this, ltype != 0);
       set_type(ltype);

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -757,8 +757,6 @@ int ExpFunc::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*)
       ivl_assert(*this, def_==0);
       def_ = prog;
 
-      bool new_instance = false;
-
 	// Elaborate arguments
       for (size_t idx = 0 ; idx < argv_.size() ; idx += 1) {
 	    const VType*tmp = argv_[idx]->probe_type(ent, scope);
@@ -768,14 +766,9 @@ int ExpFunc::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*)
 	        tmp = param_type;
 
 	    errors += argv_[idx]->elaborate_expr(ent, scope, tmp);
-
-            // Type casting for unbounded arrays
-            if(param_type && param_type->is_unbounded() /*&& !param_type->type_match(tmp)*/) {
-                new_instance = true;    // we need a new instance
-            }
       }
 
-      if(new_instance) {
+      if(def_ && def_->unbounded()) {
             def_ = prog->make_instance(argv_, scope);
             name_ = def_->name();
       }

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -751,11 +751,20 @@ int ExpFunc::elaborate_expr(Entity*ent, Architecture*arc, const VType*)
       ivl_assert(*this, def_==0);
       def_ = prog;
 
+	// Elaborate arguments
       for (size_t idx = 0 ; idx < argv_.size() ; idx += 1) {
 	    const VType*tmp = argv_[idx]->probe_type(ent, arc);
-	    if(!tmp && prog)
-	        tmp = prog->peek_param_type(idx);
+	    const VType*param_type = prog ? prog->peek_param_type(idx) : NULL;
+
+	    if(!tmp && param_type)
+	        tmp = param_type;
+
 	    errors += argv_[idx]->elaborate_expr(ent, arc, tmp);
+
+            // Type casting for unbounded arrays
+            if(param_type && param_type->is_unbounded() /*&& !param_type->type_match(tmp)*/) {
+                argv_[idx] = new ExpCast(argv_[idx], get_global_typedef(param_type));
+            }
       }
 
       return errors;

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -906,6 +906,10 @@ const VType* ExpName::probe_type(Entity*ent, ScopeBase*scope) const
         if (arc && (gtype = arc->probe_genvar_type(name_))) {
                 return gtype;
         }
+
+        if (scope->is_enum_name(name_)) {
+            return &primitive_INTEGER;
+        }
       }
 
       cerr << get_fileline() << ": error: Signal/variable " << name_

--- a/vhdlpp/expression_elaborate.cc
+++ b/vhdlpp/expression_elaborate.cc
@@ -961,6 +961,19 @@ int ExpRelation::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
       return errors;
 }
 
+int ExpShift::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
+{
+      int errors = 0;
+
+      if (ltype == 0) {
+	    ltype = probe_type(ent, scope);
+      }
+
+      ivl_assert(*this, ltype != 0);
+      errors += elaborate_exprs(ent, scope, ltype);
+      return errors;
+}
+
 /*
  * When a string appears in a concatenation, then the type of the
  * string is an array with the same element type of the concatenation,

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -625,7 +625,7 @@ int ExpFunc::emit(ostream&out, Entity*ent, ScopeBase*scope)
 
 int ExpInteger::emit(ostream&out, Entity*, ScopeBase*)
 {
-      out << value_;
+      out << "32'd" << value_;
       return 0;
 }
 

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -766,6 +766,36 @@ int ExpRelation::emit(ostream&out, Entity*ent, ScopeBase*scope)
       return errors;
 }
 
+int ExpShift::emit(ostream&out, Entity*ent, ScopeBase*scope)
+{
+      int errors = 0;
+
+      errors += emit_operand1(out, ent, scope);
+
+      switch (shift_) {
+	  case SRL:
+	    out << " >> ";
+	    break;
+	  case SLL:
+	    out << " << ";
+	    break;
+	  case SRA:
+	    out << " >>> ";
+	    break;
+	  case SLA:
+	    out << " <<< ";
+	    break;
+	  case ROR:
+	  case ROL:
+	    out << " /* ?ror/rol? */ ";
+	    break;
+      }
+
+      errors += emit_operand2(out, ent, scope);
+
+      return errors;
+}
+
 bool ExpString::is_primary(void) const
 {
       return true;

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -552,7 +552,12 @@ int ExpFunc::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
-      if (name_ == "unsigned" && argv_.size()==1) {
+      // SystemVerilog takes care of signs, depending on the lvalue
+      if (name_ == "to_integer" && argv_.size()==1) {
+	    errors += argv_[0]->emit(out, ent, scope);
+      }
+
+      else if (name_ == "unsigned" && argv_.size()==1) {
 	      // Handle the special case that this is a cast to
 	      // unsigned. This function is brought in as part of the
 	      // std numeric library, but we interpret it as the same

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -33,7 +33,7 @@
 
 using namespace std;
 
-int Expression::emit(ostream&out, Entity*, Architecture*)
+int Expression::emit(ostream&out, Entity*, ScopeBase*)
 {
       out << " /* " << get_fileline() << ": internal error: "
 	  << "I don't know how to emit this expression! "
@@ -54,34 +54,34 @@ bool Expression::is_primary(void) const
       return false;
 }
 
-int ExpBinary::emit_operand1(ostream&out, Entity*ent, Architecture*arc)
+int ExpBinary::emit_operand1(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       bool oper_primary = operand1_->is_primary();
       if (! oper_primary) out << "(";
-      errors += operand1_->emit(out, ent, arc);
+      errors += operand1_->emit(out, ent, scope);
       if (! oper_primary) out << ")";
       return errors;
 }
 
-int ExpBinary::emit_operand2(ostream&out, Entity*ent, Architecture*arc)
+int ExpBinary::emit_operand2(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       bool oper_primary = operand2_->is_primary();
       if (! oper_primary) out << "(";
-      errors += operand2_->emit(out, ent, arc);
+      errors += operand2_->emit(out, ent, scope);
       if (! oper_primary) out << ")";
       return errors;
 }
 
-int ExpUnary::emit_operand1(ostream&out, Entity*ent, Architecture*arc)
+int ExpUnary::emit_operand1(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
-      errors += operand1_->emit(out, ent, arc);
+      errors += operand1_->emit(out, ent, scope);
       return errors;
 }
 
-int ExpAggregate::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpAggregate::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       if (peek_type() == 0) {
 	    out << "/* " << get_fileline() << ": internal error: "
@@ -95,9 +95,9 @@ int ExpAggregate::emit(ostream&out, Entity*ent, Architecture*arc)
       }
 
       if (const VTypeArray*atype = dynamic_cast<const VTypeArray*> (use_type))
-	    return emit_array_(out, ent, arc, atype);
+	    return emit_array_(out, ent, scope, atype);
       else if (const VTypeRecord*arecord = dynamic_cast<const VTypeRecord*> (use_type))
-	    return emit_record_(out, ent, arc, arecord);
+	    return emit_record_(out, ent, scope, arecord);
 
       out << "/* " << get_fileline() << ": internal error: "
 	  << "I don't know how to elab/emit aggregate in " << typeid(use_type).name()
@@ -105,7 +105,7 @@ int ExpAggregate::emit(ostream&out, Entity*ent, Architecture*arc)
       return 1;
 }
 
-int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const VTypeArray*atype)
+int ExpAggregate::emit_array_(ostream&out, Entity*ent, ScopeBase*scope, const VTypeArray*atype)
 {
       int errors = 0;
 
@@ -119,14 +119,14 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 	    int64_t use_msb;
 	    int64_t use_lsb;
 	    bool rc_msb, rc_lsb;
-	    rc_msb = rang.msb()->evaluate(ent, arc, use_msb);
-	    rc_lsb = rang.lsb()->evaluate(ent, arc, use_lsb);
+	    rc_msb = rang.msb()->evaluate(ent, scope, use_msb);
+	    rc_lsb = rang.lsb()->evaluate(ent, scope, use_lsb);
 
 	    if (rc_msb && rc_lsb) {
 		  int asize = (use_msb >= use_lsb) ? (use_msb - use_lsb) + 1 :
 		                                     (use_lsb - use_msb) + 1;
 		  out << "{" << asize << "{";
-		  errors += aggregate_[0].expr->emit(out, ent, arc);
+		  errors += aggregate_[0].expr->emit(out, ent, scope);
 		  out << "}}";
 	    } else {
 		  out << "{(";
@@ -134,7 +134,7 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 			out << use_msb;
 		  } else {
 			out << "(";
-			errors += rang.msb()->emit(out, ent, arc);
+			errors += rang.msb()->emit(out, ent, scope);
 			out << ")";
 		  }
 		  if (rc_lsb && use_lsb==0) {
@@ -142,11 +142,11 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 			out << "-" << use_lsb;
 		  } else {
 			out << "-(";
-			errors += rang.lsb()->emit(out, ent, arc);
+			errors += rang.lsb()->emit(out, ent, scope);
 			out << ")";
 		  }
 		  out << "+1){";
-		  errors += aggregate_[0].expr->emit(out, ent, arc);
+		  errors += aggregate_[0].expr->emit(out, ent, scope);
 		  out << "}}";
 	    }
 	    return errors;
@@ -158,9 +158,9 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 	// Fully calculate the range numbers.
       int64_t use_msb, use_lsb;
       bool rc;
-      rc = rang.msb()->evaluate(ent, arc, use_msb);
+      rc = rang.msb()->evaluate(ent, scope, use_msb);
       ivl_assert(*this, rc);
-      rc = rang.lsb()->evaluate(ent, arc, use_lsb);
+      rc = rang.lsb()->evaluate(ent, scope, use_lsb);
       ivl_assert(*this, rc);
       if(use_msb < use_lsb)
         swap(use_msb, use_lsb);
@@ -198,14 +198,14 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 	    if (prange_t*range = aggregate_[idx].choice->range_expressions()) {
 		  int64_t begin_val, end_val;
 
-		  if (! range->msb()->evaluate(ent, arc, begin_val)) {
+		  if (! range->msb()->evaluate(ent, scope, begin_val)) {
 			cerr << range->msb()->get_fileline() << ": error: "
 			     << "Unable to evaluate aggregate choice expression." << endl;
 			errors += 1;
 			continue;
 		  }
 
-		  if (! range->lsb()->evaluate(ent, arc, end_val)) {
+		  if (! range->lsb()->evaluate(ent, scope, end_val)) {
 			cerr << range->msb()->get_fileline() << ": error: "
 			     << "Unable to evaluate aggregate choice expression." << endl;
 			errors += 1;
@@ -235,7 +235,7 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 	      // elements so disable further positional
 	      // processing.
 	    positional_section = false;
-	    if (! tmp->evaluate(ent, arc, tmp_val)) {
+	    if (! tmp->evaluate(ent, scope, tmp_val)) {
 		  cerr << tmp->get_fileline() << ": error: "
 		       << "Unable to evaluate aggregate choice expression." << endl;
 		  errors += 1;
@@ -266,7 +266,7 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
 		       << "Missing element " << idx << "." << endl;
 		  errors += 1;
 	    } else {
-		  errors += cur->expr->emit(out, ent, arc);
+		  errors += cur->expr->emit(out, ent, scope);
 	    }
       }
       out << "}";
@@ -274,7 +274,7 @@ int ExpAggregate::emit_array_(ostream&out, Entity*ent, Architecture*arc, const V
       return errors;
 }
 
-int ExpAggregate::emit_record_(ostream&out, Entity*ent, Architecture*arc, const VTypeRecord*)
+int ExpAggregate::emit_record_(ostream&out, Entity*ent, ScopeBase*scope, const VTypeRecord*)
 {
       int errors = 0;
 
@@ -292,9 +292,9 @@ int ExpAggregate::emit_record_(ostream&out, Entity*ent, Architecture*arc, const 
 	    if(idx != 0)
 	        out << ",";
 
-	    //errors += name->emit(out, ent, arc);
+	    //errors += name->emit(out, ent, scope);
 	    //out << ": ";
-	    errors += val->emit(out, ent, arc);
+	    errors += val->emit(out, ent, scope);
       }
 
       out << "}";
@@ -302,13 +302,13 @@ int ExpAggregate::emit_record_(ostream&out, Entity*ent, Architecture*arc, const 
       return errors;
 }
 
-int ExpAttribute::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpAttribute::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
       if (name_ == "event") {
 	    out << "$ivlh_attribute_event(";
-	    errors += base_->emit(out, ent, arc);
+	    errors += base_->emit(out, ent, scope);
 	    out << ")";
 	    return errors;
       }
@@ -319,27 +319,27 @@ int ExpAttribute::emit(ostream&out, Entity*ent, Architecture*arc)
 	   expression doesn't even need to be evaluated.) */
       if (name_=="length") {
 	    out << "$bits(";
-	    errors += base_->emit(out, ent, arc);
+	    errors += base_->emit(out, ent, scope);
 	    out << ")";
 	    return errors;
       } else if (name_=="left" || name_=="right") {
 	    out << "$" << name_ << "(";
-	    errors += base_->emit(out, ent, arc);
+	    errors += base_->emit(out, ent, scope);
 	    out << ")";
 	    return errors;
       }
 
       out << "$ivl_attribute(";
-      errors += base_->emit(out, ent, arc);
+      errors += base_->emit(out, ent, scope);
       out << ", \"" << name_ << "\")";
       return errors;
 }
 
-int ExpArithmetic::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpArithmetic::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
-      errors += emit_operand1(out, ent, arc);
+      errors += emit_operand1(out, ent, scope);
 
       switch (fun_) {
 	  case PLUS:
@@ -369,12 +369,12 @@ int ExpArithmetic::emit(ostream&out, Entity*ent, Architecture*arc)
 	    break;
       }
 
-      errors += emit_operand2(out, ent, arc);
+      errors += emit_operand2(out, ent, scope);
 
       return errors;
 }
 
-int ExpBitstring::emit(ostream&out, Entity*, Architecture*)
+int ExpBitstring::emit(ostream&out, Entity*, ScopeBase*)
 {
       int errors = 0;
 
@@ -385,7 +385,7 @@ int ExpBitstring::emit(ostream&out, Entity*, Architecture*)
       return errors;
 }
 
-int ExpCharacter::emit_primitive_bit_(ostream&out, Entity*, Architecture*,
+int ExpCharacter::emit_primitive_bit_(ostream&out, Entity*, ScopeBase*,
 				      const VTypePrimitive*etype)
 {
       switch (etype->type()) {
@@ -407,17 +407,17 @@ int ExpCharacter::emit_primitive_bit_(ostream&out, Entity*, Architecture*,
       return 1;
 }
 
-int ExpCharacter::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpCharacter::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       const VType*etype = peek_type();
 
       if (const VTypePrimitive*use_type = dynamic_cast<const VTypePrimitive*>(etype)) {
-	    return emit_primitive_bit_(out, ent, arc, use_type);
+	    return emit_primitive_bit_(out, ent, scope, use_type);
       }
 
       if (const VTypeArray*array = dynamic_cast<const VTypeArray*>(etype)) {
 	    if (const VTypePrimitive*use_type = dynamic_cast<const VTypePrimitive*>(array->element_type())) {
-		  return emit_primitive_bit_(out, ent, arc, use_type);
+		  return emit_primitive_bit_(out, ent, scope, use_type);
 	    }
       }
 
@@ -439,22 +439,22 @@ bool ExpConcat::is_primary(void) const
       return true;
 }
 
-int ExpConcat::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpConcat::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       out << "{";
-      errors += operand1_->emit(out, ent, arc);
+      errors += operand1_->emit(out, ent, scope);
       out << ", ";
-      errors += operand2_->emit(out, ent, arc);
+      errors += operand2_->emit(out, ent, scope);
       out << "}";
       return errors;
 }
 
-int ExpConditional::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpConditional::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       out << "(";
-      errors += cond_->emit(out, ent, arc);
+      errors += cond_->emit(out, ent, scope);
       out << ")? (";
 
       if (true_clause_.size() > 1) {
@@ -463,7 +463,7 @@ int ExpConditional::emit(ostream&out, Entity*ent, Architecture*arc)
       }
 
       Expression*tmp = true_clause_.front();
-      errors += tmp->emit(out, ent, arc);
+      errors += tmp->emit(out, ent, scope);
 
       out << ") : (";
 
@@ -475,11 +475,11 @@ int ExpConditional::emit(ostream&out, Entity*ent, Architecture*arc)
 
 	    for (list<else_t*>::iterator cur = else_clause_.begin()
 		       ; cur != last ; ++cur) {
-		  errors += (*cur) ->emit_when_else(out, ent, arc);
+		  errors += (*cur) ->emit_when_else(out, ent, scope);
 	    }
      }
 
-      errors += else_clause_.back()->emit_else(out, ent, arc);
+      errors += else_clause_.back()->emit_else(out, ent, scope);
       out << ")";
 
 	// The emit_when_else() functions do not close the last
@@ -492,13 +492,13 @@ int ExpConditional::emit(ostream&out, Entity*ent, Architecture*arc)
       return errors;
 }
 
-int ExpConditional::else_t::emit_when_else(ostream&out, Entity*ent, Architecture*arc)
+int ExpConditional::else_t::emit_when_else(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       assert(cond_ != 0);
 
       out << "(";
-      errors += cond_->emit(out, ent, arc);
+      errors += cond_->emit(out, ent, scope);
       out << ")? (";
 
       if (true_clause_.size() > 1) {
@@ -507,14 +507,14 @@ int ExpConditional::else_t::emit_when_else(ostream&out, Entity*ent, Architecture
       }
 
       Expression*tmp = true_clause_.front();
-      errors += tmp->emit(out, ent, arc);
+      errors += tmp->emit(out, ent, scope);
 
       out << ") : (";
 
       return errors;
 }
 
-int ExpConditional::else_t::emit_else(ostream&out, Entity*ent, Architecture*arc)
+int ExpConditional::else_t::emit_else(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 	// Trailing else must have no condition.
@@ -526,12 +526,12 @@ int ExpConditional::else_t::emit_else(ostream&out, Entity*ent, Architecture*arc)
       }
 
       Expression*tmp = true_clause_.front();
-      errors += tmp->emit(out, ent, arc);
+      errors += tmp->emit(out, ent, scope);
 
       return errors;
 }
 
-int ExpEdge::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpEdge::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       switch (fun_) {
@@ -544,11 +544,11 @@ int ExpEdge::emit(ostream&out, Entity*ent, Architecture*arc)
 	  case ANYEDGE:
 	    break;
       }
-      errors += emit_operand1(out, ent, arc);
+      errors += emit_operand1(out, ent, scope);
       return errors;
 }
 
-int ExpFunc::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpFunc::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
@@ -558,46 +558,46 @@ int ExpFunc::emit(ostream&out, Entity*ent, Architecture*arc)
 	      // std numeric library, but we interpret it as the same
 	      // as the $unsigned function.
 	    out << "$unsigned(";
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 	    out << ")";
 
       } else if (name_ == "integer" && argv_.size() == 1) {
             // Simply skip the function name, SystemVerilog takes care of
             // rounding real numbers
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 
       } else if (name_ == "std_logic_vector" && argv_.size() == 1) {
 	      // Special case: The std_logic_vector function casts its
 	      // argument to std_logic_vector. Internally, we don't
 	      // have to do anything for that to work.
 	    out << "(";
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 	    out << ")";
 
       } else if (name_ == "to_unsigned" && argv_.size() == 2) {
 
 	    out << "$ivlh_to_unsigned(";
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 	    out << ", ";
-	    errors += argv_[1]->emit(out, ent, arc);
+	    errors += argv_[1]->emit(out, ent, scope);
 	    out << ")";
 
       } else if (name_ == "conv_std_logic_vector" && argv_.size() == 2) {
 	    int64_t use_size;
-	    bool rc = argv_[1]->evaluate(ent, arc, use_size);
+	    bool rc = argv_[1]->evaluate(ent, scope, use_size);
 	    ivl_assert(*this, rc);
 	    out << use_size << "'(";
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 	    out << ")";
 
       } else if (name_ == "rising_edge" && argv_.size()==1) {
 	    out << "$ivlh_rising_edge(";
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 	    out << ")";
 
       } else if (name_ == "falling_edge" && argv_.size()==1) {
 	    out << "$ivlh_falling_edge(";
-	    errors += argv_[0]->emit(out, ent, arc);
+	    errors += argv_[0]->emit(out, ent, scope);
 	    out << ")";
 
       } else {
@@ -615,7 +615,7 @@ int ExpFunc::emit(ostream&out, Entity*ent, Architecture*arc)
 	    out << "\\" << name_ << " (";
 	    for (size_t idx = 0; idx < argv_.size() ; idx += 1) {
 		  if (idx > 0) out << ", ";
-		  errors += argv_[idx]->emit(out, ent, arc);
+		  errors += argv_[idx]->emit(out, ent, scope);
 	    }
 	    out << ")";
       }
@@ -623,7 +623,7 @@ int ExpFunc::emit(ostream&out, Entity*ent, Architecture*arc)
       return errors;
 }
 
-int ExpInteger::emit(ostream&out, Entity*, Architecture*)
+int ExpInteger::emit(ostream&out, Entity*, ScopeBase*)
 {
       out << value_;
       return 0;
@@ -640,7 +640,7 @@ bool ExpInteger::is_primary(void) const
       return true;
 }
 
-int ExpReal::emit(ostream&out, Entity*, Architecture*)
+int ExpReal::emit(ostream&out, Entity*, ScopeBase*)
 {
       out << value_;
       return 0;
@@ -657,11 +657,11 @@ bool ExpReal::is_primary(void) const
       return true;
 }
 
-int ExpLogical::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpLogical::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
-      errors += emit_operand1(out, ent, arc);
+      errors += emit_operand1(out, ent, scope);
 
       switch (fun_) {
 	  case AND:
@@ -684,22 +684,22 @@ int ExpLogical::emit(ostream&out, Entity*ent, Architecture*arc)
 	    break;
       }
 
-      errors += emit_operand2(out, ent, arc);
+      errors += emit_operand2(out, ent, scope);
 
       return errors;
 }
 
-int ExpName::emit_as_prefix_(ostream&out, Entity*ent, Architecture*arc)
+int ExpName::emit_as_prefix_(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       if (prefix_.get()) {
-	    errors += prefix_->emit_as_prefix_(out, ent, arc);
+	    errors += prefix_->emit_as_prefix_(out, ent, scope);
       }
 
       out << "\\" << name_ << " ";
       if (index_) {
 	    out << "[";
-	    errors += index_->emit(out, ent, arc);
+	    errors += index_->emit(out, ent, scope);
 	    out << "]";
 	    ivl_assert(*this, lsb_ == 0);
       }
@@ -707,27 +707,28 @@ int ExpName::emit_as_prefix_(ostream&out, Entity*ent, Architecture*arc)
       return errors;
 }
 
-int ExpName::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpName::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
       if (prefix_.get()) {
-	    errors += prefix_->emit_as_prefix_(out, ent, arc);
+	    errors += prefix_->emit_as_prefix_(out, ent, scope);
       }
 
       const GenerateStatement*gs = 0;
+      Architecture*arc = dynamic_cast<Architecture*>(scope);
       if (arc && (gs = arc->probe_genvar_emit(name_)))
-	    out << "\\" << gs->get_name() << ":" << name_ << " ";
+            out << "\\" << gs->get_name() << ":" << name_ << " ";
       else
 	    out << "\\" << name_ << " ";
 
       if (index_) {
 	    out << "[";
-	    errors += index_->emit(out, ent, arc);
+	    errors += index_->emit(out, ent, scope);
 
 	    if (lsb_) {
 		  out << ":";
-		  errors += lsb_->emit(out, ent, arc);
+		  errors += lsb_->emit(out, ent, scope);
 	    }
 	    out << "]";
       }
@@ -740,10 +741,10 @@ bool ExpName::is_primary(void) const
       return true;
 }
 
-int ExpRelation::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpRelation::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
-      errors += emit_operand1(out, ent, arc);
+      errors += emit_operand1(out, ent, scope);
 
       switch (fun_) {
 	  case EQ:
@@ -766,7 +767,7 @@ int ExpRelation::emit(ostream&out, Entity*ent, Architecture*arc)
 	    break;
       }
 
-      errors += emit_operand2(out, ent, arc);
+      errors += emit_operand2(out, ent, scope);
       return errors;
 }
 
@@ -775,13 +776,13 @@ bool ExpString::is_primary(void) const
       return true;
 }
 
-int ExpString::emit(ostream& out, Entity*ent, Architecture*arc)
+int ExpString::emit(ostream& out, Entity*ent, ScopeBase*scope)
 {
       const VType*type = peek_type();
       assert(type != 0);
 
       if (const VTypeArray*arr = dynamic_cast<const VTypeArray*>(type)) {
-	    return emit_as_array_(out, ent, arc, arr);
+	    return emit_as_array_(out, ent, scope, arr);
       }
 
       out << "\"";
@@ -792,7 +793,7 @@ int ExpString::emit(ostream& out, Entity*ent, Architecture*arc)
       return 0;
 }
 
-int ExpString::emit_as_array_(ostream& out, Entity*, Architecture*, const VTypeArray*arr)
+int ExpString::emit_as_array_(ostream& out, Entity*, ScopeBase*, const VTypeArray*arr)
 {
       int errors = 0;
       assert(arr->dimensions() == 1);
@@ -843,39 +844,39 @@ int ExpString::emit_as_array_(ostream& out, Entity*, Architecture*, const VTypeA
       return errors;
 }
 
-int ExpUAbs::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpUAbs::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       out << "abs(";
-      errors += emit_operand1(out, ent, arc);
+      errors += emit_operand1(out, ent, scope);
       out << ")";
       return errors;
 }
 
-int ExpUNot::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpUNot::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       out << "~(";
-      errors += emit_operand1(out, ent, arc);
+      errors += emit_operand1(out, ent, scope);
       out << ")";
       return errors;
 }
 
-int ExpCast::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpCast::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       errors += type_->emit_def(out, empty_perm_string);
       out << "'(";
-      errors += base_->emit(out, ent, arc);
+      errors += base_->emit(out, ent, scope);
       out << ")";
       return errors;
 }
 
-int ExpNew::emit(ostream&out, Entity*ent, Architecture*arc)
+int ExpNew::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
       out << "new[";
-      errors += size_->emit(out, ent, arc);
+      errors += size_->emit(out, ent, scope);
       out << "]";
       return errors;
 }

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -860,3 +860,13 @@ int ExpUNot::emit(ostream&out, Entity*ent, Architecture*arc)
       out << ")";
       return errors;
 }
+
+int ExpCast::emit(ostream&out, Entity*ent, Architecture*arc)
+{
+      int errors = 0;
+      errors += type_->emit_def(out, empty_perm_string);
+      out << "'(";
+      errors += base_->emit(out, ent, arc);
+      out << ")";
+      return errors;
+}

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -870,3 +870,12 @@ int ExpCast::emit(ostream&out, Entity*ent, Architecture*arc)
       out << ")";
       return errors;
 }
+
+int ExpNew::emit(ostream&out, Entity*ent, Architecture*arc)
+{
+      int errors = 0;
+      out << "new[";
+      errors += size_->emit(out, ent, arc);
+      out << "]";
+      return errors;
+}

--- a/vhdlpp/expression_emit.cc
+++ b/vhdlpp/expression_emit.cc
@@ -562,9 +562,9 @@ int ExpFunc::emit(ostream&out, Entity*ent, ScopeBase*scope)
 	    out << ")";
 
       } else if (name_ == "integer" && argv_.size() == 1) {
-            // Simply skip the function name, SystemVerilog takes care of
-            // rounding real numbers
+	    out << "$signed(";
 	    errors += argv_[0]->emit(out, ent, scope);
+	    out << ")";
 
       } else if (name_ == "std_logic_vector" && argv_.size() == 1) {
 	      // Special case: The std_logic_vector function casts its
@@ -633,11 +633,6 @@ int ExpInteger::emit_package(ostream&out)
 {
       out << value_;
       return 0;
-}
-
-bool ExpInteger::is_primary(void) const
-{
-      return true;
 }
 
 int ExpReal::emit(ostream&out, Entity*, ScopeBase*)

--- a/vhdlpp/expression_evaluate.cc
+++ b/vhdlpp/expression_evaluate.cc
@@ -26,9 +26,9 @@ bool Expression::evaluate(ScopeBase*, int64_t&) const
       return false;
 }
 
-bool Expression::evaluate(Entity*, Architecture*arc, int64_t&val) const
+bool Expression::evaluate(Entity*, ScopeBase*scope, int64_t&val) const
 {
-      return evaluate(arc, val);
+      return evaluate(scope, val);
 }
 
 
@@ -110,16 +110,16 @@ bool ExpAttribute::evaluate(ScopeBase*, int64_t&val) const
       return false;
 }
 
-bool ExpAttribute::evaluate(Entity*ent, Architecture*arc, int64_t&val) const
+bool ExpAttribute::evaluate(Entity*ent, ScopeBase*scope, int64_t&val) const
 {
-      if (!ent || !arc) {   // it's impossible to evaluate, probably it is inside a subprogram
+      if (!ent || !scope) {   // it's impossible to evaluate, probably it is inside a subprogram
             return false;
       }
 
       if (name_ == "left" || name_ == "right") {
 	    const VType*base_type = base_->peek_type();
 	    if (base_type == 0)
-		  base_type = base_->probe_type(ent, arc);
+		  base_type = base_->probe_type(ent, scope);
 
 	    ivl_assert(*this, base_type);
 
@@ -133,14 +133,14 @@ bool ExpAttribute::evaluate(Entity*ent, Architecture*arc, int64_t&val) const
 
 	    ivl_assert(*this, arr->dimensions() == 1);
 	    if(name_ == "left")
-		  arr->dimension(0).msb()->evaluate(ent, arc, val);
+		  arr->dimension(0).msb()->evaluate(ent, scope, val);
 	    else    // "right"
-		  arr->dimension(0).lsb()->evaluate(ent, arc, val);
+		  arr->dimension(0).lsb()->evaluate(ent, scope, val);
 
 	    return true;
       }
 
-      return evaluate(arc, val);
+      return evaluate(scope, val);
 }
 
 /*
@@ -169,7 +169,7 @@ bool ExpName::evaluate(ScopeBase*scope, int64_t&val) const
       return exp->evaluate(scope, val);
 }
 
-bool ExpName::evaluate(Entity*ent, Architecture*arc, int64_t&val) const
+bool ExpName::evaluate(Entity*ent, ScopeBase*scope, int64_t&val) const
 {
       if (prefix_.get()) {
 	    cerr << get_fileline() << ": sorry: I don't know how to evaluate ExpName prefix parts." << endl;
@@ -182,8 +182,8 @@ bool ExpName::evaluate(Entity*ent, Architecture*arc, int64_t&val) const
 
 	      // Evaluate the default expression and use that.
 	    if (gen->expr)
-		  return gen->expr->evaluate(ent, arc, val);
+		  return gen->expr->evaluate(ent, scope, val);
       }
 
-      return evaluate(arc, val);
+      return evaluate(scope, val);
 }

--- a/vhdlpp/expression_evaluate.cc
+++ b/vhdlpp/expression_evaluate.cc
@@ -112,10 +112,14 @@ bool ExpAttribute::evaluate(ScopeBase*, int64_t&val) const
 
 bool ExpAttribute::evaluate(Entity*ent, Architecture*arc, int64_t&val) const
 {
+      if (!ent || !arc) {   // it's impossible to evaluate, probably it is inside a subprogram
+            return false;
+      }
+
       if (name_ == "left" || name_ == "right") {
 	    const VType*base_type = base_->peek_type();
 	    if (base_type == 0)
-		  base_type = base_->probe_type(ent,arc);
+		  base_type = base_->probe_type(ent, arc);
 
 	    ivl_assert(*this, base_type);
 
@@ -130,7 +134,7 @@ bool ExpAttribute::evaluate(Entity*ent, Architecture*arc, int64_t&val) const
 	    ivl_assert(*this, arr->dimensions() == 1);
 	    if(name_ == "left")
 		  arr->dimension(0).msb()->evaluate(ent, arc, val);
-	    else
+	    else    // "right"
 		  arr->dimension(0).lsb()->evaluate(ent, arc, val);
 
 	    return true;

--- a/vhdlpp/expression_evaluate.cc
+++ b/vhdlpp/expression_evaluate.cc
@@ -216,3 +216,37 @@ bool ExpName::evaluate(Entity*ent, ScopeBase*scope, int64_t&val) const
 
       return evaluate(scope, val);
 }
+
+bool ExpShift::evaluate(ScopeBase*scope, int64_t&val) const
+{
+      int64_t val1, val2;
+      bool rc;
+
+      rc = eval_operand1(scope, val1);
+      if (rc == false)
+	    return false;
+
+      rc = eval_operand2(scope, val2);
+      if (rc == false)
+	    return false;
+
+      switch (shift_) {
+	  case SRL:
+	    val = (uint64_t)val1 >> (uint64_t)val2;
+	    break;
+	  case SLL:
+	    val = (uint64_t)val1 << (uint64_t)val2;
+	    break;
+	  case SRA:
+	    val = (int64_t)val1 >> (int64_t)val2;
+	    break;
+	  case SLA:
+	    val = (int64_t)val1 << (int64_t)val2;
+	    break;
+	  case ROR:
+	  case ROL:
+	    return false;
+      }
+
+      return true;
+}

--- a/vhdlpp/expression_stream.cc
+++ b/vhdlpp/expression_stream.cc
@@ -24,7 +24,7 @@
 
 using namespace std;
 
-void ExpAggregate::write_to_stream(ostream&fd)
+void ExpAggregate::write_to_stream(ostream&fd) const
 {
       fd << "(";
       for (vector<element_t*>::const_iterator cur = elements_.begin()
@@ -73,7 +73,7 @@ void ExpAggregate::choice_t::write_to_stream(ostream&fd)
       fd << "/* ERROR */";
 }
 
-void ExpArithmetic::write_to_stream(ostream&out)
+void ExpArithmetic::write_to_stream(ostream&out) const
 {
       out << "(";
       write_to_stream_operand1(out);
@@ -111,13 +111,13 @@ void ExpArithmetic::write_to_stream(ostream&out)
       out << ")";
 }
 
-void ExpAttribute::write_to_stream(ostream&fd)
+void ExpAttribute::write_to_stream(ostream&fd) const
 {
       base_->write_to_stream(fd);
       fd << "'" << name_;
 }
 
-void ExpBitstring::write_to_stream(ostream&fd)
+void ExpBitstring::write_to_stream(ostream&fd) const
 {
       fd << "\"";
       for(vector<char>::const_iterator it = value_.begin();
@@ -127,7 +127,7 @@ void ExpBitstring::write_to_stream(ostream&fd)
       fd << "\"";
 }
 
-void ExpCharacter::write_to_stream(ostream&fd)
+void ExpCharacter::write_to_stream(ostream&fd) const
 {
       char buf[4];
       buf[0] = '\'';
@@ -137,7 +137,7 @@ void ExpCharacter::write_to_stream(ostream&fd)
       fd << buf;
 }
 
-void ExpConcat::write_to_stream(ostream&fd)
+void ExpConcat::write_to_stream(ostream&fd) const
 {
       fd << "(";
       operand1_->write_to_stream(fd);
@@ -146,21 +146,21 @@ void ExpConcat::write_to_stream(ostream&fd)
       fd << ")";
 }
 
-void ExpConditional::write_to_stream(ostream&)
+void ExpConditional::write_to_stream(ostream&) const
 {
       ivl_assert(*this, !"Not supported");
 }
 
-void ExpEdge::write_to_stream(ostream&)
+void ExpEdge::write_to_stream(ostream&) const
 {
       ivl_assert(*this, !"Not supported");
 }
 
-void ExpFunc::write_to_stream(ostream&fd)
+void ExpFunc::write_to_stream(ostream&fd) const
 {
       const char*comma = "";
       fd << name_ << "(";
-      for (vector<Expression*>::iterator cur = argv_.begin()
+      for (vector<Expression*>::const_iterator cur = argv_.begin()
 		 ; cur != argv_.end() ; ++cur) {
 	    fd << comma;
 	    (*cur)->write_to_stream(fd);
@@ -169,22 +169,22 @@ void ExpFunc::write_to_stream(ostream&fd)
       fd << ")";
 }
 
-void ExpInteger::write_to_stream(ostream&fd)
+void ExpInteger::write_to_stream(ostream&fd) const
 {
       fd << value_;
 }
 
-void ExpReal::write_to_stream(ostream&fd)
+void ExpReal::write_to_stream(ostream&fd) const
 {
       fd << value_;
 }
 
-void ExpLogical::write_to_stream(ostream&)
+void ExpLogical::write_to_stream(ostream&) const
 {
       ivl_assert(*this, !"Not supported");
 }
 
-void ExpName::write_to_stream(ostream&fd)
+void ExpName::write_to_stream(ostream&fd) const
 {
       if (prefix_.get()) {
 	    prefix_->write_to_stream(fd);
@@ -203,12 +203,12 @@ void ExpName::write_to_stream(ostream&fd)
       }
 }
 
-void ExpRelation::write_to_stream(ostream&)
+void ExpRelation::write_to_stream(ostream&) const
 {
       ivl_assert(*this, !"Not supported");
 }
 
-void ExpString::write_to_stream(ostream&fd)
+void ExpString::write_to_stream(ostream&fd) const
 {
     fd << "\"";
     for(vector<char>::const_iterator it = value_.begin();
@@ -218,19 +218,19 @@ void ExpString::write_to_stream(ostream&fd)
     fd << "\"";
 }
 
-void ExpUAbs::write_to_stream(ostream&fd)
+void ExpUAbs::write_to_stream(ostream&fd) const
 {
       fd << "abs ";
       write_to_stream_operand1(fd);
 }
 
-void ExpUNot::write_to_stream(ostream&fd)
+void ExpUNot::write_to_stream(ostream&fd) const
 {
       fd << "not ";
       write_to_stream_operand1(fd);
 }
 
-void ExpCast::write_to_stream(ostream&fd)
+void ExpCast::write_to_stream(ostream&fd) const
 {
       // Type casting is introduced only for a few specific cases in
       // SystemVerilog, so no need to use it here

--- a/vhdlpp/expression_stream.cc
+++ b/vhdlpp/expression_stream.cc
@@ -119,9 +119,9 @@ void ExpAttribute::write_to_stream(ostream&fd) const
 
 void ExpBitstring::write_to_stream(ostream&fd) const
 {
-      fd << "\"";
-      for(vector<char>::const_iterator it = value_.begin();
-        it != value_.end(); ++it) {
+      fd << "B\"";
+      for(vector<char>::const_reverse_iterator it = value_.rbegin();
+        it != value_.rend(); ++it) {
           fd << *it;
       }
       fd << "\"";
@@ -203,9 +203,37 @@ void ExpName::write_to_stream(ostream&fd) const
       }
 }
 
-void ExpRelation::write_to_stream(ostream&) const
+void ExpRelation::write_to_stream(ostream&fd) const
 {
-      ivl_assert(*this, !"Not supported");
+      peek_operand1()->write_to_stream(fd);
+
+      switch(fun_) {
+        case EQ:
+            fd << " = ";
+            break;
+
+        case LT:
+            fd << " < ";
+            break;
+
+        case GT:
+            fd << " > ";
+            break;
+
+        case NEQ:
+            fd << " != ";
+            break;
+
+        case LE:
+            fd << " <= ";
+            break;
+
+        case GE:
+            fd << " >= ";
+            break;
+      }
+
+      peek_operand2()->write_to_stream(fd);
 }
 
 void ExpString::write_to_stream(ostream&fd) const

--- a/vhdlpp/expression_stream.cc
+++ b/vhdlpp/expression_stream.cc
@@ -236,6 +236,39 @@ void ExpRelation::write_to_stream(ostream&fd) const
       peek_operand2()->write_to_stream(fd);
 }
 
+void ExpShift::write_to_stream(ostream&out) const
+{
+      out << "(";
+      write_to_stream_operand1(out);
+      out << ")";
+
+      switch (shift_) {
+	  case SRL:
+	    out << "srl";
+	    break;
+	  case SLL:
+	    out << "sll";
+	    break;
+	  case SLA:
+	    out << "sla";
+	    break;
+	  case SRA:
+	    out << "sra";
+	    break;
+	  case ROR:
+	    out << "ror";
+	    break;
+	  case ROL:
+	    out << "rol";
+	    break;
+      }
+
+      out << "(";
+      write_to_stream_operand2(out);
+      out << ")";
+}
+
+
 void ExpString::write_to_stream(ostream&fd) const
 {
     fd << "\"";

--- a/vhdlpp/expression_stream.cc
+++ b/vhdlpp/expression_stream.cc
@@ -230,3 +230,9 @@ void ExpUNot::write_to_stream(ostream&fd)
       write_to_stream_operand1(fd);
 }
 
+void ExpCast::write_to_stream(ostream&fd)
+{
+      // Type casting is introduced only for a few specific cases in
+      // SystemVerilog, so no need to use it here
+      base_->write_to_stream(fd);
+}

--- a/vhdlpp/library.cc
+++ b/vhdlpp/library.cc
@@ -430,13 +430,10 @@ void library_set_work_path(const char*path)
       library_work_path = path;
 }
 
+list<const Package*> work_packages;
 static void store_package_in_work(const Package*pack)
 {
-      string path = make_work_package_path(pack->name());
-
-      ofstream file (path.c_str(), ios_base::out);
-
-      pack->write_to_stream(file);
+      work_packages.push_back(pack);
 }
 
 static int emit_packages(perm_string, const map<perm_string,Package*>&packages)
@@ -445,6 +442,13 @@ static int emit_packages(perm_string, const map<perm_string,Package*>&packages)
       for (map<perm_string,Package*>::const_iterator cur = packages.begin()
 		 ; cur != packages.end() ; ++cur) {
 	    errors += cur->second->emit_package(cout);
+      }
+
+      for (list<const Package*>::const_iterator cur = work_packages.begin()
+		 ; cur != work_packages.end(); ++cur) {
+	    string path = make_work_package_path((*cur)->name());
+	    ofstream file (path.c_str(), ios_base::out);
+	    (*cur)->write_to_stream(file);
       }
 
       return errors;

--- a/vhdlpp/library.cc
+++ b/vhdlpp/library.cc
@@ -417,10 +417,13 @@ bool is_global_type(perm_string name)
       if (name == "integer") return true;
       if (name == "real") return true;
       if (name == "std_logic") return true;
+      if (name == "std_logic_vector") return true;
       if (name == "character") return true;
       if (name == "bit_vector") return true;
       if (name == "string") return true;
       if (name == "natural") return true;
+      if (name == "signed") return true;
+      if (name == "unsigned") return true;
       return false;
 }
 

--- a/vhdlpp/library.cc
+++ b/vhdlpp/library.cc
@@ -387,11 +387,10 @@ static void import_std_use(const YYLTYPE&loc, ActiveScope*/*res*/, perm_string p
 const VTypePrimitive primitive_BOOLEAN(VTypePrimitive::BOOLEAN, true);
 const VTypePrimitive primitive_BIT(VTypePrimitive::BIT, true);
 const VTypePrimitive primitive_INTEGER(VTypePrimitive::INTEGER);
+const VTypePrimitive primitive_NATURAL(VTypePrimitive::NATURAL);
 const VTypePrimitive primitive_REAL(VTypePrimitive::REAL);
 const VTypePrimitive primitive_STDLOGIC(VTypePrimitive::STDLOGIC, true);
 const VTypePrimitive primitive_CHARACTER(VTypePrimitive::CHARACTER);
-
-const VTypeRange primitive_NATURAL(&primitive_INTEGER, INT64_MAX, 0);
 
 static const VTypeArray primitive_BIT_VECTOR(&primitive_BIT,      vector<VTypeArray::range_t> (1));
 static const VTypeArray primitive_BOOL_VECTOR(&primitive_BOOLEAN, vector<VTypeArray::range_t> (1));

--- a/vhdlpp/package.cc
+++ b/vhdlpp/package.cc
@@ -130,4 +130,11 @@ void Package::write_to_stream(ostream&fd) const
       }
 
       fd << "end package " << name_ << ";" << endl;
+
+      fd << "package body " << name_ << " is" << endl;
+        for (map<perm_string,Subprogram*>::const_iterator cur = cur_subprograms_.begin()
+		 ; cur != cur_subprograms_.end() ; ++cur) {
+	    cur->second->write_to_stream_body(fd);
+        }
+      fd << "end " << name_ << ";" << endl;
 }

--- a/vhdlpp/package.cc
+++ b/vhdlpp/package.cc
@@ -73,12 +73,6 @@ void Package::write_to_stream(ostream&fd) const
 	      // Do not include global types in types dump
 	    if (is_global_type(cur->first))
 		  continue;
-	    if (cur->first == "std_logic_vector")
-		  continue;
-	    if (cur->first == "signed")
-		  continue;
-	    if (cur->first == "unsigned")
-		  continue;
 
 	    fd << "type " << cur->first << " is ";
 	    cur->second->write_type_to_stream(fd);
@@ -89,8 +83,6 @@ void Package::write_to_stream(ostream&fd) const
 
 	      // Do not include global types in types dump
 	    if (is_global_type(cur->first))
-		  continue;
-	    if (cur->first == "std_logic_vector")
 		  continue;
 
 	    fd << "type " << cur->first << " is ";

--- a/vhdlpp/package_emit.cc
+++ b/vhdlpp/package_emit.cc
@@ -69,7 +69,9 @@ int Package::emit_package(ostream&fd) const
 
       for (map<perm_string,Subprogram*>::const_iterator cur = cur_subprograms_.begin()
 		 ; cur != cur_subprograms_.end() ; ++ cur) {
-	    errors += cur->second->emit_package(fd);
+	    // Do not emit unbounded functions, we will just need fixed instances later
+	    if(!cur->second->unbounded())
+		errors += cur->second->emit_package(fd);
       }
 
       fd << "endpackage" << endl;

--- a/vhdlpp/package_emit.cc
+++ b/vhdlpp/package_emit.cc
@@ -49,7 +49,8 @@ int Package::emit_package(ostream&fd) const
       for (map<perm_string,const VType*>::const_iterator cur = cur_types_.begin()
 		 ; cur != cur_types_.end() ; ++ cur) {
 	    fd << "typedef ";
-	    errors += cur->second->emit_def(fd, cur->first);
+	    errors += cur->second->emit_def(fd,
+                    dynamic_cast<const VTypeDef*>(cur->second) ? empty_perm_string : cur->first);
 	    fd << " ;" << endl;
       }
 

--- a/vhdlpp/parse.y
+++ b/vhdlpp/parse.y
@@ -573,20 +573,40 @@ case_statement_alternative_list
  * statement alternative and pass that up instead.
  */
 case_statement_alternative
-  : K_when choice ARROW sequence_of_statements
+  : K_when choices ARROW sequence_of_statements
       { CaseSeqStmt::CaseStmtAlternative* tmp;
-        if ($2->others()) {
-	      tmp = new CaseSeqStmt::CaseStmtAlternative(0, $4);
-	} else if (Expression*ex = $2->simple_expression()) {
-	      tmp = new CaseSeqStmt::CaseStmtAlternative(ex, $4);
-	} else {
-	      errormsg(@2, "I don't know what to make of the case choice\n");
-	      tmp = 0;
-	}
-	if (tmp) FILE_NAME(tmp, @1);
-	delete $2;
-	delete $4;
-	$$ = tmp;
+        std::list<ExpAggregate::choice_t*>*choices = $2;
+        std::list<Expression*>*exp_list = new std::list<Expression*>;
+        bool others = false;
+
+        for(std::list<ExpAggregate::choice_t*>::iterator it = choices->begin();
+                it != choices->end(); ++it) {
+            if((*it)->others() || others)
+                // If there is one "others", then it also covers all other alternatives
+                // Continue the loop to delete every choice_t, but do not
+                // bother to add the expressions to the exp_list (we are going to
+                // delete them very soon)
+                others = true;
+            else
+                exp_list->push_back((*it)->simple_expression());
+
+            delete (*it);
+        }
+
+        if(others) {
+            tmp = new CaseSeqStmt::CaseStmtAlternative(0, $4);
+            for(std::list<Expression*>::iterator it = exp_list->begin();
+                    it != exp_list->end(); ++it) {
+                delete (*it);
+            }
+        } else {
+            tmp = new CaseSeqStmt::CaseStmtAlternative(exp_list, $4);
+        }
+        if (tmp) FILE_NAME(tmp, @1);
+
+        delete choices;
+        delete $4;
+        $$ = tmp;
       }
    ;
 

--- a/vhdlpp/parse.y
+++ b/vhdlpp/parse.y
@@ -2393,6 +2393,9 @@ type_declaration
 		    tmp->set_definition($4);
 		    active_scope->incomplete_types.erase(cur);
 	      }
+	      if(const VTypeEnum*enum_type = dynamic_cast<const VTypeEnum*>($4)) {
+		    active_scope->use_enum(enum_type);
+	      }
 	}
 	delete[]$2;
       }

--- a/vhdlpp/parse.y
+++ b/vhdlpp/parse.y
@@ -2504,9 +2504,9 @@ K_postponed_opt    : K_postponed    | ;
 K_shared_opt       : K_shared       | ;
 %%
 
-static void yyerror(YYLTYPE*, yyscan_t, const char*, bool, const char* /*msg*/)
+static void yyerror(YYLTYPE*loc, yyscan_t, const char*, bool, const char*msg)
 {
-	//fprintf(stderr, "%s\n", msg);
+      fprintf(stderr, "%s:%u: %s\n", loc->text, loc->first_line, msg);
       parse_errors += 1;
 }
 

--- a/vhdlpp/parse.y
+++ b/vhdlpp/parse.y
@@ -2139,7 +2139,41 @@ sequential_statement
       }
   ;
 
-shift_expression : simple_expression { $$ = $1; } ;
+shift_expression
+  : simple_expression
+  | simple_expression K_srl simple_expression
+      { ExpShift*tmp = new ExpShift(ExpShift::SRL, $1, $3);
+        FILE_NAME(tmp, @2);
+        $$ = tmp;
+      }
+  | simple_expression K_sll simple_expression
+      { ExpShift*tmp = new ExpShift(ExpShift::SLL, $1, $3);
+        FILE_NAME(tmp, @2);
+        $$ = tmp;
+      }
+  | simple_expression K_sra simple_expression
+      { ExpShift*tmp = new ExpShift(ExpShift::SRA, $1, $3);
+        FILE_NAME(tmp, @2);
+        $$ = tmp;
+      }
+  | simple_expression K_sla simple_expression
+      { ExpShift*tmp = new ExpShift(ExpShift::SLA, $1, $3);
+        FILE_NAME(tmp, @2);
+        $$ = tmp;
+      }
+  | simple_expression K_ror simple_expression
+      { sorrymsg(@2, "ROR is not supported.\n");
+        ExpShift*tmp = new ExpShift(ExpShift::ROR, $1, $3);
+        FILE_NAME(tmp, @2);
+        $$ = tmp;
+      }
+  | simple_expression K_rol simple_expression
+      { sorrymsg(@2, "ROL is not supported.\n");
+        ExpShift*tmp = new ExpShift(ExpShift::ROL, $1, $3);
+        FILE_NAME(tmp, @2);
+        $$ = tmp;
+      }
+  ;
 
 sign
   : '+'

--- a/vhdlpp/parse_misc.cc
+++ b/vhdlpp/parse_misc.cc
@@ -105,6 +105,7 @@ static const VType* calculate_subtype_array(const YYLTYPE&loc, const char*base_n
 
 	    VTypeArray*subtype = new VTypeArray(element, range,
                                                 base_array->signed_vector());
+	    subtype->set_parent_type(base_array);
 	    return subtype;
       }
 

--- a/vhdlpp/parse_types.h
+++ b/vhdlpp/parse_types.h
@@ -72,6 +72,9 @@ class prange_t {
     public:
       prange_t(Expression* left, Expression* right, bool dir)
         : left_(left), right_(right), direction_(dir), auto_dir_(false) {}
+      prange_t(const prange_t&other) :
+          left_(other.left_->clone()), right_(other.right_->clone()),
+          direction_(other.direction_), auto_dir_(other.auto_dir_) {}
       ~prange_t() { delete left_; delete right_; }
       void dump(ostream&out, int indent) const;
 
@@ -91,7 +94,6 @@ class prange_t {
       bool auto_dir_;
 
     private: //not implemented
-      prange_t(const prange_t&);
       prange_t operator=(const prange_t&);
 };
 

--- a/vhdlpp/scope.cc
+++ b/vhdlpp/scope.cc
@@ -106,6 +106,9 @@ const VType*ScopeBase::find_type(perm_string by_name)
 
 bool ScopeBase::find_constant(perm_string by_name, const VType*&typ, Expression*&exp) const
 {
+      typ = NULL;
+      exp = NULL;
+
       map<perm_string,struct const_t*>::const_iterator cur = cur_constants_.find(by_name);
       if (cur == cur_constants_.end()) {
         cur = use_constants_.find(by_name);
@@ -121,6 +124,8 @@ bool ScopeBase::find_constant(perm_string by_name, const VType*&typ, Expression*
         exp = cur->second->val;
         return true;
       }
+
+      return false;
 }
 
 Signal* ScopeBase::find_signal(perm_string by_name) const

--- a/vhdlpp/scope.cc
+++ b/vhdlpp/scope.cc
@@ -59,6 +59,8 @@ ScopeBase::ScopeBase(const ActiveScope&ref)
     use_subprograms_ = ref.use_subprograms_;
     cur_subprograms_ = ref.cur_subprograms_;
 
+    use_enums_ = ref.use_enums_;
+
       // This constructor is invoked when the parser is finished with
       // an active scope and is making the actual scope. At this point
       // we know that "this" is the parent scope for the subprograms,
@@ -181,6 +183,17 @@ Subprogram* ScopeBase::find_subprogram(perm_string name) const
       return 0;
 }
 
+bool ScopeBase::is_enum_name(perm_string name) const
+{
+    for(list<const VTypeEnum*>::const_iterator it = use_enums_.begin();
+            it != use_enums_.end(); ++it) {
+        if((*it)->has_name(name))
+            return true;
+    }
+
+    return false;
+}
+
 /*
  * This method is only used by the ActiveScope derived class to import
  * definition from another scope.
@@ -219,6 +232,8 @@ void ScopeBase::do_use_from(const ScopeBase*that)
 		 ; cur != that->cur_constants_.end() ; ++ cur) {
 	    use_constants_[cur->first] = cur->second;
       }
+
+      use_enums_ = that->use_enums_;
 }
 
 void ScopeBase::transfer_from(ScopeBase&ref)

--- a/vhdlpp/scope.cc
+++ b/vhdlpp/scope.cc
@@ -21,6 +21,7 @@
 # include  "scope.h"
 # include  "package.h"
 # include  "subprogram.h"
+# include  "entity.h"
 # include  <algorithm>
 # include  <iostream>
 # include  <iterator>
@@ -146,6 +147,23 @@ Variable* ScopeBase::find_variable(perm_string by_name) const
       } else {
 	    return cur->second;
       }
+}
+
+const InterfacePort* ScopeBase::find_param(perm_string by_name) const
+{
+      for(map<perm_string,Subprogram*>::const_iterator it = use_subprograms_.begin();
+              it != use_subprograms_.end(); ++it) {
+          if(const InterfacePort*port = it->second->find_param(by_name))
+              return port;
+      }
+
+      for(map<perm_string,Subprogram*>::const_iterator it = cur_subprograms_.begin();
+              it != cur_subprograms_.end(); ++it) {
+          if(const InterfacePort*port = it->second->find_param(by_name))
+              return port;
+      }
+
+      return NULL;
 }
 
 Subprogram* ScopeBase::find_subprogram(perm_string name) const

--- a/vhdlpp/scope.cc
+++ b/vhdlpp/scope.cc
@@ -104,7 +104,7 @@ const VType*ScopeBase::find_type(perm_string by_name)
 	    return cur->second;
 }
 
-bool ScopeBase::find_constant(perm_string by_name, const VType*&typ, Expression*&exp)
+bool ScopeBase::find_constant(perm_string by_name, const VType*&typ, Expression*&exp) const
 {
       map<perm_string,struct const_t*>::const_iterator cur = cur_constants_.find(by_name);
       if (cur == cur_constants_.end()) {
@@ -279,6 +279,11 @@ bool ActiveScope::is_vector_name(perm_string name) const
       if (find_signal(name))
 	    return true;
       if (find_variable(name))
+	    return true;
+
+      const VType*dummy_type;
+      Expression*dummy_exp;
+      if (find_constant(name, dummy_type, dummy_exp))
 	    return true;
 
       if (context_entity_ && context_entity_->find_port(name))

--- a/vhdlpp/scope.h
+++ b/vhdlpp/scope.h
@@ -53,7 +53,7 @@ class ScopeBase {
       virtual ~ScopeBase() =0;
 
       const VType* find_type(perm_string by_name);
-      bool find_constant(perm_string by_name, const VType*&typ, Expression*&exp);
+      bool find_constant(perm_string by_name, const VType*&typ, Expression*&exp) const;
       Signal* find_signal(perm_string by_name) const;
       Variable* find_variable(perm_string by_name) const;
       virtual const InterfacePort* find_param(perm_string by_name) const;

--- a/vhdlpp/scope.h
+++ b/vhdlpp/scope.h
@@ -62,6 +62,13 @@ class ScopeBase {
 	// this one. After the transfer new_* maps are emptied in the another scope.
       void transfer_from(ScopeBase&ref);
 
+      inline void bind_subprogram(perm_string name, Subprogram*obj)
+      { map<perm_string, Subprogram*>::iterator it;
+        if((it = use_subprograms_.find(name)) != use_subprograms_.end() )
+            use_subprograms_.erase(it);
+        cur_subprograms_[name] = obj;
+      }
+
     protected:
       void cleanup();
 

--- a/vhdlpp/scope.h
+++ b/vhdlpp/scope.h
@@ -56,6 +56,7 @@ class ScopeBase {
       bool find_constant(perm_string by_name, const VType*&typ, Expression*&exp);
       Signal* find_signal(perm_string by_name) const;
       Variable* find_variable(perm_string by_name) const;
+      virtual const InterfacePort* find_param(perm_string by_name) const;
       Subprogram* find_subprogram(perm_string by_name) const;
 	// Moves all signals, variables and components from another scope to
 	// this one. After the transfer new_* maps are emptied in the another scope.

--- a/vhdlpp/scope.h
+++ b/vhdlpp/scope.h
@@ -58,6 +58,7 @@ class ScopeBase {
       Variable* find_variable(perm_string by_name) const;
       virtual const InterfacePort* find_param(perm_string by_name) const;
       Subprogram* find_subprogram(perm_string by_name) const;
+      bool is_enum_name(perm_string name) const;
 	// Moves all signals, variables and components from another scope to
 	// this one. After the transfer new_* maps are emptied in the another scope.
       void transfer_from(ScopeBase&ref);
@@ -113,6 +114,8 @@ class ScopeBase {
 
       std::map<perm_string, Subprogram*> use_subprograms_; //imported
       std::map<perm_string, Subprogram*> cur_subprograms_; //current
+
+      std::list<const VTypeEnum*> use_enums_;
 
       void do_use_from(const ScopeBase*that);
 };
@@ -198,6 +201,9 @@ class ActiveScope : public ScopeBase {
             use_types_.erase(it);
         cur_types_[name] = t;
       }
+
+      inline void use_enum(const VTypeEnum* t)
+      { use_enums_.push_back(t); }
 
       inline void use_name(perm_string name, const VType* t)
       { use_types_[name] = t; }

--- a/vhdlpp/sequential.cc
+++ b/vhdlpp/sequential.cc
@@ -19,6 +19,7 @@
 
 # include  "sequential.h"
 # include  "expression.h"
+# include  <cassert>
 
 template<typename T>
 inline static void visit_stmt_list(std::list<T*>& stmts, SeqStmtVisitor& func)
@@ -193,6 +194,12 @@ ReturnStmt::ReturnStmt(Expression*val)
 ReturnStmt::~ReturnStmt()
 {
       delete val_;
+}
+
+void ReturnStmt::cast_to(const VType*type)
+{
+    assert(val_);
+    val_ = new ExpCast(val_, type);
 }
 
 LoopStatement::LoopStatement(perm_string name, list<SequentialStmt*>* stmts)

--- a/vhdlpp/sequential.cc
+++ b/vhdlpp/sequential.cc
@@ -21,7 +21,7 @@
 # include  "expression.h"
 
 template<typename T>
-inline static void visit_stmt_list(std::list<T*>& stmts, void((*func))(SequentialStmt*))
+inline static void visit_stmt_list(std::list<T*>& stmts, SeqStmtVisitor& func)
 {
     for(typename std::list<T*>::iterator it = stmts.begin(); it != stmts.end(); ++it) {
         (*it)->visit(func);
@@ -83,12 +83,12 @@ void IfSequential::extract_false(std::list<SequentialStmt*>&that)
       }
 }
 
-void IfSequential::visit(void((*func))(SequentialStmt*))
+void IfSequential::visit(SeqStmtVisitor& func)
 {
     visit_stmt_list(if_, func);
     visit_stmt_list(elsif_, func);
     visit_stmt_list(else_, func);
-    ((*func))(this);
+    func(this);
 }
 
 IfSequential::Elsif::Elsif(Expression*cond, std::list<SequentialStmt*>*tr)
@@ -107,7 +107,7 @@ IfSequential::Elsif::~Elsif()
       }
 }
 
-void IfSequential::Elsif::visit(void((*func))(SequentialStmt*))
+void IfSequential::Elsif::visit(SeqStmtVisitor& func)
 {
     visit_stmt_list(if_, func);
 }
@@ -139,10 +139,10 @@ CaseSeqStmt::~CaseSeqStmt()
       }
 }
 
-void CaseSeqStmt::visit(void((*func))(SequentialStmt*))
+void CaseSeqStmt::visit(SeqStmtVisitor& func)
 {
     visit_stmt_list(alt_, func);
-    ((*func))(this);
+    func(this);
 }
 
 CaseSeqStmt::CaseStmtAlternative::CaseStmtAlternative(Expression* exp, list<SequentialStmt*>* stmts)
@@ -161,7 +161,7 @@ CaseSeqStmt::CaseStmtAlternative::~CaseStmtAlternative()
       }
 }
 
-void CaseSeqStmt::CaseStmtAlternative::visit(void((*func))(SequentialStmt*))
+void CaseSeqStmt::CaseStmtAlternative::visit(SeqStmtVisitor& func)
 {
     visit_stmt_list(stmts_, func);
 }
@@ -210,10 +210,10 @@ LoopStatement::~LoopStatement()
     }
 }
 
-void LoopStatement::visit(void((*func))(SequentialStmt*))
+void LoopStatement::visit(SeqStmtVisitor& func)
 {
     visit_stmt_list(stmts_, func);
-    (*func)(this);
+    func(this);
 }
 
 ForLoopStatement::ForLoopStatement(perm_string scope_name, perm_string it, prange_t* range, list<SequentialStmt*>* stmts)

--- a/vhdlpp/sequential.cc
+++ b/vhdlpp/sequential.cc
@@ -146,7 +146,8 @@ void CaseSeqStmt::visit(SeqStmtVisitor& func)
     func(this);
 }
 
-CaseSeqStmt::CaseStmtAlternative::CaseStmtAlternative(Expression* exp, list<SequentialStmt*>* stmts)
+CaseSeqStmt::CaseStmtAlternative::CaseStmtAlternative(std::list<Expression*>*exp,
+        list<SequentialStmt*>*stmts)
 : exp_(exp)
 {
       if (stmts) stmts_.splice(stmts_.end(), *stmts);

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -25,7 +25,7 @@
 # include  <list>
 # include  <functional>
 
-class Architecture;
+class ScopeBase;
 class Entity;
 class Expression;
 class SequentialStmt;
@@ -42,8 +42,8 @@ class SequentialStmt  : public LineInfo {
       virtual ~SequentialStmt() =0;
 
     public:
-      virtual int elaborate(Entity*ent, Architecture*arc);
-      virtual int emit(ostream&out, Entity*entity, Architecture*arc);
+      virtual int elaborate(Entity*ent, ScopeBase*scope);
+      virtual int emit(ostream&out, Entity*entity, ScopeBase*scope);
       virtual void dump(ostream&out, int indent) const;
 
       // Recursively visits a tree of sequential statements.
@@ -65,8 +65,8 @@ class LoopStatement : public SequentialStmt {
       void visit(SeqStmtVisitor& func);
 
     protected:
-      int elaborate_substatements(Entity*ent, Architecture*arc);
-      int emit_substatements(std::ostream&out, Entity*ent, Architecture*arc);
+      int elaborate_substatements(Entity*ent, ScopeBase*scope);
+      int emit_substatements(std::ostream&out, Entity*ent, ScopeBase*scope);
 
     private:
       perm_string name_;
@@ -81,9 +81,9 @@ class IfSequential  : public SequentialStmt {
 	    Elsif(Expression*cond, std::list<SequentialStmt*>*tr);
 	    ~Elsif();
 
-	    int elaborate(Entity*entity, Architecture*arc);
-	    int condition_emit(ostream&out, Entity*entity, Architecture*arc);
-	    int statement_emit(ostream&out, Entity*entity, Architecture*arc);
+	    int elaborate(Entity*entity, ScopeBase*scope);
+	    int condition_emit(ostream&out, Entity*entity, ScopeBase*scope);
+	    int statement_emit(ostream&out, Entity*entity, ScopeBase*scope);
 
 	    void dump(ostream&out, int indent) const;
 	    void visit(SeqStmtVisitor& func);
@@ -103,8 +103,8 @@ class IfSequential  : public SequentialStmt {
       ~IfSequential();
 
     public:
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
       void visit(SeqStmtVisitor& func);
 
@@ -130,7 +130,7 @@ class ReturnStmt  : public SequentialStmt {
       ~ReturnStmt();
 
     public:
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
       const Expression*peek_expr() const { return val_; };
@@ -146,8 +146,8 @@ class SignalSeqAssignment  : public SequentialStmt {
       ~SignalSeqAssignment();
 
     public:
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -162,9 +162,9 @@ class CaseSeqStmt : public SequentialStmt {
             CaseStmtAlternative(Expression* exp, std::list<SequentialStmt*>* stmts);
             ~CaseStmtAlternative();
             void dump(std::ostream& out, int indent) const;
-	    int elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype);
-	    int elaborate(Entity*ent, Architecture*arc);
-	    int emit(ostream&out, Entity*entity, Architecture*arc);
+	    int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
+	    int elaborate(Entity*ent, ScopeBase*scope);
+	    int emit(ostream&out, Entity*entity, ScopeBase*scope);
 	    void visit(SeqStmtVisitor& func);
 
         private:
@@ -181,8 +181,8 @@ class CaseSeqStmt : public SequentialStmt {
 
     public:
       void dump(ostream&out, int indent) const;
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void visit(SeqStmtVisitor& func);
 
     private:
@@ -196,8 +196,8 @@ class ProcedureCall : public SequentialStmt {
       ProcedureCall(perm_string name, std::list<named_expr_t*>* param_list);
       ~ProcedureCall();
 
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -211,8 +211,8 @@ class VariableSeqAssignment  : public SequentialStmt {
       ~VariableSeqAssignment();
 
     public:
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -226,8 +226,8 @@ class WhileLoopStatement : public LoopStatement {
 			 ExpLogical*, list<SequentialStmt*>*);
       ~WhileLoopStatement();
 
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -240,14 +240,14 @@ class ForLoopStatement : public LoopStatement {
 		       perm_string index, prange_t*, list<SequentialStmt*>*);
       ~ForLoopStatement();
 
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*ent, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*ent, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
     private:
       // Emits for-loop which direction is determined at run-time.
       // It is used for 'range & 'reverse_range attributes.
-      int emit_runtime_(ostream&out, Entity*ent, Architecture*arc);
+      int emit_runtime_(ostream&out, Entity*ent, ScopeBase*scope);
 
       perm_string it_;
       prange_t* range_;
@@ -258,8 +258,8 @@ class BasicLoopStatement : public LoopStatement {
       BasicLoopStatement(perm_string lname, list<SequentialStmt*>*);
       ~BasicLoopStatement();
 
-      int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int elaborate(Entity*ent, ScopeBase*scope);
+      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 };
 

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -45,6 +45,7 @@ class SequentialStmt  : public LineInfo {
       virtual int elaborate(Entity*ent, ScopeBase*scope);
       virtual int emit(ostream&out, Entity*entity, ScopeBase*scope);
       virtual void dump(ostream&out, int indent) const;
+      virtual void write_to_stream(std::ostream&fd);
 
       // Recursively visits a tree of sequential statements.
       virtual void visit(SeqStmtVisitor& func) { func(this); }
@@ -67,6 +68,7 @@ class LoopStatement : public SequentialStmt {
     protected:
       int elaborate_substatements(Entity*ent, ScopeBase*scope);
       int emit_substatements(std::ostream&out, Entity*ent, ScopeBase*scope);
+      void write_to_stream_substatements(ostream&fd);
 
     private:
       perm_string name_;
@@ -84,6 +86,9 @@ class IfSequential  : public SequentialStmt {
 	    int elaborate(Entity*entity, ScopeBase*scope);
 	    int condition_emit(ostream&out, Entity*entity, ScopeBase*scope);
 	    int statement_emit(ostream&out, Entity*entity, ScopeBase*scope);
+
+	    void condition_write_to_stream(ostream&fd);
+	    void statement_write_to_stream(ostream&fd);
 
 	    void dump(ostream&out, int indent) const;
 	    void visit(SeqStmtVisitor& func);
@@ -105,6 +110,7 @@ class IfSequential  : public SequentialStmt {
     public:
       int elaborate(Entity*ent, ScopeBase*scope);
       int emit(ostream&out, Entity*entity, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
       void dump(ostream&out, int indent) const;
       void visit(SeqStmtVisitor& func);
 
@@ -131,6 +137,7 @@ class ReturnStmt  : public SequentialStmt {
 
     public:
       int emit(ostream&out, Entity*entity, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
       void dump(ostream&out, int indent) const;
 
       const Expression*peek_expr() const { return val_; };
@@ -148,6 +155,7 @@ class SignalSeqAssignment  : public SequentialStmt {
     public:
       int elaborate(Entity*ent, ScopeBase*scope);
       int emit(ostream&out, Entity*entity, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -165,6 +173,7 @@ class CaseSeqStmt : public SequentialStmt {
 	    int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
 	    int elaborate(Entity*ent, ScopeBase*scope);
 	    int emit(ostream&out, Entity*entity, ScopeBase*scope);
+            void write_to_stream(std::ostream&fd);
 	    void visit(SeqStmtVisitor& func);
 
         private:
@@ -183,6 +192,7 @@ class CaseSeqStmt : public SequentialStmt {
       void dump(ostream&out, int indent) const;
       int elaborate(Entity*ent, ScopeBase*scope);
       int emit(ostream&out, Entity*entity, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
       void visit(SeqStmtVisitor& func);
 
     private:
@@ -213,6 +223,7 @@ class VariableSeqAssignment  : public SequentialStmt {
     public:
       int elaborate(Entity*ent, ScopeBase*scope);
       int emit(ostream&out, Entity*entity, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -227,7 +238,6 @@ class WhileLoopStatement : public LoopStatement {
       ~WhileLoopStatement();
 
       int elaborate(Entity*ent, ScopeBase*scope);
-      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -242,6 +252,7 @@ class ForLoopStatement : public LoopStatement {
 
       int elaborate(Entity*ent, ScopeBase*scope);
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
       void dump(ostream&out, int indent) const;
 
     private:
@@ -259,7 +270,6 @@ class BasicLoopStatement : public LoopStatement {
       ~BasicLoopStatement();
 
       int elaborate(Entity*ent, ScopeBase*scope);
-      int emit(ostream&out, Entity*entity, ScopeBase*scope);
       void dump(ostream&out, int indent) const;
 };
 

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -134,6 +134,7 @@ class ReturnStmt  : public SequentialStmt {
       void dump(ostream&out, int indent) const;
 
       const Expression*peek_expr() const { return val_; };
+      void cast_to(const VType*type);
 
     private:
       Expression*val_;

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -167,7 +167,7 @@ class CaseSeqStmt : public SequentialStmt {
     public:
       class CaseStmtAlternative : public LineInfo {
         public:
-            CaseStmtAlternative(Expression* exp, std::list<SequentialStmt*>* stmts);
+            CaseStmtAlternative(std::list<Expression*>*exp, std::list<SequentialStmt*>*stmts);
             ~CaseStmtAlternative();
             void dump(std::ostream& out, int indent) const;
 	    int elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype);
@@ -177,7 +177,7 @@ class CaseSeqStmt : public SequentialStmt {
 	    void visit(SeqStmtVisitor& func);
 
         private:
-            Expression* exp_;
+            std::list<Expression*>*exp_;
 	    std::list<SequentialStmt*> stmts_;
         private: // not implemented
             CaseStmtAlternative(const CaseStmtAlternative&);

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -23,10 +23,17 @@
 # include  "LineInfo.h"
 # include "parse_types.h"
 # include  <list>
+# include  <functional>
 
 class Architecture;
 class Entity;
 class Expression;
+class SequentialStmt;
+
+struct SeqStmtVisitor {
+    virtual ~SeqStmtVisitor() {};
+    virtual void operator() (SequentialStmt*s) = 0;
+};
 
 class SequentialStmt  : public LineInfo {
 
@@ -38,7 +45,9 @@ class SequentialStmt  : public LineInfo {
       virtual int elaborate(Entity*ent, Architecture*arc);
       virtual int emit(ostream&out, Entity*entity, Architecture*arc);
       virtual void dump(ostream&out, int indent) const;
-      virtual void visit(void(*func)(SequentialStmt*)) { (*func)(this); }
+
+      // Recursively visits a tree of sequential statements.
+      virtual void visit(SeqStmtVisitor& func) { func(this); }
 };
 
 /*
@@ -53,7 +62,7 @@ class LoopStatement : public SequentialStmt {
       inline perm_string loop_name() const { return name_; }
 
       void dump(ostream&out, int indent)  const;
-      void visit(void(*func)(SequentialStmt*));
+      void visit(SeqStmtVisitor& func);
 
     protected:
       int elaborate_substatements(Entity*ent, Architecture*arc);
@@ -77,7 +86,7 @@ class IfSequential  : public SequentialStmt {
 	    int statement_emit(ostream&out, Entity*entity, Architecture*arc);
 
 	    void dump(ostream&out, int indent) const;
-	    void visit(void(*func)(SequentialStmt*));
+	    void visit(SeqStmtVisitor& func);
 
 	  private:
 	    Expression*cond_;
@@ -97,7 +106,7 @@ class IfSequential  : public SequentialStmt {
       int elaborate(Entity*ent, Architecture*arc);
       int emit(ostream&out, Entity*entity, Architecture*arc);
       void dump(ostream&out, int indent) const;
-      void visit(void(*func)(SequentialStmt*));
+      void visit(SeqStmtVisitor& func);
 
       const Expression*peek_condition() const { return cond_; }
 
@@ -155,7 +164,7 @@ class CaseSeqStmt : public SequentialStmt {
 	    int elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype);
 	    int elaborate(Entity*ent, Architecture*arc);
 	    int emit(ostream&out, Entity*entity, Architecture*arc);
-	    void visit(void(*func)(SequentialStmt*));
+	    void visit(SeqStmtVisitor& func);
 
         private:
             Expression* exp_;
@@ -173,7 +182,7 @@ class CaseSeqStmt : public SequentialStmt {
       void dump(ostream&out, int indent) const;
       int elaborate(Entity*ent, Architecture*arc);
       int emit(ostream&out, Entity*entity, Architecture*arc);
-      void visit(void(*func)(SequentialStmt*));
+      void visit(SeqStmtVisitor& func);
 
     private:
       Expression* cond_;

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -38,6 +38,7 @@ class SequentialStmt  : public LineInfo {
       virtual int elaborate(Entity*ent, Architecture*arc);
       virtual int emit(ostream&out, Entity*entity, Architecture*arc);
       virtual void dump(ostream&out, int indent) const;
+      virtual void visit(void(*func)(SequentialStmt*)) { (*func)(this); }
 };
 
 /*
@@ -52,6 +53,7 @@ class LoopStatement : public SequentialStmt {
       inline perm_string loop_name() const { return name_; }
 
       void dump(ostream&out, int indent)  const;
+      void visit(void(*func)(SequentialStmt*));
 
     protected:
       int elaborate_substatements(Entity*ent, Architecture*arc);
@@ -75,6 +77,7 @@ class IfSequential  : public SequentialStmt {
 	    int statement_emit(ostream&out, Entity*entity, Architecture*arc);
 
 	    void dump(ostream&out, int indent) const;
+	    void visit(void(*func)(SequentialStmt*));
 
 	  private:
 	    Expression*cond_;
@@ -94,6 +97,7 @@ class IfSequential  : public SequentialStmt {
       int elaborate(Entity*ent, Architecture*arc);
       int emit(ostream&out, Entity*entity, Architecture*arc);
       void dump(ostream&out, int indent) const;
+      void visit(void(*func)(SequentialStmt*));
 
       const Expression*peek_condition() const { return cond_; }
 
@@ -151,6 +155,7 @@ class CaseSeqStmt : public SequentialStmt {
 	    int elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype);
 	    int elaborate(Entity*ent, Architecture*arc);
 	    int emit(ostream&out, Entity*entity, Architecture*arc);
+	    void visit(void(*func)(SequentialStmt*));
 
         private:
             Expression* exp_;
@@ -168,6 +173,7 @@ class CaseSeqStmt : public SequentialStmt {
       void dump(ostream&out, int indent) const;
       int elaborate(Entity*ent, Architecture*arc);
       int emit(ostream&out, Entity*entity, Architecture*arc);
+      void visit(void(*func)(SequentialStmt*));
 
     private:
       Expression* cond_;

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -225,10 +225,14 @@ class ForLoopStatement : public LoopStatement {
       ~ForLoopStatement();
 
       int elaborate(Entity*ent, Architecture*arc);
-      int emit(ostream&out, Entity*entity, Architecture*arc);
+      int emit(ostream&out, Entity*ent, Architecture*arc);
       void dump(ostream&out, int indent) const;
 
     private:
+      // Emits for-loop which direction is determined at run-time.
+      // It is used for 'range & 'reverse_range attributes.
+      int emit_runtime_(ostream&out, Entity*ent, Architecture*arc);
+
       perm_string it_;
       prange_t* range_;
 };

--- a/vhdlpp/sequential_debug.cc
+++ b/vhdlpp/sequential_debug.cc
@@ -105,7 +105,9 @@ void CaseSeqStmt::CaseStmtAlternative::dump(ostream& out, int indent) const
 
       out << setw(indent) << "" << "when ";
       if (exp_)
-	    exp_->dump(out, 0);
+	    for (list<Expression*>::iterator it = exp_->begin(); it != exp_->end(); ++it) {
+	        (*it)->dump(out, 0);
+	    }
       else
 	    out << "others" << endl;
 

--- a/vhdlpp/sequential_elaborate.cc
+++ b/vhdlpp/sequential_elaborate.cc
@@ -20,35 +20,35 @@
 # include  "sequential.h"
 # include  "expression.h"
 
-int SequentialStmt::elaborate(Entity*, Architecture*)
+int SequentialStmt::elaborate(Entity*, ScopeBase*)
 {
       return 0;
 }
 
-int LoopStatement::elaborate_substatements(Entity*ent, Architecture*arc)
+int LoopStatement::elaborate_substatements(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
       for (list<SequentialStmt*>::iterator cur = stmts_.begin()
 		 ; cur != stmts_.end() ; ++cur) {
-	    errors += (*cur)->elaborate(ent, arc);
+	    errors += (*cur)->elaborate(ent, scope);
       }
 
       return errors;
 }
 
-int CaseSeqStmt::elaborate(Entity*ent, Architecture*arc)
+int CaseSeqStmt::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
-      const VType*ctype = cond_->probe_type(ent, arc);
-      errors += cond_->elaborate_expr(ent, arc, ctype);
+      const VType*ctype = cond_->probe_type(ent, scope);
+      errors += cond_->elaborate_expr(ent, scope, ctype);
 
       for (list<CaseStmtAlternative*>::iterator cur = alt_.begin()
 		 ; cur != alt_.end() ; ++cur) {
 	    CaseStmtAlternative*curp = *cur;
-	    errors += curp->elaborate_expr(ent, arc, ctype);
-	    errors += curp->elaborate(ent, arc);
+	    errors += curp->elaborate_expr(ent, scope, ctype);
+	    errors += curp->elaborate(ent, scope);
       }
 
       return errors;
@@ -59,78 +59,78 @@ int CaseSeqStmt::elaborate(Entity*ent, Architecture*arc)
  * ltype is the probed type for the main case condition. The
  * expression needs to elaborate itself in that context.
  */
-int CaseSeqStmt::CaseStmtAlternative::elaborate_expr(Entity*ent, Architecture*arc, const VType*ltype)
+int CaseSeqStmt::CaseStmtAlternative::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
       if (exp_)
-	    errors += exp_->elaborate_expr(ent, arc, ltype);
+	    errors += exp_->elaborate_expr(ent, scope, ltype);
       return errors;
 }
 
-int CaseSeqStmt::CaseStmtAlternative::elaborate(Entity*ent, Architecture*arc)
+int CaseSeqStmt::CaseStmtAlternative::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
       for (list<SequentialStmt*>::iterator cur = stmts_.begin()
 		 ; cur != stmts_.end() ; ++cur) {
 	    SequentialStmt*curp = *cur;
-	    errors += curp->elaborate(ent, arc);
+	    errors += curp->elaborate(ent, scope);
       }
 
       return errors;
 }
 
-int ForLoopStatement::elaborate(Entity*ent, Architecture*arc)
+int ForLoopStatement::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
-      errors += elaborate_substatements(ent, arc);
+      errors += elaborate_substatements(ent, scope);
       return errors;
 }
 
-int IfSequential::elaborate(Entity*ent, Architecture*arc)
+int IfSequential::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
-      errors += cond_->elaborate_expr(ent, arc, 0);
+      errors += cond_->elaborate_expr(ent, scope, 0);
 
       for (list<SequentialStmt*>::iterator cur = if_.begin()
 		 ; cur != if_.end() ; ++cur) {
-	    errors += (*cur)->elaborate(ent, arc);
+	    errors += (*cur)->elaborate(ent, scope);
       }
 
       for (list<IfSequential::Elsif*>::iterator cur = elsif_.begin()
 		 ; cur != elsif_.end() ; ++cur) {
-	    errors += (*cur)->elaborate(ent, arc);
+	    errors += (*cur)->elaborate(ent, scope);
       }
 
       for (list<SequentialStmt*>::iterator cur = else_.begin()
 		 ; cur != else_.end() ; ++cur) {
-	    errors += (*cur)->elaborate(ent, arc);
+	    errors += (*cur)->elaborate(ent, scope);
       }
 
       return errors;
 }
 
-int IfSequential::Elsif::elaborate(Entity*ent, Architecture*arc)
+int IfSequential::Elsif::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
-      errors += cond_->elaborate_expr(ent, arc, 0);
+      errors += cond_->elaborate_expr(ent, scope, 0);
 
       for (list<SequentialStmt*>::iterator cur = if_.begin()
 		 ; cur != if_.end() ; ++cur) {
-	    errors += (*cur)->elaborate(ent, arc);
+	    errors += (*cur)->elaborate(ent, scope);
       }
 
       return errors;
 }
 
-int SignalSeqAssignment::elaborate(Entity*ent, Architecture*arc)
+int SignalSeqAssignment::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
 	// Elaborate the l-value expression.
-      errors += lval_->elaborate_lval(ent, arc, true);
+      errors += lval_->elaborate_lval(ent, scope, true);
 
 	// The elaborate_lval should have resolved the type of the
 	// l-value expression. We'll use that type to elaborate the
@@ -145,23 +145,23 @@ int SignalSeqAssignment::elaborate(Entity*ent, Architecture*arc)
       for (list<Expression*>::iterator cur = waveform_.begin()
 		 ; cur != waveform_.end() ; ++cur) {
 
-	    errors += (*cur)->elaborate_expr(ent, arc, lval_type);
+	    errors += (*cur)->elaborate_expr(ent, scope, lval_type);
       }
 
       return errors;
 }
 
-int ProcedureCall::elaborate(Entity*, Architecture*)
+int ProcedureCall::elaborate(Entity*, ScopeBase*)
 {
       return 0;
 }
 
-int VariableSeqAssignment::elaborate(Entity*ent, Architecture*arc)
+int VariableSeqAssignment::elaborate(Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
 	// Elaborate the l-value expression.
-      errors += lval_->elaborate_lval(ent, arc, true);
+      errors += lval_->elaborate_lval(ent, scope, true);
 
 	// The elaborate_lval should have resolved the type of the
 	// l-value expression. We'll use that type to elaborate the
@@ -173,7 +173,7 @@ int VariableSeqAssignment::elaborate(Entity*ent, Architecture*arc)
       }
 
 	// Elaborate the r-value expression.
-      errors += rval_->elaborate_expr(ent, arc, lval_type);
+      errors += rval_->elaborate_expr(ent, scope, lval_type);
 
 	// Handle functions that return unbounded arrays
       if(ExpFunc*call = dynamic_cast<ExpFunc*>(rval_)) {
@@ -185,13 +185,13 @@ int VariableSeqAssignment::elaborate(Entity*ent, Architecture*arc)
       return errors;
 }
 
-int WhileLoopStatement::elaborate(Entity*, Architecture*)
+int WhileLoopStatement::elaborate(Entity*, ScopeBase*)
 {
     //TODO:check whether there is any wait statement in the statements (there should be)
     return 0;
 }
 
-int BasicLoopStatement::elaborate(Entity*, Architecture*)
+int BasicLoopStatement::elaborate(Entity*, ScopeBase*)
 {
     return 0;
 }

--- a/vhdlpp/sequential_elaborate.cc
+++ b/vhdlpp/sequential_elaborate.cc
@@ -62,8 +62,12 @@ int CaseSeqStmt::elaborate(Entity*ent, ScopeBase*scope)
 int CaseSeqStmt::CaseStmtAlternative::elaborate_expr(Entity*ent, ScopeBase*scope, const VType*ltype)
 {
       int errors = 0;
-      if (exp_)
-	    errors += exp_->elaborate_expr(ent, scope, ltype);
+      if (exp_) {
+            for (list<Expression*>::iterator it = exp_->begin(); it != exp_->end();
+                    ++it) {
+                errors += (*it)->elaborate_expr(ent, scope, ltype);
+            }
+      }
       return errors;
 }
 

--- a/vhdlpp/sequential_elaborate.cc
+++ b/vhdlpp/sequential_elaborate.cc
@@ -80,7 +80,6 @@ int CaseSeqStmt::CaseStmtAlternative::elaborate(Entity*ent, Architecture*arc)
       return errors;
 }
 
-
 int ForLoopStatement::elaborate(Entity*ent, Architecture*arc)
 {
       int errors = 0;
@@ -175,6 +174,13 @@ int VariableSeqAssignment::elaborate(Entity*ent, Architecture*arc)
 
 	// Elaborate the r-value expression.
       errors += rval_->elaborate_expr(ent, arc, lval_type);
+
+	// Handle functions that return unbounded arrays
+      if(ExpFunc*call = dynamic_cast<ExpFunc*>(rval_)) {
+	    const VType*ret_type = call->func_ret_type();
+            if(ret_type && ret_type->is_unbounded())
+                rval_ = new ExpCast(rval_, get_global_typedef(lval_type));
+      }
 
       return errors;
 }

--- a/vhdlpp/sequential_elaborate.cc
+++ b/vhdlpp/sequential_elaborate.cc
@@ -179,13 +179,6 @@ int VariableSeqAssignment::elaborate(Entity*ent, ScopeBase*scope)
 	// Elaborate the r-value expression.
       errors += rval_->elaborate_expr(ent, scope, lval_type);
 
-	// Handle functions that return unbounded arrays
-      if(ExpFunc*call = dynamic_cast<ExpFunc*>(rval_)) {
-	    const VType*ret_type = call->func_ret_type();
-            if(ret_type && ret_type->is_unbounded())
-                rval_ = new ExpCast(rval_, get_global_typedef(lval_type));
-      }
-
       return errors;
 }
 

--- a/vhdlpp/sequential_emit.cc
+++ b/vhdlpp/sequential_emit.cc
@@ -271,12 +271,19 @@ int CaseSeqStmt::CaseStmtAlternative::emit(ostream&out, Entity*ent, ScopeBase*sc
 {
       int errors = 0;
 
+      bool first = true;
       if (exp_) {
-	    errors += exp_->emit(out, ent, scope);
-	    out << ":" << endl;
+            for (list<Expression*>::iterator it = exp_->begin(); it != exp_->end(); ++it) {
+		  if(first)
+		    first = false;
+		  else
+		    out << ",";
+		  errors += (*it)->emit(out, ent, scope);
+            }
       } else {
-	    out << "default:" << endl;
+		  out << "default";
       }
+      out << ":" << endl;
 
       SequentialStmt*curp;
 
@@ -306,7 +313,15 @@ void CaseSeqStmt::CaseStmtAlternative::write_to_stream(ostream&fd)
 {
       fd << "when ";
       if (exp_) {
-	    exp_->write_to_stream(fd);
+          bool first = true;
+	  for (list<Expression*>::iterator it = exp_->begin(); it != exp_->end(); ++it) {
+              if(first)
+                  first = false;
+              else
+                  fd << "|";
+
+              (*it)->write_to_stream(fd);
+	  }
       } else {
 	  fd << "others" << endl;
       }

--- a/vhdlpp/subprogram.cc
+++ b/vhdlpp/subprogram.cc
@@ -107,7 +107,7 @@ void Subprogram::fix_variables() {
         // SystemVerilog does not handle variables that have length dependendent
         // on other variables. We have to convert it to a dynamic array and
         // construct it.
-        if(type->is_variable_length()) {
+        if(type->is_variable_length(this)) {
             const VTypeArray*arr = dynamic_cast<const VTypeArray*>(type);
 
             // Currently we handle only one dimensional variables

--- a/vhdlpp/subprogram.cc
+++ b/vhdlpp/subprogram.cc
@@ -97,20 +97,19 @@ void Subprogram::fix_port_types()
       }
 }
 
+VTypeArray*Subprogram::fix_logic_darray(const VTypeArray*type)
+{
+    Expression*zero = new ExpInteger(0);
+    std::vector<VTypeArray::range_t> sub_range;
+    sub_range.push_back(VTypeArray::range_t(zero, zero));
+    return new VTypeArray(type, sub_range);
+}
+
 bool Subprogram::check_unb_vector(const VType*&type)
 {
     if(const VTypeArray*arr = dynamic_cast<const VTypeArray*>(type)) {
         if(arr->dimensions() == 1 && arr->dimension(0).is_box() ) {
-            // For the time being, dynamic arrays work exclusively with vectors.
-            // To emulate simple 'logic'/'bit' type, we need to create a vector
-            // of width == 1, to be used as the array element type.
-            // Effectively 'logic name []' becomes 'logic [0:0] name []'.
-            Expression*zero = new ExpInteger(0);
-            std::vector<VTypeArray::range_t> sub_range;
-            sub_range.push_back(VTypeArray::range_t(zero, zero));
-            VTypeArray*new_arr = new VTypeArray(arr, sub_range);
-            type = get_global_typedef(new_arr);
-
+            type = get_global_typedef(fix_logic_darray(arr));
             return true;
         }
     }

--- a/vhdlpp/subprogram.cc
+++ b/vhdlpp/subprogram.cc
@@ -268,8 +268,14 @@ bool Subprogram::fixed_return_type(void)
         (*s)->visit(r);
     }
 
-    const VType*return_type = r.get_type();
+    VType*return_type = const_cast<VType*>(r.get_type());
     if(return_type && !return_type->is_unbounded()) {
+        // Let's check if the variable length can be evaluated without any scope.
+        // If not, then it is depends on information about e.g. function params
+        if(return_type->is_variable_length(NULL)) {
+            if(VTypeArray*arr = dynamic_cast<VTypeArray*>(return_type))
+                arr->evaluate_ranges(this);
+        }
         return_type_ = return_type;
         return true;
     } else {

--- a/vhdlpp/subprogram.cc
+++ b/vhdlpp/subprogram.cc
@@ -308,3 +308,39 @@ void Subprogram::write_to_stream(ostream&fd) const
       return_type_->write_to_stream(fd);
       fd << ";" << endl;
 }
+
+void Subprogram::write_to_stream_body(ostream&fd) const
+{
+      fd << "function " << name_ << "(";
+      if (ports_ && ! ports_->empty()) {
+	    list<InterfacePort*>::const_iterator cur = ports_->begin();
+	    InterfacePort*curp = *cur;
+	    fd << curp->name << " : ";
+	    curp->type->write_to_stream(fd);
+	    for (++cur ; cur != ports_->end() ; ++cur) {
+		  curp = *cur;
+		  fd << "; " << curp->name << " : ";
+		  curp->type->write_to_stream(fd);
+	    }
+      }
+      fd << ") return ";
+      return_type_->write_to_stream(fd);
+      fd << " is" << endl;
+
+      for (map<perm_string,Variable*>::const_iterator cur = new_variables_.begin()
+         ; cur != new_variables_.end() ; ++cur) {
+            cur->second->write_to_stream(fd);
+      }
+
+      fd << "begin" << endl;
+
+      if (statements_) {
+            for (list<SequentialStmt*>::const_iterator cur = statements_->begin()
+                       ; cur != statements_->end() ; ++cur) {
+                  (*cur)->write_to_stream(fd);
+            }
+      } else {
+	    fd << "--empty body" << endl;
+      }
+	    fd << "end function;" << endl;
+}

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -61,6 +61,7 @@ class Subprogram : public LineInfo, public ScopeBase {
       int emit_package(std::ostream&fd) const;
 
       void write_to_stream(std::ostream&fd) const;
+      void write_to_stream_body(std::ostream&fd) const;
       void dump(std::ostream&fd) const;
 
 	// Creates a new instance of the function that takes arguments of

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -70,34 +70,14 @@ class Subprogram : public LineInfo, public ScopeBase {
 	// for limited length logic vector.
       Subprogram*make_instance(std::vector<Expression*> arguments, ScopeBase*scope);
 
+	// Checks if either return type or parameters are unbounded vectors.
+      bool unbounded() const;
+
     private:
 	// Tries to set the return type to a fixed type. VHDL functions that
 	// return std_logic_vectors do not specify its length, as SystemVerilog
 	// demands.
-	// The function goes through the function body looking for return
-	// statments and probes the returned type. If it is the same for every
-	// statemnt then we can assume that the function returns vector of a
-	// fixed size.
-      bool fixed_return_type();
-
-	// Iterates through the list of function ports to fix all quirks related
-	// to translation between VHDL and SystemVerilog.
-      void fix_port_types();
-
-	// SystemVerilog does not allow to have signals/variables which size is
-	// evaluated at runtime. This function finds such variables and modifies
-	// their type to dynamic array and adds appropriate 'new' statement in
-	// the program body.
-      void fix_variables();
-
-	// For the time being, dynamic arrays work exclusively with vectors.
-	// To emulate dynamic array of 'logic'/'bit' type, we need to create a vector
-	// of width == 1, to be used as the array element type.
-	// Effectively 'logic name []' becomes 'logic [0:0] name []'.
-      VTypeArray*fix_logic_darray(const VTypeArray*type);
-
-	// Creates a typedef for an unbounded vector and updates the given type.
-      bool check_unb_vector(const VType*&type);
+      void fix_return_type();
 
       perm_string name_;
       const ScopeBase*parent_;

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -63,13 +63,17 @@ class Subprogram : public LineInfo, public ScopeBase {
       void dump(std::ostream&fd) const;
 
     private:
-	// Determines appropriate return type, basing on the *first* return
-	// statement found in the function body. In case of std_logic_vector
-	// VHDL requires skipping its size, contrary to Verilog.
-      void fix_return_type(void);
+	// Tries to set the return type to a fixed type. VHDL functions that
+	// return std_logic_vectors do not specify its length, as SystemVerilog
+	// demands.
+	// The function goes through the function body looking for return
+	// statments and probes the returned type. If it is the same for every
+	// statemnt then we can assume that the function returns vector of a
+	// fixed size.
+      bool fixed_return_type();
 
 	// Iterates through the list of function ports to fix all quirks related
-        // to translation between VHDL and SystemVerilog.
+	// to translation between VHDL and SystemVerilog.
       void fix_port_types();
 
 	// Creates a typedef for an unbounded vector and updates the given type.

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -76,6 +76,12 @@ class Subprogram : public LineInfo, public ScopeBase {
 	// to translation between VHDL and SystemVerilog.
       void fix_port_types();
 
+	// SystemVerilog does not allow to have signals/variables which size is
+	// evaluated at runtime. This function finds such variables and modifies
+	// their type to dynamic array and adds appropriate 'new' statement in
+	// the program body.
+      void fix_variables();
+
 	// For the time being, dynamic arrays work exclusively with vectors.
 	// To emulate dynamic array of 'logic'/'bit' type, we need to create a vector
 	// of width == 1, to be used as the array element type.

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -45,6 +45,7 @@ class Subprogram : public LineInfo, public ScopeBase {
       inline const perm_string&name() const { return name_; }
 
       void set_program_body(std::list<SequentialStmt*>*statements);
+      inline bool empty_program_body() const { return !statements_ || statements_->empty(); }
 
 	// Return true if the specification (name, types, ports)
 	// matches this subprogram and that subprogram.
@@ -61,6 +62,12 @@ class Subprogram : public LineInfo, public ScopeBase {
 
       void write_to_stream(std::ostream&fd) const;
       void dump(std::ostream&fd) const;
+
+	// Creates a new instance of the function that takes arguments of
+	// a different type. It is used to allow VHDL functions that work with
+	// unbounded std_logic_vectors, so there can be a separate instance
+	// for limited length logic vector.
+      Subprogram*make_instance(std::vector<Expression*> arguments, ScopeBase*scope);
 
     private:
 	// Tries to set the return type to a fixed type. VHDL functions that

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -76,6 +76,12 @@ class Subprogram : public LineInfo, public ScopeBase {
 	// to translation between VHDL and SystemVerilog.
       void fix_port_types();
 
+	// For the time being, dynamic arrays work exclusively with vectors.
+	// To emulate dynamic array of 'logic'/'bit' type, we need to create a vector
+	// of width == 1, to be used as the array element type.
+	// Effectively 'logic name []' becomes 'logic [0:0] name []'.
+      VTypeArray*fix_logic_darray(const VTypeArray*type);
+
 	// Creates a typedef for an unbounded vector and updates the given type.
       bool check_unb_vector(const VType*&type);
 

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -54,7 +54,7 @@ class Subprogram : public LineInfo, public ScopeBase {
       const VType*peek_param_type(int idx) const;
       const VType*peek_return_type() const { return return_type_; }
 
-      int emit(ostream&out, Entity*ent, Architecture*arc);
+      int emit(ostream&out, Entity*ent, ScopeBase*scope);
 
 	// Emit a definition as it would show up in a package.
       int emit_package(std::ostream&fd) const;

--- a/vhdlpp/subprogram.h
+++ b/vhdlpp/subprogram.h
@@ -3,6 +3,8 @@
 /*
  * Copyright (c) 2013-2014 Stephen Williams (steve@icarus.com)
  * Copyright CERN 2013 / Stephen Williams (steve@icarus.com)
+ * Copyright CERN 2015
+ * @author Maciej Suminski (maciej.suminski@cern.ch)
  *
  *    This source code is free software; you can redistribute it
  *    and/or modify it in source code form under the terms of the GNU
@@ -50,6 +52,7 @@ class Subprogram : public LineInfo, public ScopeBase {
 
       const InterfacePort*find_param(perm_string nam) const;
       const VType*peek_param_type(int idx) const;
+      const VType*peek_return_type() const { return return_type_; }
 
       int emit(ostream&out, Entity*ent, Architecture*arc);
 
@@ -60,9 +63,17 @@ class Subprogram : public LineInfo, public ScopeBase {
       void dump(std::ostream&fd) const;
 
     private:
-	// Determines appropriate return type. Un case of std_logic_vector
-	// VHDL requires skipping its size in contrary to Verilog
+	// Determines appropriate return type, basing on the *first* return
+	// statement found in the function body. In case of std_logic_vector
+	// VHDL requires skipping its size, contrary to Verilog.
       void fix_return_type(void);
+
+	// Iterates through the list of function ports to fix all quirks related
+        // to translation between VHDL and SystemVerilog.
+      void fix_port_types();
+
+	// Creates a typedef for an unbounded vector and updates the given type.
+      bool check_unb_vector(const VType*&type);
 
       perm_string name_;
       const ScopeBase*parent_;

--- a/vhdlpp/subprogram_emit.cc
+++ b/vhdlpp/subprogram_emit.cc
@@ -70,7 +70,7 @@ int Subprogram::emit_package(ostream&fd) const
       if (statements_) {
 	    for (list<SequentialStmt*>::const_iterator cur = statements_->begin()
 		       ; cur != statements_->end() ; ++cur) {
-		  errors += (*cur)->emit(fd, NULL, NULL);
+		  errors += (*cur)->emit(fd, NULL, const_cast<Subprogram*>(this));
 	    }
       } else {
 	    fd << " begin /* empty body */ end" << endl;

--- a/vhdlpp/vsignal.cc
+++ b/vhdlpp/vsignal.cc
@@ -77,3 +77,10 @@ int Variable::emit(ostream&out, Entity*, ScopeBase*)
       out << ";" << endl;
       return errors;
 }
+
+void Variable::write_to_stream(std::ostream&fd)
+{
+      fd << "variable " << peek_name() << " : ";
+      peek_type()->write_to_stream(fd);
+      fd << ";" << endl;
+}

--- a/vhdlpp/vsignal.cc
+++ b/vhdlpp/vsignal.cc
@@ -54,7 +54,7 @@ int Signal::emit(ostream&out, Entity*ent, Architecture*arc)
       type_elaborate_(decl);
       if (peek_refcnt_sequ_() > 0 || !peek_type()->can_be_packed())
 	    decl.reg_flag = true;
-      errors += decl.emit(out, peek_name_());
+      errors += decl.emit(out, peek_name());
 
       Expression*init_expr = peek_init_expr();
       if (init_expr) {
@@ -73,7 +73,7 @@ int Variable::emit(ostream&out, Entity*, Architecture*)
       type_elaborate_(decl);
       if (peek_refcnt_sequ_() > 0 || !peek_type()->can_be_packed())
 	    decl.reg_flag = true;
-      errors += decl.emit(out, peek_name_());
+      errors += decl.emit(out, peek_name());
       out << ";" << endl;
       return errors;
 }

--- a/vhdlpp/vsignal.cc
+++ b/vhdlpp/vsignal.cc
@@ -34,10 +34,10 @@ SigVarBase::~SigVarBase()
 {
 }
 
-void SigVarBase::elaborate_init_expr(Entity*ent, Architecture*arc)
+void SigVarBase::elaborate_init_expr(Entity*ent, ScopeBase*scope)
 {
     if(init_expr_) {
-        init_expr_->elaborate_expr(ent, arc, peek_type());
+        init_expr_->elaborate_expr(ent, scope, peek_type());
     }
 }
 
@@ -46,7 +46,7 @@ void SigVarBase::type_elaborate_(VType::decl_t&decl)
       decl.type = type_;
 }
 
-int Signal::emit(ostream&out, Entity*ent, Architecture*arc)
+int Signal::emit(ostream&out, Entity*ent, ScopeBase*scope)
 {
       int errors = 0;
 
@@ -59,13 +59,13 @@ int Signal::emit(ostream&out, Entity*ent, Architecture*arc)
       Expression*init_expr = peek_init_expr();
       if (init_expr) {
 	    out << " = ";
-	    init_expr->emit(out, ent, arc);
+	    init_expr->emit(out, ent, scope);
       }
       out << ";" << endl;
       return errors;
 }
 
-int Variable::emit(ostream&out, Entity*, Architecture*)
+int Variable::emit(ostream&out, Entity*, ScopeBase*)
 {
       int errors = 0;
 

--- a/vhdlpp/vsignal.h
+++ b/vhdlpp/vsignal.h
@@ -24,6 +24,7 @@
 # include  "vtype.h"
 
 class Architecture;
+class ScopeBase;
 class Entity;
 class Expression;
 
@@ -42,7 +43,7 @@ class SigVarBase : public LineInfo {
       void dump(ostream&out, int indent = 0) const;
 
 	// Elaborates initializer expressions if needed.
-      void elaborate_init_expr(Entity*ent, Architecture*arc);
+      void elaborate_init_expr(Entity*ent, ScopeBase*scope);
 
       perm_string peek_name() const { return name_; }
 
@@ -70,7 +71,7 @@ class Signal : public SigVarBase {
     public:
       Signal(perm_string name, const VType*type, Expression*init_expr);
 
-      int emit(ostream&out, Entity*ent, Architecture*arc);
+      int emit(ostream&out, Entity*ent, ScopeBase*scope);
 };
 
 class Variable : public SigVarBase {
@@ -78,7 +79,7 @@ class Variable : public SigVarBase {
     public:
       Variable(perm_string name, const VType*type);
 
-      int emit(ostream&out, Entity*ent, Architecture*arc);
+      int emit(ostream&out, Entity*ent, ScopeBase*scope);
 };
 
 inline void SigVarBase::count_ref_sequ()

--- a/vhdlpp/vsignal.h
+++ b/vhdlpp/vsignal.h
@@ -44,8 +44,9 @@ class SigVarBase : public LineInfo {
 	// Elaborates initializer expressions if needed.
       void elaborate_init_expr(Entity*ent, Architecture*arc);
 
+      perm_string peek_name() const { return name_; }
+
     protected:
-      perm_string peek_name_() const { return name_; }
       unsigned peek_refcnt_sequ_() const { return refcnt_sequ_; }
 
       void type_elaborate_(VType::decl_t&decl);

--- a/vhdlpp/vsignal.h
+++ b/vhdlpp/vsignal.h
@@ -80,6 +80,7 @@ class Variable : public SigVarBase {
       Variable(perm_string name, const VType*type);
 
       int emit(ostream&out, Entity*ent, ScopeBase*scope);
+      void write_to_stream(std::ostream&fd);
 };
 
 inline void SigVarBase::count_ref_sequ()

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -67,11 +67,14 @@ void VTypePrimitive::show(ostream&out) const
 	  case INTEGER:
 	    out << "INTEGER";
 	    break;
+	  case NATURAL:
+	    out << "NATURAL";
+	    break;
 	  case REAL:
 	    out << "REAL";
 	    break;
 	  case STDLOGIC:
-	    out << "std_logic";
+	    out << "STD_LOGIC";
 	    break;
       }
 }

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -148,6 +148,17 @@ void VTypeArray::show(ostream&out) const
 	    out << "<nil>";
 }
 
+bool VTypeArray::is_unbounded() const {
+    for(std::vector<range_t>::const_iterator it = ranges_.begin();
+            it != ranges_.end(); ++it)
+    {
+        if(it->is_box())
+            return true;
+    }
+
+    return etype_->is_unbounded();
+}
+
 VTypeRange::VTypeRange(const VType*base, int64_t max_val, int64_t min_val)
 : base_(base)
 {

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -26,7 +26,6 @@
 
 using namespace std;
 
-
 VType::~VType()
 {
 }
@@ -76,6 +75,11 @@ void VTypePrimitive::show(ostream&out) const
       }
 }
 
+VTypeArray::range_t*VTypeArray::range_t::clone() const
+{
+    return new VTypeArray::range_t(safe_clone(msb_), safe_clone(lsb_), direction_);
+}
+
 VTypeArray::VTypeArray(const VType*element, const vector<VTypeArray::range_t>&r, bool sv)
 : etype_(element), ranges_(r), signed_flag_(sv), parent_(NULL)
 {
@@ -104,6 +108,18 @@ VTypeArray::VTypeArray(const VType*element, std::list<prange_t*>*r, bool sv)
 
 VTypeArray::~VTypeArray()
 {
+}
+
+VType*VTypeArray::clone() const {
+    std::vector<range_t> new_ranges;
+    new_ranges.reserve(ranges_.size());
+    for(std::vector<range_t>::const_iterator it = ranges_.begin();
+            it != ranges_.end(); ++it) {
+        new_ranges.push_back(*(it->clone()));
+    }
+    VTypeArray*a = new VTypeArray(etype_->clone(), new_ranges, signed_flag_);
+    a->set_parent_type(parent_);
+    return a;
 }
 
 const VType* VTypeArray::basic_type(bool typedef_allowed) const

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -167,20 +167,23 @@ bool VTypeArray::is_unbounded() const {
     return etype_->is_unbounded();
 }
 
-bool VTypeArray::is_variable_length() const {
+bool VTypeArray::is_variable_length(ScopeBase*scope) const {
     int64_t dummy;
+
+    if(is_unbounded())
+        return true;
 
     for(std::vector<range_t>::const_iterator it = ranges_.begin();
             it != ranges_.end(); ++it)
     {
-        if(!it->lsb()->evaluate(NULL, dummy))
+        if(!it->lsb()->evaluate(scope, dummy))
             return true;
 
-        if(!it->msb()->evaluate(NULL, dummy))
+        if(!it->msb()->evaluate(scope, dummy))
             return true;
     }
 
-    return etype_->is_variable_length();
+    return etype_->is_variable_length(scope);
 }
 
 VTypeRange::VTypeRange(const VType*base, int64_t max_val, int64_t min_val)

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -186,6 +186,19 @@ bool VTypeArray::is_variable_length(ScopeBase*scope) const {
     return etype_->is_variable_length(scope);
 }
 
+void VTypeArray::evaluate_ranges(ScopeBase*scope) {
+    for(std::vector<range_t>::iterator it = ranges_.begin(); it != ranges_.end(); ++it ) {
+        int64_t lsb_val = -1, msb_val = -1;
+        bool dir = it->is_downto();
+
+        if(it->msb()->evaluate(scope, msb_val) && it->lsb()->evaluate(scope, lsb_val)) {
+            assert(lsb_val >= 0);
+            assert(msb_val >= 0);
+            *it = range_t(new ExpInteger(msb_val), new ExpInteger(lsb_val), dir);
+        }
+    }
+}
+
 VTypeRange::VTypeRange(const VType*base, int64_t max_val, int64_t min_val)
 : base_(base)
 {

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -23,6 +23,7 @@
 # include  <map>
 # include  <typeinfo>
 # include  <cassert>
+# include  <algorithm>
 
 using namespace std;
 
@@ -249,6 +250,11 @@ void VTypeEnum::show(ostream&out) const
       for (size_t idx = 1 ; idx < names_.size() ; idx += 1)
 	    out << ", " << names_[idx];
       out << ")";
+}
+
+bool VTypeEnum::has_name(perm_string name) const
+{
+      return std::find(names_.begin(), names_.end(), name) != names_.end();
 }
 
 VTypeRecord::VTypeRecord(std::list<element_t*>*elements)

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -19,6 +19,7 @@
 
 # include  "vtype.h"
 # include  "parse_types.h"
+# include  "compiler.h"
 # include  <map>
 # include  <typeinfo>
 # include  <cassert>
@@ -33,6 +34,13 @@ VType::~VType()
 void VType::show(ostream&out) const
 {
       write_to_stream(out);
+}
+
+perm_string VType::get_generic_typename() const
+{
+    char buf[16] = {0,};
+    snprintf(buf, 16, "type_%p", this);
+    return lex_strings.make(buf);
 }
 
 VTypePrimitive::VTypePrimitive(VTypePrimitive::type_t tt, bool packed)

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -77,7 +77,7 @@ void VTypePrimitive::show(ostream&out) const
 }
 
 VTypeArray::VTypeArray(const VType*element, const vector<VTypeArray::range_t>&r, bool sv)
-: etype_(element), ranges_(r), signed_flag_(sv)
+: etype_(element), ranges_(r), signed_flag_(sv), parent_(NULL)
 {
 }
 
@@ -89,7 +89,7 @@ VTypeArray::VTypeArray(const VType*element, const vector<VTypeArray::range_t>&r,
  * this is a memory leak. Something to fix.
  */
 VTypeArray::VTypeArray(const VType*element, std::list<prange_t*>*r, bool sv)
-: etype_(element), ranges_(r->size()), signed_flag_(sv)
+: etype_(element), ranges_(r->size()), signed_flag_(sv), parent_(NULL)
 {
       for (size_t idx = 0 ; idx < ranges_.size() ; idx += 1) {
 	    prange_t*curp = r->front();

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -167,6 +167,22 @@ bool VTypeArray::is_unbounded() const {
     return etype_->is_unbounded();
 }
 
+bool VTypeArray::is_variable_length() const {
+    int64_t dummy;
+
+    for(std::vector<range_t>::const_iterator it = ranges_.begin();
+            it != ranges_.end(); ++it)
+    {
+        if(!it->lsb()->evaluate(NULL, dummy))
+            return true;
+
+        if(!it->msb()->evaluate(NULL, dummy))
+            return true;
+    }
+
+    return etype_->is_variable_length();
+}
+
 VTypeRange::VTypeRange(const VType*base, int64_t max_val, int64_t min_val)
 : base_(base)
 {

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -215,11 +215,12 @@ class VTypeArray : public VType {
 
       int emit_def(std::ostream&out, perm_string name) const;
       int emit_typedef(std::ostream&out, typedef_context_t&ctx) const;
-      int emit_dimensions(std::ostream&out) const;
 
       bool can_be_packed() const { return etype_->can_be_packed(); }
 
     private:
+      int emit_with_dims_(std::ostream&out, bool packed, perm_string name) const;
+
       void write_range_to_stream_(std::ostream&fd) const;
       const VType*etype_;
 

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -30,6 +30,7 @@
 # include  "StringHeap.h"
 
 class Architecture;
+class ScopeBase;
 class Entity;
 class Expression;
 class prange_t;
@@ -52,7 +53,7 @@ class VType {
 
 	// This is rarely used, but some types may have expressions
 	// that need to be elaborated.
-      virtual int elaborate(Entity*end, Architecture*arc) const;
+      virtual int elaborate(Entity*end, ScopeBase*scope) const;
 
 	// This virtual method returns true if that is equivalent to
 	// this type. This method is used for example to compare
@@ -205,7 +206,7 @@ class VTypeArray : public VType {
       VTypeArray(const VType*etype, std::list<prange_t*>*r, bool signed_vector =false);
       ~VTypeArray();
 
-      int elaborate(Entity*ent, Architecture*arc) const;
+      int elaborate(Entity*ent, ScopeBase*scope) const;
       void write_to_stream(std::ostream&fd) const;
       void write_type_to_stream(std::ostream&fd) const;
       void show(std::ostream&) const;

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -85,6 +85,9 @@ class VType {
 	// Determines if a type can be used in Verilog packed array.
       virtual bool can_be_packed() const { return false; }
 
+	// Returns true if the type has an undefined dimension.
+      virtual bool is_unbounded() const { return false; }
+
     private:
       friend struct decl_t;
 	// This virtual method is called to emit the declaration. This
@@ -218,6 +221,8 @@ class VTypeArray : public VType {
 
       bool can_be_packed() const { return etype_->can_be_packed(); }
 
+      bool is_unbounded() const;
+
     private:
       int emit_with_dims_(std::ostream&out, bool packed, perm_string name) const;
 
@@ -320,6 +325,8 @@ class VTypeDef : public VType {
       int emit_def(std::ostream&out, perm_string name) const;
 
       bool can_be_packed() const { return type_->can_be_packed(); }
+
+      bool is_unbounded() const { return type_->is_unbounded(); }
     private:
       int emit_decl(std::ostream&out, perm_string name, bool reg_flag) const;
 

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -295,6 +295,9 @@ class VTypeEnum : public VType {
       void show(std::ostream&) const;
       int emit_def(std::ostream&out, perm_string name) const;
 
+	// Checks if the name is stored in the enum.
+      bool has_name(perm_string name) const;
+
     private:
       std::vector<perm_string>names_;
 };

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -88,6 +88,10 @@ class VType {
 	// Returns true if the type has an undefined dimension.
       virtual bool is_unbounded() const { return false; }
 
+	// Checks if the variable length is dependent on other expressions, that
+	// cannot be evaluated (e.g. 'length, 'left, 'right).
+      virtual bool is_variable_length() const { return false; }
+
 	// Returns a perm_string that can be used in automatically created
 	// typedefs (i.e. not ones defined by the user).
       perm_string get_generic_typename() const;
@@ -226,6 +230,8 @@ class VTypeArray : public VType {
       bool can_be_packed() const { return etype_->can_be_packed(); }
 
       bool is_unbounded() const;
+
+      bool is_variable_length() const;
 
 	// To handle subtypes
       inline void set_parent_type(const VTypeArray*parent) { parent_ = parent; }

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -212,7 +212,7 @@ class VTypeArray : public VType {
       inline bool signed_vector() const { return signed_flag_; }
 
 	// returns the type of element held in the array
-      inline const VType* element_type() const { return etype_; }
+      inline const VType* element_type() const { return parent_ ? parent_->element_type() : etype_; }
 
 	// returns the basic type of element held in the array
 	// (unfolds typedefs and multidimensional arrays)
@@ -227,6 +227,9 @@ class VTypeArray : public VType {
 
       bool is_unbounded() const;
 
+	// To handle subtypes
+      inline void set_parent_type(const VTypeArray*parent) { parent_ = parent; }
+
     private:
       int emit_with_dims_(std::ostream&out, bool packed, perm_string name) const;
 
@@ -235,6 +238,7 @@ class VTypeArray : public VType {
 
       std::vector<range_t> ranges_;
       bool signed_flag_;
+      const VTypeArray*parent_;
 };
 
 class VTypeRange : public VType {

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -238,6 +238,10 @@ class VTypeArray : public VType {
 	// To handle subtypes
       inline void set_parent_type(const VTypeArray*parent) { parent_ = parent; }
 
+	// Wherever it is possible, replaces range lsb & msb expressions with
+	// constant integers.
+      void evaluate_ranges(ScopeBase*scope);
+
     private:
       int emit_with_dims_(std::ostream&out, bool packed, perm_string name) const;
 

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -51,6 +51,8 @@ class VType {
       VType() { }
       virtual ~VType() =0;
 
+      virtual VType*clone() const =0;
+
 	// This is rarely used, but some types may have expressions
 	// that need to be elaborated.
       virtual int elaborate(Entity*end, ScopeBase*scope) const;
@@ -136,6 +138,8 @@ extern void preload_global_types(void);
  * This type is a placeholder for ERROR types.
  */
 class VTypeERROR : public VType {
+    VType*clone() const { return NULL; }
+
     public:
       int emit_def(std::ostream&out, perm_string name) const;
 };
@@ -152,6 +156,8 @@ class VTypePrimitive : public VType {
     public:
       VTypePrimitive(type_t tt, bool packed = false);
       ~VTypePrimitive();
+
+      VType*clone() const { return new VTypePrimitive(*this); }
 
       void write_to_stream(std::ostream&fd) const;
       void show(std::ostream&) const;
@@ -189,6 +195,8 @@ class VTypeArray : public VType {
 	    range_t(Expression*m = NULL, Expression*l = NULL, bool dir = true) :
                 msb_(m), lsb_(l), direction_(dir) { }
 
+	    range_t*clone() const;
+
 	    inline bool is_box() const { return msb_==0 && lsb_==0; }
 	    inline bool is_downto() const { return direction_; }
 
@@ -205,6 +213,8 @@ class VTypeArray : public VType {
       VTypeArray(const VType*etype, const std::vector<range_t>&r, bool signed_vector =false);
       VTypeArray(const VType*etype, std::list<prange_t*>*r, bool signed_vector =false);
       ~VTypeArray();
+
+      VType*clone() const;
 
       int elaborate(Entity*ent, ScopeBase*scope) const;
       void write_to_stream(std::ostream&fd) const;
@@ -246,8 +256,8 @@ class VTypeArray : public VType {
       int emit_with_dims_(std::ostream&out, bool packed, perm_string name) const;
 
       void write_range_to_stream_(std::ostream&fd) const;
-      const VType*etype_;
 
+      const VType*etype_;
       std::vector<range_t> ranges_;
       bool signed_flag_;
       const VTypeArray*parent_;
@@ -258,6 +268,8 @@ class VTypeRange : public VType {
     public:
       VTypeRange(const VType*base, int64_t max_val, int64_t min_val);
       ~VTypeRange();
+
+      VType*clone() const { return new VTypeRange(base_->clone(), max_, min_); }
 
 	// Get the type that is limited by the range.
       inline const VType* base_type() const { return base_; }
@@ -276,6 +288,8 @@ class VTypeEnum : public VType {
     public:
       VTypeEnum(const std::list<perm_string>*names);
       ~VTypeEnum();
+
+      VType*clone() const { return new VTypeEnum(*this); }
 
       void write_to_stream(std::ostream&fd) const;
       void show(std::ostream&) const;
@@ -310,6 +324,8 @@ class VTypeRecord : public VType {
       explicit VTypeRecord(std::list<element_t*>*elements);
       ~VTypeRecord();
 
+      VType*clone() const { return new VTypeRecord(*this); }
+
       void write_to_stream(std::ostream&fd) const;
       void show(std::ostream&) const;
       int emit_def(std::ostream&out, perm_string name) const;
@@ -327,6 +343,8 @@ class VTypeDef : public VType {
       explicit VTypeDef(perm_string name);
       explicit VTypeDef(perm_string name, const VType*is);
       ~VTypeDef();
+
+      VType*clone() const { return new VTypeDef(*this); }
 
       inline perm_string peek_name() const { return name_; }
 

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -34,6 +34,7 @@ class Entity;
 class Expression;
 class prange_t;
 class VTypeDef;
+class ScopeBase;
 
 typedef enum typedef_topo_e { NONE=0, PENDING, MARKED } typedef_topo_t;
 typedef std::map<const VTypeDef*, typedef_topo_t> typedef_context_t;
@@ -90,7 +91,7 @@ class VType {
 
 	// Checks if the variable length is dependent on other expressions, that
 	// cannot be evaluated (e.g. 'length, 'left, 'right).
-      virtual bool is_variable_length() const { return false; }
+      virtual bool is_variable_length(ScopeBase*) const { return false; }
 
 	// Returns a perm_string that can be used in automatically created
 	// typedefs (i.e. not ones defined by the user).
@@ -231,7 +232,7 @@ class VTypeArray : public VType {
 
       bool is_unbounded() const;
 
-      bool is_variable_length() const;
+      bool is_variable_length(ScopeBase*scope) const;
 
 	// To handle subtypes
       inline void set_parent_type(const VTypeArray*parent) { parent_ = parent; }

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -151,7 +151,7 @@ class VTypeERROR : public VType {
 class VTypePrimitive : public VType {
 
     public:
-      enum type_t { BOOLEAN, BIT, INTEGER, REAL, STDLOGIC, CHARACTER };
+      enum type_t { BOOLEAN, BIT, INTEGER, NATURAL, REAL, STDLOGIC, CHARACTER };
 
     public:
       VTypePrimitive(type_t tt, bool packed = false);
@@ -177,6 +177,7 @@ class VTypePrimitive : public VType {
 extern const VTypePrimitive primitive_BOOLEAN;
 extern const VTypePrimitive primitive_BIT;
 extern const VTypePrimitive primitive_INTEGER;
+extern const VTypePrimitive primitive_NATURAL;
 extern const VTypePrimitive primitive_REAL;
 extern const VTypePrimitive primitive_STDLOGIC;
 extern const VTypePrimitive primitive_CHARACTER;

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -88,6 +88,10 @@ class VType {
 	// Returns true if the type has an undefined dimension.
       virtual bool is_unbounded() const { return false; }
 
+	// Returns a perm_string that can be used in automatically created
+	// typedefs (i.e. not ones defined by the user).
+      perm_string get_generic_typename() const;
+
     private:
       friend struct decl_t;
 	// This virtual method is called to emit the declaration. This

--- a/vhdlpp/vtype_elaborate.cc
+++ b/vhdlpp/vtype_elaborate.cc
@@ -21,24 +21,24 @@
 # include  "vtype.h"
 # include  "expression.h"
 
-int VType::elaborate(Entity*, Architecture*) const
+int VType::elaborate(Entity*, ScopeBase*) const
 {
       return 0;
 }
 
-int VTypeArray::elaborate(Entity*ent, Architecture*arc) const
+int VTypeArray::elaborate(Entity*ent, ScopeBase*scope) const
 {
       int errors = 0;
-      etype_->elaborate(ent, arc);
+      etype_->elaborate(ent, scope);
 
       for (vector<range_t>::const_iterator cur = ranges_.begin()
 		 ; cur != ranges_.end() ; ++ cur) {
 
 	    Expression*tmp = cur->msb();
-	    if (tmp) errors += tmp->elaborate_expr(ent, arc, 0);
+	    if (tmp) errors += tmp->elaborate_expr(ent, scope, 0);
 
 	    tmp = cur->lsb();
-	    if (tmp) errors += tmp->elaborate_expr(ent, arc, 0);
+	    if (tmp) errors += tmp->elaborate_expr(ent, scope, 0);
       }
 
       return errors;

--- a/vhdlpp/vtype_emit.cc
+++ b/vhdlpp/vtype_emit.cc
@@ -154,6 +154,9 @@ int VTypePrimitive::emit_primitive_type(ostream&out) const
 	  case STDLOGIC:
 	    out << "logic";
 	    break;
+	  case NATURAL:
+	    out << "int unsigned";
+	    break;
 	  case INTEGER:
 	    out << "int";
 	    break;

--- a/vhdlpp/vtype_emit.cc
+++ b/vhdlpp/vtype_emit.cc
@@ -209,10 +209,11 @@ int VTypeRecord::emit_def(ostream&out, perm_string name) const
  * type. (We are defining a variable here, not the type itself.) The
  * emit_typedef() method was presumably called to define type already.
  */
-int VTypeDef::emit_def(ostream&out, perm_string) const
+int VTypeDef::emit_def(ostream&out, perm_string name) const
 {
       int errors = 0;
       emit_name(out, name_);
+      emit_name(out, name);
       return errors;
 }
 

--- a/vhdlpp/vtype_stream.cc
+++ b/vhdlpp/vtype_stream.cc
@@ -140,6 +140,9 @@ void VTypePrimitive::write_to_stream(ostream&fd) const
 	  case INTEGER:
 	    fd << "integer";
 	    break;
+	  case NATURAL:
+	    fd << "natural";
+	    break;
 	  case REAL:
 	    fd << "real";
 	    break;

--- a/vpi/sys_darray.c
+++ b/vpi/sys_darray.c
@@ -143,6 +143,7 @@ static PLI_INT32 to_from_vec_compiletf(ICARUS_VPI_CONST PLI_BYTE8*name)
 	case vpiReg:
 	case vpiBitVar:
 	case vpiIntegerVar:
+	case vpiConstant:
 	    break;
 	default:
 	    vpi_printf("ERROR: %s:%d: ", vpi_get_str(vpiFile, callh),


### PR DESCRIPTION
- enum can be used as a port type in modules (SystemVerilog)
- shift operators (SRL/SLL/SRA/SLA) (VHDL)
- labeled assignments (VHDL)
- fixed accessing words in constant arrays of vectors (VHDL)
- 'natural' type translated as 'int unsigned' (VHDL)
- a bunch of minor fixes