### PR TITLE
Makefile.in: fix mkdir race during "make -j N install"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -332,40 +332,40 @@ endif
 install: all installdirs $(libdir)/ivl$(suffix)/ivl@EXEEXT@  $(libdir)/ivl$(suffix)/include/constants.vams $(libdir)/ivl$(suffix)/include/disciplines.vams $(includedir)/ivl_target.h $(includedir)/_pli_types.h $(includedir)/sv_vpi_user.h $(includedir)/vpi_user.h $(includedir)/acc_user.h $(includedir)/veriuser.h $(WIN32_INSTALL) $(INSTALL_DOC)
 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ && ) true
 
-$(bindir)/iverilog-vpi$(suffix): ./iverilog-vpi
+$(bindir)/iverilog-vpi$(suffix): ./iverilog-vpi installdirs
 	$(INSTALL_SCRIPT) ./iverilog-vpi "$(DESTDIR)$(bindir)/iverilog-vpi$(suffix)"
 
-$(libdir)/ivl$(suffix)/ivl@EXEEXT@: ./ivl@EXEEXT@
+$(libdir)/ivl$(suffix)/ivl@EXEEXT@: ./ivl@EXEEXT@ installdirs
 	$(INSTALL_PROGRAM) ./ivl@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivl@EXEEXT@"
 
-$(libdir)/ivl$(suffix)/include/constants.vams: $(srcdir)/constants.vams
+$(libdir)/ivl$(suffix)/include/constants.vams: $(srcdir)/constants.vams installdirs
 	$(INSTALL_DATA) $(srcdir)/constants.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/constants.vams"
 
-$(libdir)/ivl$(suffix)/include/disciplines.vams: $(srcdir)/disciplines.vams
+$(libdir)/ivl$(suffix)/include/disciplines.vams: $(srcdir)/disciplines.vams installdirs
 	$(INSTALL_DATA) $(srcdir)/disciplines.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/disciplines.vams"
 
-$(includedir)/ivl_target.h: $(srcdir)/ivl_target.h
+$(includedir)/ivl_target.h: $(srcdir)/ivl_target.h installdirs
 	$(INSTALL_DATA) $(srcdir)/ivl_target.h "$(DESTDIR)$(includedir)/ivl_target.h"
 
-$(includedir)/_pli_types.h: _pli_types.h
+$(includedir)/_pli_types.h: _pli_types.h installdirs
 	$(INSTALL_DATA) $< "$(DESTDIR)$(includedir)/_pli_types.h"
 
-$(includedir)/sv_vpi_user.h: $(srcdir)/sv_vpi_user.h
+$(includedir)/sv_vpi_user.h: $(srcdir)/sv_vpi_user.h installdirs
 	$(INSTALL_DATA) $(srcdir)/sv_vpi_user.h "$(DESTDIR)$(includedir)/sv_vpi_user.h"
 
-$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h
+$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h installdirs
 	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
 
-$(includedir)/acc_user.h: $(srcdir)/acc_user.h
+$(includedir)/acc_user.h: $(srcdir)/acc_user.h installdirs
 	$(INSTALL_DATA) $(srcdir)/acc_user.h "$(DESTDIR)$(includedir)/acc_user.h"
 
-$(includedir)/veriuser.h: $(srcdir)/veriuser.h
+$(includedir)/veriuser.h: $(srcdir)/veriuser.h installdirs
 	$(INSTALL_DATA) $(srcdir)/veriuser.h "$(DESTDIR)$(includedir)/veriuser.h"
 
-$(mandir)/man1/iverilog-vpi$(suffix).1: iverilog-vpi.man
+$(mandir)/man1/iverilog-vpi$(suffix).1: iverilog-vpi.man installdirs
 	$(INSTALL_DATA) iverilog-vpi.man "$(DESTDIR)$(mandir)/man1/iverilog-vpi$(suffix).1"
 
-$(prefix)/iverilog-vpi$(suffix).pdf: iverilog-vpi.pdf
+$(prefix)/iverilog-vpi$(suffix).pdf: iverilog-vpi.pdf installdirs
 	$(INSTALL_DATA) iverilog-vpi.pdf "$(DESTDIR)$(prefix)/iverilog-vpi$(suffix).pdf"
 
 


### PR DESCRIPTION
Without the dependency on `installdirs`, when running `make -j N DESTDIR=/somewhere install`, those file installation targets might run concurrently with the mkinstalldirs target, which might lead to file not found errors.

For example:
```
$ make -j24 DESTDIR=/var/tmp/portage/sci-electronics/iverilog-10.3/image install
....
mkdir -p -- /var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/bin /var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/include/iverilog /var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/lib64/ivl /var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/lib64/ivl/include /var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/share/man /var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/share/man/man1
/usr/bin/install: cannot create regular file '/var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/lib64/ivl/include/disciplines.vams': No such file or directory
/usr/bin/install: cannot create regular file '/var/tmp/portage/sci-electronics/iverilog-10.3/image/usr/lib64/ivl/ivl': No such file or directory
make: *** [Makefile:345: /usr/lib64/ivl/include/disciplines.vams] Error 1
``` 