### PR TITLE
replace deprecated yacc directives

### DIFF
--- a/tgt-pcb/fp.y
+++ b/tgt-pcb/fp.y
@@ -1,5 +1,5 @@
 
-%pure-parser
+%define api.pure
 %parse-param {const char*file_path}
 
 %{

--- a/vhdlpp/parse.y
+++ b/vhdlpp/parse.y
@@ -1,5 +1,5 @@
 
-%pure-parser
+%define api.pure
 %lex-param { yyscan_t yyscanner }
 %parse-param {yyscan_t yyscanner  }
 %parse-param {const char*file_path}


### PR DESCRIPTION
bison 3.4.2 complains when encountering '%pure-parser':
"warning: deprecated directive, use ‘%define api.pure’"

A quick google suggests this option has been around since at least
2012, maybe longer, so probably safe to replace.

Signed-off-by: Nicholas Sielicki <sielicki@yandex.com>