### PR TITLE
Added an option for ignoring errors about missing modules

### DIFF
--- a/compiler.h
+++ b/compiler.h
@@ -117,6 +117,9 @@ extern bool debug_emit;
 extern bool debug_synth2;
 extern bool debug_optimizer;
 
+/* Ignore errors about missing modules */
+extern bool ignore_missing_modules;
+
 /* Control evaluation of functions at compile time:
  *   0 = only for functions in constant expressions
  *   1 = only for automatic functions

--- a/driver/main.c
+++ b/driver/main.c
@@ -38,7 +38,7 @@ const char NOTICE[] =
 ;
 
 const char HELP[] =
-"Usage: iverilog [-ESvV] [-B base] [-c cmdfile|-f cmdfile]\n"
+"Usage: iverilog [-EiSvV] [-B base] [-c cmdfile|-f cmdfile]\n"
 "                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012] [-g<feature>]\n"
 "                [-D macro[=defn]] [-I includedir]\n"
 "                [-M [mode=]depfile] [-m module]\n"
@@ -139,6 +139,9 @@ int gen_std_include = 1;
 int gen_relative_include = 0;
 
 char warning_flags[16] = "n";
+
+/* Boolean: true means ignore errors about missing modules */
+int ignore_missing_modules = 0;
 
 unsigned integer_width = 32;
 
@@ -987,7 +990,7 @@ int main(int argc, char **argv)
 	}
       }
 
-      while ((opt = getopt(argc, argv, "B:c:D:d:Ef:g:hl:I:M:m:N:o:P:p:Ss:T:t:vVW:y:Y:")) != EOF) {
+      while ((opt = getopt(argc, argv, "B:c:D:d:Ef:g:hl:I:iM:m:N:o:P:p:Ss:T:t:vVW:y:Y:")) != EOF) {
 
 	    switch (opt) {
 		case 'B':
@@ -1041,6 +1044,10 @@ int main(int argc, char **argv)
 		case 'I':
 		  process_include_dir(optarg);
 		  break;
+
+		case 'i':
+  		  ignore_missing_modules = 1;
+  		  break;
 
 		case 'l':
 		  process_file_name(optarg, 1);
@@ -1184,6 +1191,7 @@ int main(int argc, char **argv)
       fprintf(iconfig_file, "generation:%s\n", gen_verilog_ams);
       fprintf(iconfig_file, "generation:%s\n", gen_icarus);
       fprintf(iconfig_file, "warnings:%s\n", warning_flags);
+      fprintf(iconfig_file, "ignore_missing_modules:%s\n", ignore_missing_modules ? "true" : "false");
       fprintf(iconfig_file, "out:%s\n", opath);
       if (depfile) {
             fprintf(iconfig_file, "depfile:%s\n", depfile);

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -2204,8 +2204,10 @@ void PGModule::elaborate(Design*des, NetScope*scope) const
 	    return;
       }
 
-      cerr << get_fileline() << ": internal error: Unknown module type: " <<
-	    type_ << endl;
+      if (!ignore_missing_modules) {
+        cerr << get_fileline() << ": internal error: Unknown module type: " <<
+	      type_ << endl;
+      }
 }
 
 void PGModule::elaborate_scope(Design*des, NetScope*sc) const
@@ -2249,9 +2251,11 @@ void PGModule::elaborate_scope(Design*des, NetScope*sc) const
 
 	// Not a module or primitive that I know about or can find by
 	// any means, so give up.
-      cerr << get_fileline() << ": error: Unknown module type: " << type_ << endl;
-      missing_modules[type_] += 1;
-      des->errors += 1;
+      if (!ignore_missing_modules) {
+        cerr << get_fileline() << ": error: Unknown module type: " << type_ << endl;
+        missing_modules[type_] += 1;
+        des->errors += 1;
+      }
 }
 
 

--- a/main.cc
+++ b/main.cc
@@ -165,6 +165,11 @@ bool warn_anachronisms = false;
 bool warn_floating_nets = false;
 
 /*
+ * Ignore errors about missing modules
+ */
+bool ignore_missing_modules = false;
+
+/*
  * Debug message class flags.
  */
 bool debug_scopes = false;
@@ -570,6 +575,9 @@ static bool set_default_timescale(const char*ts_string)
  *
  *    warnings:<string>
  *        Warning flag letters.
+ *
+ *    ignore_missing_modules:<bool>
+ *        true to ignore errors about missing modules
  */
 bool had_timescale = false;
 static void read_iconfig_file(const char*ipath)
@@ -719,6 +727,10 @@ static void read_iconfig_file(const char*ipath)
 		      default:
 			break;
 		  }
+
+		} else if (strcmp(buf, "ignore_missing_modules") == 0) {
+		  if (strcmp(cp, "true") == 0)
+		    ignore_missing_modules = true;
 
 	    } else if (strcmp(buf, "-y") == 0) {
 		  build_library_index(cp, CASE_SENSITIVE);


### PR DESCRIPTION
This commit adds an option (-i) to ignore errors about missing modules.

Ignoring missing modules is really useful for using iverilog as linter in text editors (like Atom or Sublime Text), where you usually only want to check single files without caring about modules on other files.