### PR TITLE
Fix redefinition of YYLTYPE struct caused by wrong include order

### DIFF
--- a/driver/cflexor.lex
+++ b/driver/cflexor.lex
@@ -22,8 +22,8 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-# include  "cfparse.h"
 # include  "cfparse_misc.h"
+# include  "cfparse.h"
 # include  "globals.h"
 # include  <string.h>
 


### PR DESCRIPTION
cfparse.h defines the YYLTYPE struct in case it has not been defined, and
also declares an extern YYLTYPE cflloc which is used in cflexor.

As cfparse_misc.h defines an extended YYLTYPE, the cflloc instance in
cfparse.c has this extended type, i.e. there is a type mismatch.

Changing the include order in cflexor causes both cflexor.c and
cfparse.c to use the definition from cfparse_misc.h.

This has been uncovered by GCC when using LTO:
```
gcc -flto=8 main.o substit.o cflexor.o cfparse.o -o iverilog 
cfparse.h:105:16: warning: type of 'cflloc' does not match original declaration [-Wlto-type-mismatch]
  105 | extern YYLTYPE cflloc;
      |                ^
cfparse.c:1162:9: note: type 'struct cfltype' should match type 'struct YYLTYPE'
 1162 | YYLTYPE yylloc
      |         ^
cfparse.c:1162:9: note: 'cflloc' was previously declared here
cfparse.c:1162:9: note: code may be misoptimized unless '-fno-strict-aliasing' is used

```