### PR TITLE
Changes necessary to compile with gcc on Debian/Linux testing

### DIFF
--- a/vhdlpp/parse_misc.cc
+++ b/vhdlpp/parse_misc.cc
@@ -122,7 +122,7 @@ const VType* calculate_subtype_array(const YYLTYPE&loc, const char*base_name,
 	    Expression*rig = tmpr->right();
 	    return calculate_subtype_array(loc, base_name, scope,
 					   lef, 
-					   (tmpr->direction() == ExpRange::range_dir_t::DOWNTO
+					   (tmpr->direction() == ExpRange::DOWNTO
 					   	? true
 					   	: false), 
 					   rig);

--- a/vhdlpp/vtype.cc
+++ b/vhdlpp/vtype.cc
@@ -120,7 +120,7 @@ VTypeArray::VTypeArray(const VType*element, std::list<ExpRange*>*r, bool sv)
 	    ExpRange*curp = r->front();
 	    r->pop_front();
 	    ranges_[idx] = range_t(curp->msb(), curp->lsb(), 
-	    	(curp->direction() == ExpRange::range_dir_t::DOWNTO
+	    	(curp->direction() == ExpRange::DOWNTO
 	    		? true
 	    		: false));
       }


### PR DESCRIPTION
To be able to compile the newest sources with gcc on my Debian/Linux testing machine, I had to modify two files.
Otherwise I get the errors:
 error: ‘ExpRange::range_dir_t’ is not a class or namespace

The other solution could be to compile with "-std=c++0x" option, which should add scoped enums.
I have not tested it though.