### PR TITLE
Added missing compilation instruction on README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -77,7 +77,8 @@ the configure scripts.
 Unpack the tar-ball and cd into the verilog-######### directory
 (presumably that is how you got to this README) and compile the source
 with the commands:
-
+	
+  sh autoconf.sh
   ./configure
   make
 

--- a/README.txt
+++ b/README.txt
@@ -78,9 +78,14 @@ Unpack the tar-ball and cd into the verilog-######### directory
 (presumably that is how you got to this README) and compile the source
 with the commands:
 	
-  sh autoconf.sh
   ./configure
   make
+
+If you are building from git, you have to run the command below before
+compile the source. This will generate the "configure" file, which is 
+automatically done when building from tarball.
+
+  sh configure.sh
 
 Normally, this command automatically figures out everything it needs
 to know. It generally works pretty well. There are a few flags to the


### PR DESCRIPTION
Added command to run 'autoconf.sh', generating the 'configure' file.
