### PR TITLE
Make a few constructors explicit.

### DIFF
--- a/PScope.h
+++ b/PScope.h
@@ -146,7 +146,7 @@ class PScope : public LexicalScope {
 	// modules. Scopes for tasks and functions point to their
 	// containing module.
       PScope(perm_string name, LexicalScope*parent);
-      PScope(perm_string name);
+      explicit PScope(perm_string name);
       virtual ~PScope();
 
       perm_string pscope_name() const { return name_; }
@@ -169,7 +169,7 @@ class PScopeExtra : public PScope {
 
     public:
       PScopeExtra(perm_string, LexicalScope*parent);
-      PScopeExtra(perm_string);
+      explicit PScopeExtra(perm_string);
       ~PScopeExtra();
 
 	/* Task definitions within this module */

--- a/Statement.h
+++ b/Statement.h
@@ -289,7 +289,7 @@ class PCAssign  : public Statement {
  */
 class PChainConstructor : public Statement {
     public:
-      PChainConstructor(const list<PExpr*>&parms);
+      explicit PChainConstructor(const list<PExpr*>&parms);
       ~PChainConstructor();
 
       virtual NetProc* elaborate(Design*des, NetScope*scope) const;

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -4030,7 +4030,7 @@ static verinum param_part_select_bits(const verinum&par_val, long wid,
 	// If the input is a string, and the part select is working on
 	// byte boundaries, then make the result into a string.
       if (par_val.is_string() && (labs(lsv)%8 == 0) && (wid%8 == 0))
-	    return result.as_string();
+	    return verinum(result.as_string());
 
       return result;
 }

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -5931,7 +5931,7 @@ class elaborate_root_scope_t : public elaborator_work_item_t {
 
 class top_defparams : public elaborator_work_item_t {
     public:
-      top_defparams(Design*des__)
+      explicit top_defparams(Design*des__)
       : elaborator_work_item_t(des__)
       { }
 
@@ -5962,7 +5962,7 @@ class top_defparams : public elaborator_work_item_t {
 
 class later_defparams : public elaborator_work_item_t {
     public:
-      later_defparams(Design*des__)
+      explicit later_defparams(Design*des__)
       : elaborator_work_item_t(des__)
       { }
 

--- a/libmisc/StringHeap.h
+++ b/libmisc/StringHeap.h
@@ -46,7 +46,7 @@ class perm_string {
     private:
       friend class StringHeap;
       friend class StringHeapLex;
-      perm_string(const char*t) : text_(t) { };
+      explicit perm_string(const char*t) : text_(t) { };
 
     private:
       const char*text_;

--- a/netlist.h
+++ b/netlist.h
@@ -290,7 +290,7 @@ class NetObj  : public NetPins, public Attrib {
 
 class IslandBranch {
     public:
-      IslandBranch(ivl_discipline_t dis =0) : island_(0), discipline_(dis) { }
+      explicit IslandBranch(ivl_discipline_t dis =0) : island_(0), discipline_(dis) { }
 
       ivl_island_t get_island() const { return island_; }
 
@@ -2654,7 +2654,7 @@ class NetProc : public virtual LineInfo {
 class NetAlloc  : public NetProc {
 
     public:
-      NetAlloc(NetScope*);
+      explicit NetAlloc(NetScope*);
       ~NetAlloc();
 
       const string name() const;
@@ -3458,7 +3458,7 @@ class NetForLoop : public NetProc {
 class NetFree   : public NetProc {
 
     public:
-      NetFree(NetScope*);
+      explicit NetFree(NetScope*);
       ~NetFree();
 
       const string name() const;
@@ -3745,7 +3745,7 @@ class NetEAccess : public NetExpr {
 class NetUTask  : public NetProc {
 
     public:
-      NetUTask(NetScope*);
+      explicit NetUTask(NetScope*);
       ~NetUTask();
 
       const string name() const;
@@ -4237,7 +4237,7 @@ class NetESelect  : public NetExpr {
 class NetEEvent : public NetExpr {
 
     public:
-      NetEEvent(NetEvent*);
+      explicit NetEEvent(NetEvent*);
       ~NetEEvent();
 
       const NetEvent* event() const;
@@ -4260,7 +4260,7 @@ class NetEEvent : public NetExpr {
 class NetENetenum  : public NetExpr {
 
     public:
-      NetENetenum(const netenum_t*);
+      explicit NetENetenum(const netenum_t*);
       ~NetENetenum();
 
       const netenum_t* netenum() const;
@@ -4357,7 +4357,7 @@ class NetEProperty : public NetExpr {
 class NetEScope  : public NetExpr {
 
     public:
-      NetEScope(NetScope*);
+      explicit NetEScope(NetScope*);
       ~NetEScope();
 
       const NetScope* scope() const;
@@ -4688,7 +4688,7 @@ class NetECast : public NetEUnary {
 class NetESignal  : public NetExpr {
 
     public:
-      NetESignal(NetNet*n);
+      explicit NetESignal(NetNet*n);
       NetESignal(NetNet*n, NetExpr*word_index);
       ~NetESignal();
 

--- a/netmisc.h
+++ b/netmisc.h
@@ -155,7 +155,7 @@ extern NetExpr*normalize_variable_slice_base(const list<long>&indices, NetExpr *
  * index values in the form [<>][<>]....
  */
 template <class TYPE> struct __IndicesManip {
-      inline __IndicesManip(const std::list<TYPE>&v) : val(v) { }
+      explicit inline __IndicesManip(const std::list<TYPE>&v) : val(v) { }
       const std::list<TYPE>&val;
 };
 template <class TYPE> inline __IndicesManip<TYPE> as_indices(const std::list<TYPE>&indices)

--- a/pform.h
+++ b/pform.h
@@ -104,7 +104,7 @@ struct net_decl_assign_t {
 
 /* The lgate is gate instantiation information. */
 struct lgate {
-      inline lgate(int =0)
+      explicit inline lgate(int =0)
       : parms(0), parms_by_name(0), file(NULL), lineno(0)
       { }
 

--- a/svector.h
+++ b/svector.h
@@ -39,7 +39,7 @@ template <class TYPE> class svector {
 
       explicit svector(unsigned size) : nitems_(size), items_(new TYPE[size])
 	    { for (unsigned idx = 0 ;  idx < size ;  idx += 1)
-		  items_[idx] = 0;
+		  items_[idx] = TYPE(0);
 	    }
 
       svector(const svector<TYPE>&that)

--- a/tgt-blif/nex_data.h
+++ b/tgt-blif/nex_data.h
@@ -32,7 +32,7 @@ class blif_nex_data_t {
     private:
 	// The constructors are private. Only the get_nex_data()
 	// function can create these objects.
-      blif_nex_data_t(ivl_nexus_t nex);
+      explicit blif_nex_data_t(ivl_nexus_t nex);
       ~blif_nex_data_t();
 
     public:

--- a/tgt-vhdl/state.cc
+++ b/tgt-vhdl/state.cc
@@ -144,7 +144,7 @@ ivl_signal_t find_signal_named(const std::string &name, const vhdl_scope *scope)
 
 // Compare the name of an entity against a string
 struct cmp_ent_name {
-   cmp_ent_name(const string& n) : name_(n) {}
+   explicit cmp_ent_name(const string& n) : name_(n) {}
 
    bool operator()(const vhdl_entity* ent) const
    {

--- a/tgt-vhdl/support.hh
+++ b/tgt-vhdl/support.hh
@@ -41,7 +41,7 @@ enum support_function_t {
 
 class support_function : public vhdl_function {
 public:
-   support_function(support_function_t type)
+   explicit support_function(support_function_t type)
       : vhdl_function(function_name(type), function_type(type)),
         type_(type) {}
    void emit(std::ostream &of, int level) const;

--- a/tgt-vhdl/vhdl_syntax.hh
+++ b/tgt-vhdl/vhdl_syntax.hh
@@ -178,7 +178,7 @@ private:
 
 class vhdl_const_string : public vhdl_expr {
 public:
-   vhdl_const_string(const string& value)
+   explicit vhdl_const_string(const string& value)
       : vhdl_expr(vhdl_type::string(), true), value_(value) {}
 
    void emit(std::ostream &of, int level) const;
@@ -207,7 +207,7 @@ private:
 
 class vhdl_const_bit : public vhdl_expr {
 public:
-   vhdl_const_bit(char bit)
+   explicit vhdl_const_bit(char bit)
       : vhdl_expr(vhdl_type::std_logic(), true), bit_(bit) {}
    void emit(std::ostream &of, int level) const;
    vhdl_expr *to_boolean();
@@ -237,7 +237,7 @@ private:
 
 class vhdl_const_int : public vhdl_expr {
 public:
-   vhdl_const_int(int64_t value)
+   explicit vhdl_const_int(int64_t value)
       : vhdl_expr(vhdl_type::integer(), true), value_(value) {}
    void emit(std::ostream &of, int level) const;
    vhdl_expr *to_vector(vhdl_type_name_t name, int w);
@@ -247,7 +247,7 @@ private:
 
 class vhdl_const_bool : public vhdl_expr {
 public:
-   vhdl_const_bool(bool value)
+   explicit vhdl_const_bool(bool value)
       : vhdl_expr(vhdl_type::boolean(), true), value_(value) {}
    void emit(std::ostream &of, int level) const;
 private:
@@ -478,7 +478,7 @@ private:
 
 class vhdl_assert_stmt : public vhdl_report_stmt {
 public:
-   vhdl_assert_stmt(const char *reason);
+   explicit vhdl_assert_stmt(const char *reason);
 
    void emit(ostream &of, int level) const;
 };
@@ -486,7 +486,7 @@ public:
 
 class vhdl_if_stmt : public vhdl_seq_stmt {
 public:
-   vhdl_if_stmt(vhdl_expr *test);
+   explicit vhdl_if_stmt(vhdl_expr *test);
    ~vhdl_if_stmt();
 
    stmt_container *get_then_container() { return &then_part_; }
@@ -513,7 +513,7 @@ private:
 class vhdl_case_branch : public vhdl_element {
    friend class vhdl_case_stmt;
 public:
-   vhdl_case_branch(vhdl_expr *when) : when_(when) {}
+   explicit vhdl_case_branch(vhdl_expr *when) : when_(when) {}
    ~vhdl_case_branch();
 
    stmt_container *get_container() { return &stmts_; }
@@ -527,7 +527,7 @@ typedef std::list<vhdl_case_branch*> case_branch_list_t;
 
 class vhdl_case_stmt : public vhdl_seq_stmt {
 public:
-   vhdl_case_stmt(vhdl_expr *test) : test_(test) {}
+   explicit vhdl_case_stmt(vhdl_expr *test) : test_(test) {}
    ~vhdl_case_stmt();
 
    void add_branch(vhdl_case_branch *b) { branches_.push_back(b); }
@@ -554,7 +554,7 @@ private:
 
 class vhdl_while_stmt : public vhdl_loop_stmt {
 public:
-   vhdl_while_stmt(vhdl_expr *test) : test_(test) {}
+   explicit vhdl_while_stmt(vhdl_expr *test) : test_(test) {}
    ~vhdl_while_stmt();
 
    void emit(std::ostream &of, int level) const;
@@ -584,7 +584,7 @@ private:
  */
 class vhdl_pcall_stmt : public vhdl_seq_stmt {
 public:
-   vhdl_pcall_stmt(const char *name) : name_(name) {}
+   explicit vhdl_pcall_stmt(const char *name) : name_(name) {}
 
    void emit(std::ostream &of, int level) const;
    void add_expr(vhdl_expr *e) { exprs_.add_expr(e); }
@@ -658,7 +658,7 @@ public:
 
    void emit(std::ostream &of, int level) const;
 private:
-   vhdl_component_decl(const char *name);
+   explicit vhdl_component_decl(const char *name);
 
    decl_list_t ports_;
 };
@@ -852,7 +852,7 @@ private:
 
 class vhdl_forward_fdecl : public vhdl_decl {
 public:
-   vhdl_forward_fdecl(const vhdl_function *f)
+   explicit vhdl_forward_fdecl(const vhdl_function *f)
       : vhdl_decl((f->get_name() + "_Forward").c_str()), f_(f) {}
 
    void emit(std::ostream &of, int level) const;
@@ -863,7 +863,7 @@ private:
 
 class vhdl_process : public vhdl_conc_stmt, public vhdl_procedural {
 public:
-   vhdl_process(const char *name = "") : name_(name) {}
+   explicit vhdl_process(const char *name = "") : name_(name) {}
 
    void emit(std::ostream &of, int level) const;
    void add_sensitivity(const std::string &name);

--- a/verinum.h
+++ b/verinum.h
@@ -42,9 +42,9 @@ class verinum {
       enum V { V0 = 0, V1, Vx, Vz };
 
       verinum();
-      verinum(const string&str);
+      explicit verinum(const string&str);
       verinum(const V*v, unsigned nbits, bool has_len =true);
-      verinum(V, unsigned nbits =1, bool has_len =true);
+      explicit verinum(V, unsigned nbits =1, bool has_len =true);
       verinum(uint64_t val, unsigned bits);
       verinum(double val, bool);
       verinum(const verinum&);

--- a/vhdlpp/entity.h
+++ b/vhdlpp/entity.h
@@ -41,7 +41,7 @@ class InterfacePort : public LineInfo {
           : mode(mod), name(nam), type(typ), expr(exp)
       {}
 
-      InterfacePort(const VType*typ)
+      explicit InterfacePort(const VType*typ)
           : mode(PORT_NONE), type(typ), expr(NULL)
       {}
 
@@ -64,7 +64,7 @@ class InterfacePort : public LineInfo {
 class ComponentBase : public LineInfo {
 
     public:
-      ComponentBase(perm_string name);
+      explicit ComponentBase(perm_string name);
       ~ComponentBase();
 
 	// Entities have names.
@@ -101,7 +101,7 @@ class ComponentBase : public LineInfo {
 class Entity : public ComponentBase {
 
     public:
-      Entity(perm_string name);
+      explicit Entity(perm_string name);
       ~Entity();
 
 	// bind an architecture to the entity, and return the

--- a/vhdlpp/expression.h
+++ b/vhdlpp/expression.h
@@ -162,7 +162,7 @@ static inline ostream& operator <<(ostream&out, const Expression&exp)
 class ExpUnary : public Expression {
 
     public:
-      ExpUnary(Expression*op1);
+      explicit ExpUnary(Expression*op1);
       virtual ~ExpUnary() =0;
 
       inline const Expression*peek_operand() const { return operand1_; }
@@ -299,7 +299,7 @@ class ExpAggregate : public Expression {
       };
 
     public:
-      ExpAggregate(std::list<element_t*>*el);
+      explicit ExpAggregate(std::list<element_t*>*el);
       ~ExpAggregate();
 
       Expression*clone() const;
@@ -402,7 +402,7 @@ class ExpBitstring : public Expression {
 class ExpCharacter : public Expression {
 
     public:
-      ExpCharacter(char val);
+      explicit ExpCharacter(char val);
       ExpCharacter(const ExpCharacter&other) : Expression() { value_ = other.value_; }
       ~ExpCharacter();
 
@@ -571,7 +571,7 @@ class ExpFunc : public Expression {
 class ExpInteger : public Expression {
 
     public:
-      ExpInteger(int64_t val);
+      explicit ExpInteger(int64_t val);
       ExpInteger(const ExpInteger&other) : Expression(), value_(other.value_) {}
       ~ExpInteger();
 
@@ -594,7 +594,7 @@ class ExpInteger : public Expression {
 class ExpReal : public Expression {
 
     public:
-      ExpReal(double val);
+      explicit ExpReal(double val);
       ExpReal(const ExpReal&other) : Expression(), value_(other.value_) {}
       ~ExpReal();
 
@@ -808,7 +808,7 @@ class ExpString : public Expression {
 class ExpUAbs : public ExpUnary {
 
     public:
-      ExpUAbs(Expression*op1);
+      explicit ExpUAbs(Expression*op1);
       ~ExpUAbs();
 
       Expression*clone() const { return new ExpUAbs(peek_operand()->clone()); }
@@ -821,7 +821,7 @@ class ExpUAbs : public ExpUnary {
 class ExpUNot : public ExpUnary {
 
     public:
-      ExpUNot(Expression*op1);
+      explicit ExpUNot(Expression*op1);
       ~ExpUNot();
 
       Expression*clone() const { return new ExpUNot(peek_operand()->clone()); }
@@ -862,7 +862,7 @@ class ExpCast : public Expression {
 class ExpNew : public Expression {
 
     public:
-      ExpNew(Expression*size);
+      explicit ExpNew(Expression*size);
       ~ExpNew();
 
       Expression*clone() const { return new ExpNew(size_->clone()); }

--- a/vhdlpp/scope.h
+++ b/vhdlpp/scope.h
@@ -152,7 +152,7 @@ class ActiveScope : public ScopeBase {
 
     public:
       ActiveScope() : package_header_(0), context_entity_(0) { }
-      ActiveScope(ActiveScope*par) : ScopeBase(*par), package_header_(0), context_entity_(0) { }
+      explicit ActiveScope(ActiveScope*par) : ScopeBase(*par), package_header_(0), context_entity_(0) { }
 
       ~ActiveScope() { }
 

--- a/vhdlpp/sequential.h
+++ b/vhdlpp/sequential.h
@@ -131,7 +131,7 @@ class IfSequential  : public SequentialStmt {
 
 class ReturnStmt  : public SequentialStmt {
     public:
-      ReturnStmt(Expression*val);
+      explicit ReturnStmt(Expression*val);
       ~ReturnStmt();
 
     public:
@@ -201,7 +201,7 @@ class CaseSeqStmt : public SequentialStmt {
 
 class ProcedureCall : public SequentialStmt {
     public:
-      ProcedureCall(perm_string name);
+      explicit ProcedureCall(perm_string name);
       ProcedureCall(perm_string name, std::list<named_expr_t*>* param_list);
       ProcedureCall(perm_string name, std::list<Expression*>* param_list);
       ~ProcedureCall();
@@ -311,7 +311,7 @@ class AssertStmt : public ReportStmt {
 
 class WaitForStmt : public SequentialStmt {
     public:
-      WaitForStmt(Expression*delay);
+      explicit WaitForStmt(Expression*delay);
 
       void dump(ostream&out, int indent) const;
       int elaborate(Entity*ent, ScopeBase*scope);

--- a/vhdlpp/sequential_elaborate.cc
+++ b/vhdlpp/sequential_elaborate.cc
@@ -233,7 +233,7 @@ int WaitStmt::elaborate(Entity*ent, ScopeBase*scope)
 {
     if(type_ == UNTIL) {
         struct fill_sens_list_t : public ExprVisitor {
-            fill_sens_list_t(set<ExpName*>& sig_list)
+            explicit fill_sens_list_t(set<ExpName*>& sig_list)
             : sig_list_(sig_list) {};
 
             void operator() (Expression*s) {

--- a/vhdlpp/std_funcs.cc
+++ b/vhdlpp/std_funcs.cc
@@ -61,7 +61,7 @@ static class SubprogramToInteger : public SubprogramHeader {
 // Special case: size casting (e.g. conv_std_logic_vector() / resize()).
 static class SubprogramSizeCast : public SubprogramHeader {
     public:
-      SubprogramSizeCast(perm_string nam)
+      explicit SubprogramSizeCast(perm_string nam)
           : SubprogramHeader(nam, NULL, &primitive_STDLOGIC_VECTOR) {
           ports_ = new std::list<InterfacePort*>();
           ports_->push_back(new InterfacePort(&primitive_STDLOGIC_VECTOR));

--- a/vhdlpp/subprogram.cc
+++ b/vhdlpp/subprogram.cc
@@ -222,7 +222,7 @@ SubprogramHeader*SubprogramHeader::make_instance(std::vector<Expression*> argume
 }
 
 struct check_return_type : public SeqStmtVisitor {
-    check_return_type(const SubprogramBody*subp) : subp_(subp), ret_type_(NULL) {}
+    explicit check_return_type(const SubprogramBody*subp) : subp_(subp), ret_type_(NULL) {}
 
     void operator() (SequentialStmt*s)
     {

--- a/vhdlpp/vtype.h
+++ b/vhdlpp/vtype.h
@@ -289,7 +289,7 @@ class VTypeRange : public VType {
 class VTypeEnum : public VType {
 
     public:
-      VTypeEnum(const std::list<perm_string>*names);
+      explicit VTypeEnum(const std::list<perm_string>*names);
       ~VTypeEnum();
 
       VType*clone() const { return new VTypeEnum(*this); }

--- a/vvp/class_type.cc
+++ b/vvp/class_type.cc
@@ -36,7 +36,7 @@ using namespace std;
  */
 class class_property_t {
     public:
-      explicit inline class_property_t() { }
+      inline class_property_t() { }
       virtual ~class_property_t() =0;
 	// How much space does an instance of this property require?
       virtual size_t instance_size() const =0;
@@ -143,7 +143,7 @@ template <class T> class property_atom : public class_property_t {
 
 class property_bit : public class_property_t {
     public:
-      inline property_bit(size_t wid): wid_(wid) { }
+      explicit inline property_bit(size_t wid): wid_(wid) { }
       ~property_bit() { }
 
       size_t instance_size() const { return sizeof(vvp_vector2_t); }
@@ -168,7 +168,7 @@ class property_bit : public class_property_t {
 
 class property_logic : public class_property_t {
     public:
-      inline property_logic(size_t wid): wid_(wid) { }
+      explicit inline property_logic(size_t wid): wid_(wid) { }
       ~property_logic() { }
 
       size_t instance_size() const { return sizeof(vvp_vector4_t); }

--- a/vvp/compile.cc
+++ b/vvp/compile.cc
@@ -453,7 +453,7 @@ void resolv_submit(resolv_list_s*cur)
  */
 struct vvp_net_resolv_list_s: public resolv_list_s {
 
-      vvp_net_resolv_list_s(char*l) : resolv_list_s(l) { }
+      explicit vvp_net_resolv_list_s(char*l) : resolv_list_s(l) { }
 	// port to be driven by the located node.
       vvp_net_ptr_t port;
       virtual bool resolve(bool mes);
@@ -627,7 +627,7 @@ void compile_vpi_lookup(vpiHandle *handle, char*label)
  */
 
 struct code_label_resolv_list_s: public resolv_list_s {
-      code_label_resolv_list_s(char*lab) : resolv_list_s(lab) {
+      explicit code_label_resolv_list_s(char*lab) : resolv_list_s(lab) {
 	    code = NULL;
       }
       struct vvp_code_s *code;
@@ -662,7 +662,7 @@ void code_label_lookup(struct vvp_code_s *code, char *label)
 }
 
 struct code_array_resolv_list_s: public resolv_list_s {
-      code_array_resolv_list_s(char*lab) : resolv_list_s(lab) {
+      explicit code_array_resolv_list_s(char*lab) : resolv_list_s(lab) {
 	    code = NULL;
       }
       struct vvp_code_s *code;

--- a/vvp/delay.h
+++ b/vvp/delay.h
@@ -76,7 +76,7 @@ class vvp_fun_delay  : public vvp_net_fun_t, private vvp_gen_event_s {
 
       enum delay_type_t {UNKNOWN_DELAY, VEC4_DELAY, VEC8_DELAY, REAL_DELAY};
       struct event_ {
-	    event_(vvp_time64_t s) : sim_time(s) {
+	    explicit event_(vvp_time64_t s) : sim_time(s) {
 		  ptr_real = 0.0;
 		  next = NULL;
 	    }
@@ -191,7 +191,7 @@ class vvp_fun_modpath_src  : public vvp_net_fun_t {
       friend class vvp_fun_modpath;
 
     public:
-      vvp_fun_modpath_src(vvp_time64_t d[12]);
+      explicit vvp_fun_modpath_src(vvp_time64_t d[12]);
     protected:
       ~vvp_fun_modpath_src();
 

--- a/vvp/schedule.cc
+++ b/vvp/schedule.cc
@@ -161,7 +161,7 @@ void del_thr_event_s::single_step_display(void)
 
 struct assign_vector4_event_s  : public event_s {
 	/* The default constructor. */
-      assign_vector4_event_s(const vvp_vector4_t&that) : val(that) {
+      explicit assign_vector4_event_s(const vvp_vector4_t&that) : val(that) {
 	    base = 0;
 	    vwid = 0;
       }
@@ -325,7 +325,7 @@ unsigned long count_assign_aword_pool(void) { return array_w_heap.pool; }
  */
 struct propagate_vector4_event_s : public event_s {
 	/* The default constructor. */
-      propagate_vector4_event_s(const vvp_vector4_t&that) : val(that) {
+      explicit propagate_vector4_event_s(const vvp_vector4_t&that) : val(that) {
 	    net = NULL;
       }
 	/* A constructor that makes the val directly. */

--- a/vvp/vpi_const.cc
+++ b/vvp/vpi_const.cc
@@ -31,7 +31,7 @@
 
 class __vpiStringConst : public __vpiHandle {
     public:
-      __vpiStringConst(char*val);
+      explicit __vpiStringConst(char*val);
       ~__vpiStringConst();
       int get_type_code(void) const;
       int vpi_get(int code);
@@ -224,7 +224,7 @@ void __vpiStringConst::vpi_get_value(p_vpi_value vp)
 
 
 struct __vpiStringConstTEMP : public __vpiStringConst {
-      inline __vpiStringConstTEMP(char*v) : __vpiStringConst(v) { }
+      explicit inline __vpiStringConstTEMP(char*v) : __vpiStringConst(v) { }
       free_object_fun_t free_object_fun(void);
 };
 

--- a/vvp/vpi_priv.h
+++ b/vvp/vpi_priv.h
@@ -152,7 +152,7 @@ extern vpiHandle vpip_make_iterator(unsigned nargs, vpiHandle*args,
 
 class __vpiDecConst : public __vpiHandle {
     public:
-      __vpiDecConst(int val =0);
+      explicit __vpiDecConst(int val =0);
       __vpiDecConst(const __vpiDecConst&that);
       int get_type_code(void) const;
       int vpi_get(int code);
@@ -797,7 +797,7 @@ vpiHandle vpip_make_binary_param(char*name, const vvp_vector4_t&bits,
 
 class __vpiRealConst : public __vpiHandle {
     public:
-      __vpiRealConst(double);
+      explicit __vpiRealConst(double);
       int get_type_code(void) const;
       int vpi_get(int code);
       void vpi_get_value(p_vpi_value val);

--- a/vvp/vpi_signal.cc
+++ b/vvp/vpi_signal.cc
@@ -1121,8 +1121,8 @@ static vpiHandle fill_in_net4(struct __vpiSignal*obj,
 			      bool signed_flag, vvp_net_t*node)
 {
       obj->id.name = name? vpip_name_string(name) : 0;
-      obj->msb = msb;
-      obj->lsb = lsb;
+      obj->msb = __vpiDecConst(msb);
+      obj->lsb = __vpiDecConst(lsb);
       obj->signed_flag = signed_flag? 1 : 0;
       obj->is_netarray = 0;
       obj->node = node;

--- a/vvp/vpi_tasks.cc
+++ b/vvp/vpi_tasks.cc
@@ -213,7 +213,7 @@ vpiHandle sysfunc_real::vpi_put_value(p_vpi_value vp, int)
 
 class sysfunc_vec4 : public __vpiSysTaskCall {
     public:
-      inline sysfunc_vec4(unsigned wid): return_value_(wid, BIT4_X) { }
+      explicit inline sysfunc_vec4(unsigned wid): return_value_(wid, BIT4_X) { }
       int get_type_code(void) const { return vpiSysFuncCall; }
       int vpi_get(int code);
       char* vpi_get_str(int code)   { return systask_get_str(code, this); }
@@ -389,7 +389,7 @@ vpiHandle sysfunc_vec4::vpi_put_value(p_vpi_value vp, int)
 }
 
 struct sysfunc_4net : public __vpiSysTaskCall {
-      inline sysfunc_4net(unsigned wid) : vwid_(wid) { }
+      explicit inline sysfunc_4net(unsigned wid) : vwid_(wid) { }
       int get_type_code(void) const { return vpiSysFuncCall; }
       int vpi_get(int code);
       char* vpi_get_str(int code)   { return systask_get_str(code, this); }

--- a/vvp/vpi_vthr_vector.cc
+++ b/vvp/vpi_vthr_vector.cc
@@ -207,7 +207,7 @@ static void thread_word_delete_real(vpiHandle item)
 
 class __vpiVThrStrStack : public __vpiHandle {
     public:
-      __vpiVThrStrStack(unsigned depth);
+      explicit __vpiVThrStrStack(unsigned depth);
       int get_type_code(void) const;
       int vpi_get(int code);
       void vpi_get_value(p_vpi_value val);

--- a/vvp/vvp_darray.h
+++ b/vvp/vvp_darray.h
@@ -49,7 +49,7 @@ class vvp_darray : public vvp_object {
 template <class TYPE> class vvp_darray_atom : public vvp_darray {
 
     public:
-      inline vvp_darray_atom(size_t siz) : array_(siz) { }
+      explicit inline vvp_darray_atom(size_t siz) : array_(siz) { }
       ~vvp_darray_atom();
 
       size_t get_size(void) const;
@@ -95,7 +95,7 @@ class vvp_darray_vec2 : public vvp_darray {
 class vvp_darray_real : public vvp_darray {
 
     public:
-      inline vvp_darray_real(size_t siz) : array_(siz) { }
+      explicit inline vvp_darray_real(size_t siz) : array_(siz) { }
       ~vvp_darray_real();
 
       size_t get_size(void) const;
@@ -109,7 +109,7 @@ class vvp_darray_real : public vvp_darray {
 class vvp_darray_string : public vvp_darray {
 
     public:
-      inline vvp_darray_string(size_t siz) : array_(siz) { }
+      explicit inline vvp_darray_string(size_t siz) : array_(siz) { }
       ~vvp_darray_string();
 
       size_t get_size(void) const;
@@ -123,7 +123,7 @@ class vvp_darray_string : public vvp_darray {
 class vvp_darray_object : public vvp_darray {
 
     public:
-      inline vvp_darray_object(size_t siz) : array_(siz) { }
+      explicit inline vvp_darray_object(size_t siz) : array_(siz) { }
       ~vvp_darray_object();
 
       size_t get_size(void) const;

--- a/vvp/vvp_net_sig.h
+++ b/vvp/vvp_net_sig.h
@@ -463,7 +463,7 @@ class vvp_wire_vec4 : public vvp_wire_base {
 class vvp_wire_vec8 : public vvp_wire_base {
 
     public:
-      vvp_wire_vec8(unsigned wid);
+      explicit vvp_wire_vec8(unsigned wid);
 
 	// The main filter behavior for this class
       prop_t filter_vec4(const vvp_vector4_t&bit, vvp_vector4_t&rep,


### PR DESCRIPTION
This prevents implicit conversions and a removes few cppcheck warnings.
