### PR TITLE
Update lexor.lex

### DIFF
--- a/ivlpp/lexor.lex
+++ b/ivlpp/lexor.lex
@@ -625,7 +625,7 @@ keywords (include|define|undef|ifdef|ifndef|else|elseif|endif)
     fputc('\n', yyout);
 }
 
-<<EOF>> { if (!load_next_input()) yyterminate(); }
+<<EOF>> { fputc('\n', yyout); if (!load_next_input()) yyterminate(); }
 
 %%
  /* Defined macros are kept in this table for convenient lookup. As


### PR DESCRIPTION
Change on the ivlpp lex file to always append a newline character after EOF. This solves the problem when concatenating files using -E with files that do not finish with a newline character.

Example results can be in the form 'endmodulemodule <module_name>(...)'.

This change will result to the following:
'endmodule
module <module_name>(...)'