### PR TITLE
Degrade primitive redefinition and ifnone with edge-sensitive-path to warnings

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5752,7 +5752,7 @@ specify_item
 		  pform_module_specify_path(tmp);
 		}
 	| K_ifnone specify_edge_path_decl ';'
-		{ yyerror(@1, "Sorry: ifnone with an edge-sensitive path is "
+		{ yywarn(@1, "Sorry: ifnone with an edge-sensitive path is "
 		              "not supported.");
 		  yyerrok;
 		}

--- a/parse_misc.cc
+++ b/parse_misc.cc
@@ -41,13 +41,14 @@ std::ostream& operator << (std::ostream&o, const YYLTYPE&loc)
 
 void VLwarn(const char*msg)
 {
-      cerr << yylloc.text << ":" << yylloc.first_line << ": " << msg << endl;
+      warn_count += 1;
+      cerr << yylloc.text << ":" << yylloc.first_line << ": Warning: " << msg << endl;
 }
 
 void VLerror(const char*msg)
 {
       error_count += 1;
-      cerr << yylloc.text << ":" << yylloc.first_line << ": " << msg << endl;
+      cerr << yylloc.text << ":" << yylloc.first_line << ": Error: " << msg << endl;
 }
 
 void VLerror(const YYLTYPE&loc, const char*msg, ...)

--- a/parse_misc.cc
+++ b/parse_misc.cc
@@ -42,13 +42,13 @@ std::ostream& operator << (std::ostream&o, const YYLTYPE&loc)
 void VLwarn(const char*msg)
 {
       warn_count += 1;
-      cerr << yylloc.text << ":" << yylloc.first_line << ": Warning: " << msg << endl;
+      cerr << yylloc.text << ":" << yylloc.first_line << ": " << msg << endl;
 }
 
 void VLerror(const char*msg)
 {
       error_count += 1;
-      cerr << yylloc.text << ":" << yylloc.first_line << ": Error: " << msg << endl;
+      cerr << yylloc.text << ":" << yylloc.first_line << ": " << msg << endl;
 }
 
 void VLerror(const YYLTYPE&loc, const char*msg, ...)

--- a/parse_misc.cc
+++ b/parse_misc.cc
@@ -39,6 +39,10 @@ std::ostream& operator << (std::ostream&o, const YYLTYPE&loc)
       return o;
 }
 
+void VLwarn(const char*msg)
+{
+      cerr << yylloc.text << ":" << yylloc.first_line << ": " << msg << endl;
+}
 
 void VLerror(const char*msg)
 {

--- a/parse_misc.h
+++ b/parse_misc.h
@@ -59,6 +59,7 @@ extern int  VLlex();
 extern void VLerror(const char*msg);
 extern void VLerror(const YYLTYPE&loc, const char*msg, ...) __attribute__((format(printf,2,3)));
 #define yywarn VLwarn
+extern void VLwarn(const char*msg);
 extern void VLwarn(const YYLTYPE&loc, const char*msg);
 
 extern void destroy_lexor();

--- a/pform.cc
+++ b/pform.cc
@@ -1847,7 +1847,7 @@ void pform_make_udp(perm_string name, list<perm_string>*parms,
 
 	// Put the primitive into the primitives table
       if (pform_primitives[name]) {
-	    VLerror("UDP primitive already exists.");
+	    VLwarn("UDP primitive already exists.");
 
       } else {
 	    PUdp*udp = new PUdp(name, parms->size());


### PR DESCRIPTION
While trying to simulate a larger ASIC design (together with some technology libraries), I came across two major annoyances:
  - The technology files redefine primitives with the same content in multiple places, and can not easily be altered
  - The technology files make heavy use of timing checks, many of them using the unsupported ifnone+edge-sensitive path construct.

In the end I got my simulations working and maybe the changes I needed to do to iverilog can be acceptable for mainline. As altering the vendor libraries is not really an option for me and these two things seem to be commonly used, maybe it can increase adoption of iverilog for such uses.

As it was at times hard for me to figure out, which messages from iverilog are errors and which are warnings, I also tried improving the distinction between the two.