### PR TITLE
Fix MinGW compilation issues

### DIFF
--- a/ivl.def
+++ b/ivl.def
@@ -302,6 +302,7 @@ ivl_stmt_parm_count
 ivl_stmt_rval
 ivl_stmt_sfunc_as_task
 ivl_stmt_sub_stmt
+ivl_stmt_case_quality
 
 ivl_switch_a
 ivl_switch_b

--- a/vpi/fstapi.c
+++ b/vpi/fstapi.c
@@ -313,6 +313,7 @@ return(NULL);
 #include <limits.h>
 #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
 #define fstMunmap(__addr,__len)                         free(__addr)
+#define MAP_FAILED (void*)-1 
 
 static void *fstMmap2(size_t __len, int __fd, off_t __off)
 {


### PR DESCRIPTION
The current version does not compile in mingw (using steps described on https://iverilog.fandom.com/wiki/Installation_using_MSYS2). 

A quick review of the code had shown that this is due to recently introduced changes. There are two problems that break the compilation (using gcc-8.3.0):
-  ivl_stmt_case_quality is not defined in ivl.def so tgt-stub cannot be linked
- mmap.h is absent in msys2, so MAP_FAILED is not defined (breaking the compilation of vpi/fstapi.c)

 By making the corresponding changes it compiles perfectly.