### PR TITLE
Fix x86_64-w64-mingw32 build: undefined ___strtod

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -223,8 +223,10 @@ AC_SUBST(strip_dynamic)
 # -------------
 AC_DEFUN([AX_C99_STRTOD],
 [# On MinGW we need to jump through hoops to get a C99 compliant strtod().
- # mingw-w64 doesn't need this, and the 64-bit version doesn't support it.
 case "${host}" in
+    x86_64-w64-mingw32)
+        LDFLAGS+=" -Wl,--undefined=__strtod,--wrap,strtod,--defsym,___wrap_strtod=__strtod"
+        ;;
     *-*-mingw32)
         LDFLAGS+=" -Wl,--undefined=___strtod,--wrap,strtod,--defsym,___wrap_strtod=___strtod"
         ;;


### PR DESCRIPTION
Hi,

I have detected that "___strtod" is not defined in x86_64-w64-mingw32, as it is in i686-w64-mingw32. Instead, it is defined "__strtod" (with 2 " _ " instead of 3). Therefore, the build fails.

*x86_64-w64-mingw32*

> $ x86_64-w64-mingw32-nm /usr/x86_64-w64-mingw32/lib/libmingwex.a | grep -e "___strtod"

> $ x86_64-w64-mingw32-nm /usr/x86_64-w64-mingw32/lib/libmingwex.a | grep -e "__strtod"
0000000000000500 T __strtodg
0000000000000000 T __strtod
                 U __strtodg
                 U __strtodg
                 U __strtodg
                 U __strtod

*i686-w64-mingw32*

> $ i686-w64-mingw32-nm /usr/i686-w64-mingw32/lib/libmingwex.a | grep -e "___strtod"
000004f0 T ___strtodg
00000000 T ___strtod
         U ___strtodg
         U ___strtodg
         U ___strtodg
         U ___strtod

This commits fixes the issue.
