### PR TITLE
Fix 3 compiler warnings

### DIFF
--- a/t-dll-api.cc
+++ b/t-dll-api.cc
@@ -171,13 +171,6 @@ extern "C" unsigned ivl_expr_lineno(ivl_expr_t net)
       return net->lineno;
 }
 
-inline static const char *basename(ivl_scope_t scope, const char *inst)
-{
-      inst += strlen(ivl_scope_name(scope));
-      assert(*inst == '.');
-      return inst+1;
-}
-
 extern "C" ivl_variable_type_t ivl_const_type(ivl_net_const_t net)
 {
       assert(net);

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -151,13 +151,6 @@ void ivl_net_const_s::operator delete(void*, size_t)
 
 static StringHeapLex net_const_strings;
 
-inline static const char *basename(ivl_scope_t scope, const char *inst)
-{
-      inst += strlen(ivl_scope_name(scope));
-      assert(*inst == '.');
-      return inst+1;
-}
-
 static perm_string make_scope_name(const hname_t&name)
 {
       if (! name.has_numbers())

--- a/vpi/sys_scanf.c
+++ b/vpi/sys_scanf.c
@@ -20,6 +20,7 @@
 /* round() is ISO C99 from math.h. This define should enable it. */
 # define _ISOC99_SOURCE 1
 # define _SVID_SOURCE 1
+# define _DEFAULT_SOURCE 1
 
 # include  "sys_priv.h"
 # include  <ctype.h>


### PR DESCRIPTION
This pull request removes two unused static functions and adds the definition of _DEFAULT_SOURCE.
Tested with gcc 5.1 in fedora 22.