### PR TITLE
SystemVerilog case qualifier support

### DIFF
--- a/Statement.cc
+++ b/Statement.cc
@@ -206,8 +206,8 @@ const pform_name_t& PCallTask::path() const
       return path_;
 }
 
-PCase::PCase(NetCase::TYPE t, PExpr*ex, svector<PCase::Item*>*l)
-: type_(t), expr_(ex), items_(l)
+PCase::PCase(NetCase::TYPE t, ivl_case_qualifier_t q, PExpr*ex, svector<PCase::Item*>*l)
+    : type_(t), qualifier_(q), expr_(ex), items_(l)
 {
 }
 

--- a/Statement.h
+++ b/Statement.h
@@ -254,7 +254,7 @@ class PCase  : public Statement {
 	    Statement*stat;
       };
 
-      PCase(NetCase::TYPE, PExpr*ex, svector<Item*>*);
+      PCase(NetCase::TYPE, ivl_case_qualifier_t, PExpr*ex, svector<Item*>*);
       ~PCase();
 
       virtual NetProc* elaborate(Design*des, NetScope*scope) const;
@@ -264,6 +264,7 @@ class PCase  : public Statement {
 
     private:
       NetCase::TYPE type_;
+      ivl_case_qualifier_t qualifier_;
       PExpr*expr_;
 
       svector<Item*>*items_;

--- a/ivl_target.h
+++ b/ivl_target.h
@@ -456,6 +456,14 @@ typedef enum ivl_variable_type_e ENUM_UNSIGNED_INT {
       IVL_VT_VECTOR = IVL_VT_LOGIC /* For compatibility */
 } ivl_variable_type_t;
 
+/* Qualifier attached to a case (or if/else) statement */
+typedef enum ivl_case_qualifier_e {
+      IVL_CQ_NONE     = 0,
+      IVL_CQ_PRIORITY = 1,
+      IVL_CQ_UNIQUE   = 2,
+      IVL_CQ_UNIQUE0  = 3
+} ivl_case_qualifier_t;
+
 /* This is the type of the function to apply to a process. */
 typedef int (*ivl_process_f)(ivl_process_t net, void*cd);
 


### PR DESCRIPTION
This allows SystemVerilog priority and unique case qualifiers to be parsed, and causes the runtime engine to issue a warning for timesteps where an unexpected value is seen.