### PR TITLE
vvp grammar: .port_info statements should require/generate semicolons.

### DIFF
--- a/tgt-vvp/vvp_scope.c
+++ b/tgt-vvp/vvp_scope.c
@@ -2304,7 +2304,7 @@ int draw_scope(ivl_scope_t net, ivl_scope_t parent)
             unsigned width = ivl_scope_mod_module_port_width(net,idx);
             if( name == 0 )
                 name = "";
-            fprintf( vvp_out, "    .port_info %u %s %u \"%s\"\n",
+            fprintf( vvp_out, "    .port_info %u %s %u \"%s\";\n",
                     idx, vvp_port_info_type_str(ptype), width,
 		    vvp_mangle_name(name) );
         }

--- a/vvp/parse.y
+++ b/vvp/parse.y
@@ -27,6 +27,7 @@
 # include  <cstdlib>
 # include  <cassert>
 # include  "ivl_alloc.h"
+# include  "version_base.h"
 
 /*
  * These are bits in the lexor.
@@ -708,8 +709,18 @@ statement
 
 
   /* Port information for scopes... currently this is just meta-data for VPI queries */
-	| K_PORT_INFO T_NUMBER port_type T_NUMBER T_STRING
+	| K_PORT_INFO T_NUMBER port_type T_NUMBER T_STRING ';'
 		{ compile_port_info( $2 /* port_index */, $3, $4 /* width */,
+		                     $5 /*&name */ ); }
+  /* Unfortunately, older versions didn't check for a semicolon at the end of
+    .port_info statements.
+     To insure backwards compatablitly with old files, we have a duplicate rule
+     that doesn't require a semicolon. After version 11, this rule will be
+     disabled (and can safely be deleted. */
+	| K_PORT_INFO T_NUMBER port_type T_NUMBER T_STRING
+		{ if (VERSION_MAJOR > 11)
+			yyerror("syntax error");
+		  compile_port_info( $2 /* port_index */, $3, $4 /* width */,
 		                     $5 /*&name */ ); }
 
 	|         K_TIMESCALE T_NUMBER T_NUMBER';'


### PR DESCRIPTION
This PR attempts to fix #179 

There are two parts. The first commit simply fixes tgt-vvp so it includes a semicolon after all .port_info statements. This fix is inherently backwards compatible, as current versions of vvp accept the extra semicolon without issue (they think it's an empty statement).

The second commit fixes the parser to be more strict and syntax error when the semicolon is missing. Because this would cause backwards compatibility issues (any vvp files generated on 11.0 dev before this commit is merged will be missing the semicolons), I've delayed the activation of this new stricter rule until 12.0

As vvp refuses to read files from older major versions, by the time work starts on 12.0, vvp will only be expected to parse vvp files generated with the correct semicolon syntax. At some point after 12.0, the second rule can be removed altogether. 