### PR TITLE
VPI search path updates

### DIFF
--- a/vvp/main.cc
+++ b/vvp/main.cc
@@ -336,6 +336,28 @@ int main(int argc, char*argv[])
 	    flag_errors += 1;
       }
 
+      if (char *var = ::getenv("IVERILOG_VPI_MODULE_PATH")) {
+            char *ptr = var;
+            char *end = var+strlen(var);
+            int len = 0;
+            while (ptr <= end) {
+                  if (*ptr == 0 || *ptr == ':' || *ptr == ';') {
+                        if (len > 0) {
+                              if (vpip_module_path_cnt >= VPIP_MODULE_PATH_MAX) {
+                                    fprintf(stderr, "Too many paths specified\n");
+                                    return -1;
+                              }
+                              vpip_module_path[vpip_module_path_cnt++] = strndup(var, len);
+                        }
+                        len = 0;
+                        var = ptr+1;
+                  } else {
+                        len++;
+                  }
+                  ptr++;
+            }
+      }
+
 #ifdef __MINGW32__
 	/* Calculate the module path from the path to the command.
 	   This is necessary because of the installation process on

--- a/vvp/vpi_modules.cc
+++ b/vvp/vpi_modules.cc
@@ -33,24 +33,9 @@ static unsigned dll_list_cnt = 0;
 typedef void (*vlog_startup_routines_t)(void);
 
 
-const char* vpip_module_path[64] = {
-#ifdef MODULE_DIR1
-      MODULE_DIR1,
-#endif
-#ifdef MODULE_DIR2
-      MODULE_DIR2,
-#endif
-      0
-};
+const char* vpip_module_path[VPIP_MODULE_PATH_MAX] = {0};
 
-unsigned vpip_module_path_cnt = 0
-#ifdef MODULE_DIR1
-         + 1
-#endif
-#ifdef MODULE_DIR2
-         + 1
-#endif
-;
+unsigned vpip_module_path_cnt = 0;
 
 void load_module_delete(void)
 {

--- a/vvp/vpi_priv.h
+++ b/vvp/vpi_priv.h
@@ -874,7 +874,7 @@ vpiHandle vpip_make_vthr_APV(char*label, unsigned index, unsigned bit, unsigned 
 extern void vpip_load_module(const char*name);
 
 # define VPIP_MODULE_PATH_MAX 64
-extern const char* vpip_module_path[64];
+extern const char* vpip_module_path[VPIP_MODULE_PATH_MAX];
 extern unsigned vpip_module_path_cnt;
 
 /*

--- a/vvp/vvp.man.in
+++ b/vvp/vvp.man.in
@@ -166,6 +166,13 @@ select lxt format, which is far more compact, though limited to
 GTKWave or compatible viewers. It can also be used to suppress VCD
 output, a time-saver for regression tests.
 
+.TP 8
+.B IVERILOG_VPI_MODULE_PATH=\fI/some/path:/some/other/path\fP
+This adds additional components to the VPI module search path. Paths
+specified in this way are searched after paths specified with \-M, but
+before the default search path. Multiple paths can be separated with
+colons or semicolons.
+
 .SH INTERACTIVE MODE
 .PP
 The simulation engine supports an interactive mode. The user may


### PR DESCRIPTION
This patch does three main things. First, it reverses the order in which the internal path list is checked so that paths specified with -M are checked first and the default paths are checked last.  Second, it enforces the path count limit to prevent crashes.  Third, it implements the environment variable IVERILOG_VPI_MODULE_PATH to specify a colon-separated list of directories in which to look for VPI modules.  