### PR TITLE
Fix iverilog files not update bug during overwrite installation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -308,66 +308,61 @@ version_tag.h version:
 
 ifeq (@MINGW32@,yes)
 ifeq ($(MAN),none)
-INSTALL_DOC = $(mandir)/man1/iverilog-vpi$(suffix).1
+INSTALL_DOC = installman
 else
 ifeq ($(PS2PDF),none)
-INSTALL_DOC = $(mandir)/man1/iverilog-vpi$(suffix).1
+INSTALL_DOC = installman
 else
-INSTALL_DOC = $(prefix)/iverilog-vpi$(suffix).pdf $(mandir)/man1/iverilog-vpi$(suffix).1
+INSTALL_DOC = installpdf installman
 all: dep iverilog-vpi.pdf
 endif
 endif
 INSTALL_DOCDIR = $(mandir)/man1
 else
-INSTALL_DOC = $(mandir)/man1/iverilog-vpi$(suffix).1
+INSTALL_DOC = installman
 INSTALL_DOCDIR = $(mandir)/man1
 endif
 
 ifeq (@MINGW32@,yes)
 WIN32_INSTALL =
 else
-WIN32_INSTALL = $(bindir)/iverilog-vpi$(suffix)
+WIN32_INSTALL = installwin32
 endif
 
-install: all installdirs $(libdir)/ivl$(suffix)/ivl@EXEEXT@  $(libdir)/ivl$(suffix)/include/constants.vams $(libdir)/ivl$(suffix)/include/disciplines.vams $(includedir)/ivl_target.h $(includedir)/_pli_types.h $(includedir)/sv_vpi_user.h $(includedir)/vpi_user.h $(includedir)/acc_user.h $(includedir)/veriuser.h $(WIN32_INSTALL) $(INSTALL_DOC)
+install: all installdirs installfiles
 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ && ) true
 
-$(bindir)/iverilog-vpi$(suffix): ./iverilog-vpi installdirs
+F = ./ivl@EXEEXT@ \
+	$(srcdir)/constants.vams \
+	$(srcdir)/disciplines.vams \
+	$(srcdir)/ivl_target.h \
+	./_pli_types.h \
+	$(srcdir)/sv_vpi_user.h \
+	$(srcdir)/vpi_user.h \
+	$(srcdir)/acc_user.h \
+	$(srcdir)/veriuser.h \
+	$(INSTALL_DOC) \
+	$(WIN32_INSTALL)
+
+installwin32: ./iverilog-vpi installdirs
 	$(INSTALL_SCRIPT) ./iverilog-vpi "$(DESTDIR)$(bindir)/iverilog-vpi$(suffix)"
 
-$(libdir)/ivl$(suffix)/ivl@EXEEXT@: ./ivl@EXEEXT@ installdirs
-	$(INSTALL_PROGRAM) ./ivl@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivl@EXEEXT@"
-
-$(libdir)/ivl$(suffix)/include/constants.vams: $(srcdir)/constants.vams installdirs
-	$(INSTALL_DATA) $(srcdir)/constants.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/constants.vams"
-
-$(libdir)/ivl$(suffix)/include/disciplines.vams: $(srcdir)/disciplines.vams installdirs
-	$(INSTALL_DATA) $(srcdir)/disciplines.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/disciplines.vams"
-
-$(includedir)/ivl_target.h: $(srcdir)/ivl_target.h installdirs
-	$(INSTALL_DATA) $(srcdir)/ivl_target.h "$(DESTDIR)$(includedir)/ivl_target.h"
-
-$(includedir)/_pli_types.h: _pli_types.h installdirs
-	$(INSTALL_DATA) $< "$(DESTDIR)$(includedir)/_pli_types.h"
-
-$(includedir)/sv_vpi_user.h: $(srcdir)/sv_vpi_user.h installdirs
-	$(INSTALL_DATA) $(srcdir)/sv_vpi_user.h "$(DESTDIR)$(includedir)/sv_vpi_user.h"
-
-$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h installdirs
-	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
-
-$(includedir)/acc_user.h: $(srcdir)/acc_user.h installdirs
-	$(INSTALL_DATA) $(srcdir)/acc_user.h "$(DESTDIR)$(includedir)/acc_user.h"
-
-$(includedir)/veriuser.h: $(srcdir)/veriuser.h installdirs
-	$(INSTALL_DATA) $(srcdir)/veriuser.h "$(DESTDIR)$(includedir)/veriuser.h"
-
-$(mandir)/man1/iverilog-vpi$(suffix).1: iverilog-vpi.man installdirs
+installman: iverilog-vpi.man installdirs
 	$(INSTALL_DATA) iverilog-vpi.man "$(DESTDIR)$(mandir)/man1/iverilog-vpi$(suffix).1"
 
-$(prefix)/iverilog-vpi$(suffix).pdf: iverilog-vpi.pdf installdirs
+installpdf: iverilog-vpi.pdf installdirs
 	$(INSTALL_DATA) iverilog-vpi.pdf "$(DESTDIR)$(prefix)/iverilog-vpi$(suffix).pdf"
 
+installfiles: $(F) installdirs
+	$(INSTALL_PROGRAM) ./ivl@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivl@EXEEXT@"
+	$(INSTALL_DATA) $(srcdir)/constants.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/constants.vams"
+	$(INSTALL_DATA) $(srcdir)/disciplines.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/disciplines.vams"
+	$(INSTALL_DATA) $(srcdir)/ivl_target.h "$(DESTDIR)$(includedir)/ivl_target.h"
+	$(INSTALL_DATA) ./_pli_types.h "$(DESTDIR)$(includedir)/_pli_types.h"
+	$(INSTALL_DATA) $(srcdir)/sv_vpi_user.h "$(DESTDIR)$(includedir)/sv_vpi_user.h"
+	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
+	$(INSTALL_DATA) $(srcdir)/acc_user.h "$(DESTDIR)$(includedir)/acc_user.h"
+	$(INSTALL_DATA) $(srcdir)/veriuser.h "$(DESTDIR)$(includedir)/veriuser.h"
 
 installdirs: $(srcdir)/mkinstalldirs
 	$(srcdir)/mkinstalldirs "$(DESTDIR)$(bindir)" \

--- a/Makefile.in
+++ b/Makefile.in
@@ -353,7 +353,7 @@ installman: iverilog-vpi.man installdirs
 installpdf: iverilog-vpi.pdf installdirs
 	$(INSTALL_DATA) iverilog-vpi.pdf "$(DESTDIR)$(prefix)/iverilog-vpi$(suffix).pdf"
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./ivl@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivl@EXEEXT@"
 	$(INSTALL_DATA) $(srcdir)/constants.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/constants.vams"
 	$(INSTALL_DATA) $(srcdir)/disciplines.vams "$(DESTDIR)$(libdir)/ivl$(suffix)/include/disciplines.vams"

--- a/cadpli/Makefile.in
+++ b/cadpli/Makefile.in
@@ -79,9 +79,11 @@ endif
 cadpli.vpl: $O ../vpi/libvpi.a ../libveriuser/libveriuser.o
 	$(CC) @shared@ $(LDFLAGS) -o $@ $O ../libveriuser/libveriuser.o $(SYSTEM_VPI_LDFLAGS)
 
-install: all installdirs $(vpidir)/cadpli.vpl
+install: all installdirs installfiles
 
-$(vpidir)/cadpli.vpl: ./cadpli.vpl
+F = ./cadpli.vpl
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./cadpli.vpl "$(DESTDIR)$(vpidir)/cadpli.vpl"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/cadpli/Makefile.in
+++ b/cadpli/Makefile.in
@@ -83,7 +83,7 @@ install: all installdirs installfiles
 
 F = ./cadpli.vpl
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./cadpli.vpl "$(DESTDIR)$(vpidir)/cadpli.vpl"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/driver-vpi/Makefile.in
+++ b/driver-vpi/Makefile.in
@@ -98,7 +98,7 @@ install: all installdirs installfiles
 
 F = ./iverilog-vpi@EXEEXT@
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./iverilog-vpi@EXEEXT@ "$(bindir)/iverilog-vpi$(suffix)@EXEEXT@"
 ifeq (@WIN32@,yes)
 ifneq ($(HOSTCC),$(CC))

--- a/driver-vpi/Makefile.in
+++ b/driver-vpi/Makefile.in
@@ -94,9 +94,11 @@ res.o: res.rc
 	$(WINDRES) -i res.rc -o res.o
 #
 
-install: all installdirs $(bindir)/iverilog-vpi$(suffix)@EXEEXT@
+install: all installdirs installfiles
 
-$(bindir)/iverilog-vpi$(suffix)@EXEEXT@: ./iverilog-vpi@EXEEXT@
+F = ./iverilog-vpi@EXEEXT@
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./iverilog-vpi@EXEEXT@ "$(bindir)/iverilog-vpi$(suffix)@EXEEXT@"
 ifeq (@WIN32@,yes)
 ifneq ($(HOSTCC),$(CC))

--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -112,31 +112,34 @@ iverilog.pdf: iverilog.ps
 
 ifeq (@MINGW32@,yes)
 ifeq ($(MAN),none)
-INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
+INSTALL_DOC = installman
 else
 ifeq ($(PS2PDF),none)
-INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
+INSTALL_DOC = installman
 else
-INSTALL_DOC = $(prefix)/iverilog$(suffix).pdf $(mandir)/man1/iverilog$(suffix).1
+INSTALL_DOC = installpdf installman
 all: iverilog.pdf
 endif
 endif
 INSTALL_DOCDIR = $(mandir)/man1
 else
-INSTALL_DOC = $(mandir)/man1/iverilog$(suffix).1
+INSTALL_DOC = installman
 INSTALL_DOCDIR = $(mandir)/man1
 endif
 
-install: all installdirs $(bindir)/iverilog$(suffix)@EXEEXT@ $(INSTALL_DOC)
+install: all installdirs installfiles
 
-$(bindir)/iverilog$(suffix)@EXEEXT@: ./iverilog@EXEEXT@
-	$(INSTALL_PROGRAM) ./iverilog@EXEEXT@ "$(DESTDIR)$(bindir)/iverilog$(suffix)@EXEEXT@"
+F = ./iverilog@EXEEXT@ \
+	$(INSTALL_DOC)
 
-$(mandir)/man1/iverilog$(suffix).1: iverilog.man
+installman: iverilog.man installdirs
 	$(INSTALL_DATA) iverilog.man "$(DESTDIR)$(mandir)/man1/iverilog$(suffix).1"
 
-$(prefix)/iverilog$(suffix).pdf: iverilog.pdf
+installpdf: iverilog.pdf installdirs
 	$(INSTALL_DATA) iverilog.pdf "$(DESTDIR)$(prefix)/iverilog$(suffix).pdf"
+
+installfiles: $(F) installdirs
+	$(INSTALL_PROGRAM) ./iverilog@EXEEXT@ "$(DESTDIR)$(bindir)/iverilog$(suffix)@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(INSTALL_DOCDIR)"

--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -138,7 +138,7 @@ installman: iverilog.man installdirs
 installpdf: iverilog.pdf installdirs
 	$(INSTALL_DATA) iverilog.pdf "$(DESTDIR)$(prefix)/iverilog$(suffix).pdf"
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./iverilog@EXEEXT@ "$(DESTDIR)$(bindir)/iverilog$(suffix)@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/ivlpp/Makefile.in
+++ b/ivlpp/Makefile.in
@@ -75,7 +75,7 @@ install: all installdirs installfiles
 
 F = ivlpp@EXEEXT@
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./ivlpp@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivlpp@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/ivlpp/Makefile.in
+++ b/ivlpp/Makefile.in
@@ -71,9 +71,11 @@ ivlpp@EXEEXT@: $O
 lexor.c: $(srcdir)/lexor.lex
 	$(LEX) -t $< > $@
 
-install: all installdirs $(libdir)/ivl$(suffix)/ivlpp@EXEEXT@
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/ivlpp@EXEEXT@: ivlpp@EXEEXT@
+F = ivlpp@EXEEXT@
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./ivlpp@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/ivlpp@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/libveriuser/Makefile.in
+++ b/libveriuser/Makefile.in
@@ -103,9 +103,11 @@ libveriuser.a: libveriuser.o
 	$(CC) $(CPPFLAGS) $(CFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
 	mv $*.d dep
 
-install:: all installdirs $(libdir)/libveriuser$(suffix).a $(INSTALL32)
+install:: all installdirs installfiles
 
-$(libdir)/libveriuser$(suffix).a: ./libveriuser.a
+F = ./libveriuser.a
+
+installfiles: $(F) installdirs
 	$(INSTALL_DATA) ./libveriuser.a "$(DESTDIR)$(libdir)/libveriuser$(suffix).a"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/libveriuser/Makefile.in
+++ b/libveriuser/Makefile.in
@@ -107,7 +107,7 @@ install:: all installdirs installfiles
 
 F = ./libveriuser.a
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_DATA) ./libveriuser.a "$(DESTDIR)$(libdir)/libveriuser$(suffix).a"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/tgt-blif/Makefile.in
+++ b/tgt-blif/Makefile.in
@@ -83,17 +83,16 @@ endif
 blif.tgt: $O $(TGTDEPLIBS)
 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl$(suffix)/blif.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/blif.conf $(libdir)/ivl$(suffix)/blif-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/blif.tgt: ./blif.tgt
+F = ./blif.tgt \
+	$(srcdir)/blif.conf \
+	$(srcdir)/blif-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./blif.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.tgt"
-
-$(libdir)/ivl$(suffix)/blif.conf: $(srcdir)/blif.conf
 	$(INSTALL_DATA) $(srcdir)/blif.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.conf"
-
-$(libdir)/ivl$(suffix)/blif-s.conf: $(srcdir)/blif-s.conf
 	$(INSTALL_DATA) $(srcdir)/blif-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/blif-s.conf"
-
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-blif/Makefile.in
+++ b/tgt-blif/Makefile.in
@@ -89,7 +89,7 @@ F = ./blif.tgt \
 	$(srcdir)/blif.conf \
 	$(srcdir)/blif-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./blif.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.tgt"
 	$(INSTALL_DATA) $(srcdir)/blif.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/blif.conf"
 	$(INSTALL_DATA) $(srcdir)/blif-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/blif-s.conf"

--- a/tgt-fpga/Makefile.in
+++ b/tgt-fpga/Makefile.in
@@ -93,38 +93,38 @@ iverilog-fpga.pdf: iverilog-fpga.ps
 	ps2pdf iverilog-fpga.ps iverilog-fpga.pdf
 
 ifeq (@WIN32@,yes)
-INSTALL_DOC = $(prefix)/iverilog-fpga$(suffix).pdf $(mandir)/man1/iverilog-fpga$(suffix).1
+INSTALL_DOC = installpdf installman
 INSTALL_DOCDIR = $(mandir)/man1
 all: iverilog-fpga.pdf
 else
-INSTALL_DOC = $(mandir)/man1/iverilog-fpga$(suffix).1
+INSTALL_DOC = installman
 INSTALL_DOCDIR = $(mandir)/man1
 endif
 
-install: all installdirs $(libdir)/ivl$(suffix)/fpga.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/fpga.conf $(libdir)/ivl$(suffix)/fpga-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/fpga.tgt: ./fpga.tgt
-	$(INSTALL_PROGRAM) ./fpga.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
+F = ./fpga.tgt \
+	$(srcdir)/fpga.conf \
+	$(srcdir)/fpga-s.conf \
+	$(INSTALL_DOC)
 
-$(libdir)/ivl$(suffix)/fpga.conf: $(srcdir)/fpga.conf
-	$(INSTALL_DATA) $(srcdir)/fpga.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
-
-$(libdir)/ivl$(suffix)/fpga-s.conf: $(srcdir)/fpga-s.conf
-	$(INSTALL_DATA) $(srcdir)/fpga-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
-
-
-$(mandir)/man1/iverilog-fpga$(suffix).1: $(srcdir)/iverilog-fpga.man
+installman: installdirs
 	$(INSTALL_DATA) $(srcdir)/iverilog-fpga.man "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
 
-$(prefix)/iverilog-fpga$(suffix).pdf: iverilog-fpga.pdf
+installpdf: installdirs
 	$(INSTALL_DATA) iverilog-fpga.pdf "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf"
 
+installfiles: $(F) installdirs
+	$(INSTALL_PROGRAM) ./fpga.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
+	$(INSTALL_DATA) $(srcdir)/fpga.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
+	$(INSTALL_DATA) $(srcdir)/fpga-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
+
 installdirs: $(srcdir)/../mkinstalldirs
-	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"
+	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)" "$(DESTDIR)$(INSTALL_DOCDIR)"
 
 uninstall:
 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
-	rm -f "$(DESTDIR)$(INSTALL_DOC)"
+	rm -f "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf" "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
 

--- a/tgt-fpga/Makefile.in
+++ b/tgt-fpga/Makefile.in
@@ -108,10 +108,10 @@ F = ./fpga.tgt \
 	$(srcdir)/fpga-s.conf \
 	$(INSTALL_DOC)
 
-installman: installdirs
+installman: $(srcdir)/iverilog-fpga.man installdirs
 	$(INSTALL_DATA) $(srcdir)/iverilog-fpga.man "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
 
-installpdf: installdirs
+installpdf: iverilog-fpga.pdf installdirs
 	$(INSTALL_DATA) iverilog-fpga.pdf "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf"
 
 installfiles: $(F) installdirs

--- a/tgt-fpga/Makefile.in
+++ b/tgt-fpga/Makefile.in
@@ -114,7 +114,7 @@ installman: $(srcdir)/iverilog-fpga.man installdirs
 installpdf: iverilog-fpga.pdf installdirs
 	$(INSTALL_DATA) iverilog-fpga.pdf "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf"
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./fpga.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
 	$(INSTALL_DATA) $(srcdir)/fpga.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
 	$(INSTALL_DATA) $(srcdir)/fpga-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"

--- a/tgt-null/Makefile.in
+++ b/tgt-null/Makefile.in
@@ -81,17 +81,16 @@ endif
 null.tgt: $O $(TGTDEPLIBS)
 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl$(suffix)/null.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/null.conf $(libdir)/ivl$(suffix)/null-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/null.tgt: ./null.tgt
+F = ./null.tgt \
+	$(srcdir)/null.conf \
+	$(srcdir)/null-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./null.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/null.tgt"
-
-$(libdir)/ivl$(suffix)/null.conf: $(srcdir)/null.conf
 	$(INSTALL_DATA) $(srcdir)/null.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/null.conf"
-
-$(libdir)/ivl$(suffix)/null-s.conf: $(srcdir)/null-s.conf
 	$(INSTALL_DATA) $(srcdir)/null-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/null-s.conf"
-
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-null/Makefile.in
+++ b/tgt-null/Makefile.in
@@ -87,7 +87,7 @@ F = ./null.tgt \
 	$(srcdir)/null.conf \
 	$(srcdir)/null-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./null.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/null.tgt"
 	$(INSTALL_DATA) $(srcdir)/null.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/null.conf"
 	$(INSTALL_DATA) $(srcdir)/null-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/null-s.conf"

--- a/tgt-pal/Makefile.in
+++ b/tgt-pal/Makefile.in
@@ -84,7 +84,7 @@ install: all installdirs installfiles
 
 F = ./pal.tgt
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./pal.tgt "$(DESTDIR)$(libdir)/ivl/pal.tgt"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/tgt-pal/Makefile.in
+++ b/tgt-pal/Makefile.in
@@ -80,11 +80,12 @@ endif
 pal.tgt: $O $(TGTDEPLIBS)
 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS) -lipal
 
-install: all installdirs $(libdir)/ivl/pal.tgt
+install: all installdirs installfiles
 
-$(libdir)/ivl/pal.tgt: ./pal.tgt
+F = ./pal.tgt
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./pal.tgt "$(DESTDIR)$(libdir)/ivl/pal.tgt"
-
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)/$(libdir)/ivl"

--- a/tgt-pcb/Makefile.in
+++ b/tgt-pcb/Makefile.in
@@ -105,17 +105,16 @@ endif
 pcb.tgt: $O $(TGTDEPLIBS)
 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl$(suffix)/pcb.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/pcb.conf $(libdir)/ivl$(suffix)/pcb-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/pcb.tgt: ./pcb.tgt
+F = ./pcb.tgt \
+	$(srcdir)/pcb.conf \
+	$(srcdir)/pcb-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./pcb.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.tgt"
-
-$(libdir)/ivl$(suffix)/pcb.conf: $(srcdir)/pcb.conf
 	$(INSTALL_DATA) $(srcdir)/pcb.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.conf"
-
-$(libdir)/ivl$(suffix)/pcb-s.conf: $(srcdir)/pcb-s.conf
 	$(INSTALL_DATA) $(srcdir)/pcb-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb-s.conf"
-
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-pcb/Makefile.in
+++ b/tgt-pcb/Makefile.in
@@ -111,7 +111,7 @@ F = ./pcb.tgt \
 	$(srcdir)/pcb.conf \
 	$(srcdir)/pcb-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./pcb.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.tgt"
 	$(INSTALL_DATA) $(srcdir)/pcb.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb.conf"
 	$(INSTALL_DATA) $(srcdir)/pcb-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/pcb-s.conf"

--- a/tgt-sizer/Makefile.in
+++ b/tgt-sizer/Makefile.in
@@ -87,7 +87,7 @@ F = ./sizer.tgt \
 	$(srcdir)/sizer.conf \
 	$(srcdir)/sizer-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./sizer.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.tgt"
 	$(INSTALL_DATA) $(srcdir)/sizer.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.conf"
 	$(INSTALL_DATA) $(srcdir)/sizer-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer-s.conf"

--- a/tgt-sizer/Makefile.in
+++ b/tgt-sizer/Makefile.in
@@ -81,17 +81,16 @@ endif
 sizer.tgt: $O $(TGTDEPLIBS)
 	$(CXX) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl$(suffix)/sizer.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/sizer.conf $(libdir)/ivl$(suffix)/sizer-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/sizer.tgt: ./sizer.tgt
+F = ./sizer.tgt \
+	$(srcdir)/sizer.conf \
+	$(srcdir)/sizer-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./sizer.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.tgt"
-
-$(libdir)/ivl$(suffix)/sizer.conf: $(srcdir)/sizer.conf
 	$(INSTALL_DATA) $(srcdir)/sizer.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer.conf"
-
-$(libdir)/ivl$(suffix)/sizer-s.conf: $(srcdir)/sizer-s.conf
 	$(INSTALL_DATA) $(srcdir)/sizer-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/sizer-s.conf"
-
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-stub/Makefile.in
+++ b/tgt-stub/Makefile.in
@@ -82,17 +82,16 @@ endif
 stub.tgt: $O $(TGTDEPLIBS)
 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl$(suffix)/stub.tgt \
-	$(libdir)/ivl$(suffix)/stub.conf $(libdir)/ivl$(suffix)/stub-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/stub.tgt: ./stub.tgt
+F = ./stub.tgt \
+	./stub.conf \
+	./stub-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./stub.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.tgt"
-
-$(libdir)/ivl$(suffix)/stub.conf: stub.conf
-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
-
-$(libdir)/ivl$(suffix)/stub-s.conf: stub-s.conf
-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"
+	$(INSTALL_DATA) ./stub.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
+	$(INSTALL_DATA) ./stub-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-stub/Makefile.in
+++ b/tgt-stub/Makefile.in
@@ -88,7 +88,7 @@ F = ./stub.tgt \
 	$(srcdir)/stub.conf \
 	$(srcdir)/stub-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./stub.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.tgt"
 	$(INSTALL_DATA) $(srcdir)/stub.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
 	$(INSTALL_DATA) $(srcdir)/stub-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"

--- a/tgt-stub/Makefile.in
+++ b/tgt-stub/Makefile.in
@@ -85,13 +85,13 @@ stub.tgt: $O $(TGTDEPLIBS)
 install: all installdirs installfiles
 
 F = ./stub.tgt \
-	./stub.conf \
-	./stub-s.conf
+	$(srcdir)/stub.conf \
+	$(srcdir)/stub-s.conf
 
 installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./stub.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.tgt"
-	$(INSTALL_DATA) ./stub.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
-	$(INSTALL_DATA) ./stub-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"
+	$(INSTALL_DATA) $(srcdir)/stub.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub.conf"
+	$(INSTALL_DATA) $(srcdir)/stub-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/stub-s.conf"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-verilog/Makefile.in
+++ b/tgt-verilog/Makefile.in
@@ -85,7 +85,7 @@ install: all installdirs installfiles
 F = ./verilog.tgt \
 	$(srcdir)/vpi_user.h
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./verilog.tgt "$(DESTDIR)$(libdir)/ivl/verilog.tgt"
 	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
 

--- a/tgt-verilog/Makefile.in
+++ b/tgt-verilog/Makefile.in
@@ -80,12 +80,14 @@ endif
 verilog.tgt: $O $(TGTDEPLIBS)
 	$(CC) @shared@ $(LDFLAGS) -o $@ $O $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl/verilog.tgt \
-	$(includedir)/vpi_user.h
+install: all installdirs installfiles
 
-$(libdir)/ivl/verilog.tgt: ./verilog.tgt
+F = ./verilog.tgt \
+	$(srcdir)/vpi_user.h
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./verilog.tgt "$(DESTDIR)$(libdir)/ivl/verilog.tgt"
-
+	$(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl"

--- a/tgt-vhdl/Makefile.in
+++ b/tgt-vhdl/Makefile.in
@@ -93,13 +93,13 @@ vhdl_config.h: stamp-vhdl_config-h
 install: all installdirs installfiles
 
 F = ./vhdl.tgt \
-	./vhdl.conf \
-	./vhdl-s.conf
+	$(srcdir)/vhdl.conf \
+	$(srcdir)/vhdl-s.conf
 
 installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./vhdl.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.tgt"
-	$(INSTALL_DATA) ./vhdl.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
-	$(INSTALL_DATA) ./vhdl-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"
+	$(INSTALL_DATA) $(srcdir)/vhdl.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
+	$(INSTALL_DATA) $(srcdir)/vhdl-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-vhdl/Makefile.in
+++ b/tgt-vhdl/Makefile.in
@@ -96,7 +96,7 @@ F = ./vhdl.tgt \
 	$(srcdir)/vhdl.conf \
 	$(srcdir)/vhdl-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vhdl.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.tgt"
 	$(INSTALL_DATA) $(srcdir)/vhdl.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
 	$(INSTALL_DATA) $(srcdir)/vhdl-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"

--- a/tgt-vhdl/Makefile.in
+++ b/tgt-vhdl/Makefile.in
@@ -90,17 +90,16 @@ stamp-vhdl_config-h: $(srcdir)/vhdl_config.h.in ../config.status
 	cd ..; ./config.status --header=tgt-vhdl/vhdl_config.h
 vhdl_config.h: stamp-vhdl_config-h
 
-install: all installdirs $(libdir)/ivl$(suffix)/vhdl.tgt $(libdir)/ivl$(suffix)/vhdl.conf \
-	$(libdir)/ivl$(suffix)/vhdl-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/vhdl.tgt: ./vhdl.tgt
+F = ./vhdl.tgt \
+	./vhdl.conf \
+	./vhdl-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./vhdl.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.tgt"
-
-$(libdir)/ivl$(suffix)/vhdl.conf: vhdl.conf
-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
-
-$(libdir)/ivl$(suffix)/vhdl-s.conf: vhdl-s.conf
-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"
+	$(INSTALL_DATA) ./vhdl.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl.conf"
+	$(INSTALL_DATA) ./vhdl-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdl-s.conf"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-vlog95/Makefile.in
+++ b/tgt-vlog95/Makefile.in
@@ -81,17 +81,16 @@ endif
 vlog95.tgt: $O $(TGTDEPLIBS)
 	$(CC) @shared@ $(LDFLAGS) -o $@ $O -lm $(TGTLDFLAGS)
 
-install: all installdirs $(libdir)/ivl$(suffix)/vlog95.tgt $(INSTALL_DOC) $(libdir)/ivl$(suffix)/vlog95.conf $(libdir)/ivl$(suffix)/vlog95-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/vlog95.tgt: ./vlog95.tgt
+F = ./vlog95.tgt \
+	$(srcdir)/vlog95.conf \
+	$(srcdir)/vlog95-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./vlog95.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.tgt"
-
-$(libdir)/ivl$(suffix)/vlog95.conf: $(srcdir)/vlog95.conf
 	$(INSTALL_DATA) $(srcdir)/vlog95.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.conf"
-
-$(libdir)/ivl$(suffix)/vlog95-s.conf: $(srcdir)/vlog95-s.conf
 	$(INSTALL_DATA) $(srcdir)/vlog95-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95-s.conf"
-
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-vlog95/Makefile.in
+++ b/tgt-vlog95/Makefile.in
@@ -87,7 +87,7 @@ F = ./vlog95.tgt \
 	$(srcdir)/vlog95.conf \
 	$(srcdir)/vlog95-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vlog95.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.tgt"
 	$(INSTALL_DATA) $(srcdir)/vlog95.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95.conf"
 	$(INSTALL_DATA) $(srcdir)/vlog95-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vlog95-s.conf"

--- a/tgt-vvp/Makefile.in
+++ b/tgt-vvp/Makefile.in
@@ -104,17 +104,16 @@ stamp-vvp_config-h: $(srcdir)/vvp_config.h.in ../config.status
 	cd ..; ./config.status --header=tgt-vvp/vvp_config.h
 vvp_config.h: stamp-vvp_config-h
 
-install: all installdirs $(libdir)/ivl$(suffix)/vvp.tgt $(libdir)/ivl$(suffix)/vvp.conf $(libdir)/ivl$(suffix)/vvp-s.conf
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/vvp.tgt: ./vvp.tgt
+F = ./vvp.tgt \
+	./vvp.conf \
+	./vvp-s.conf
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./vvp.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.tgt"
-
-$(libdir)/ivl$(suffix)/vvp.conf: vvp.conf
-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.conf"
-
-$(libdir)/ivl$(suffix)/vvp-s.conf: vvp-s.conf
-	$(INSTALL_DATA) $< "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp-s.conf"
-
+	$(INSTALL_DATA) ./vvp.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.conf"
+	$(INSTALL_DATA) ./vvp-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp-s.conf"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(libdir)/ivl$(suffix)"

--- a/tgt-vvp/Makefile.in
+++ b/tgt-vvp/Makefile.in
@@ -110,7 +110,7 @@ F = ./vvp.tgt \
 	./vvp.conf \
 	./vvp-s.conf
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vvp.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.tgt"
 	$(INSTALL_DATA) ./vvp.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp.conf"
 	$(INSTALL_DATA) ./vvp-s.conf "$(DESTDIR)$(libdir)/ivl$(suffix)/vvp-s.conf"

--- a/vhdlpp/Makefile.in
+++ b/vhdlpp/Makefile.in
@@ -127,9 +127,11 @@ lexor_keyword.o: lexor_keyword.cc parse.h
 lexor_keyword.cc: $(srcdir)/lexor_keyword.gperf
 	gperf -o -i 7 --ignore-case -C -k 1-4,6,9,$$ -H keyword_hash -N check_identifier -t $(srcdir)/lexor_keyword.gperf > lexor_keyword.cc || (rm -f lexor_keyword.cc ; false)
 
-install: all installdirs $(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@
+install: all installdirs installfiles
 
-$(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@: vhdlpp@EXEEXT@
+F = vhdlpp@EXEEXT@
+
+installfiles: $(F) installdirs
 	$(INSTALL_PROGRAM) ./vhdlpp@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/vhdlpp/Makefile.in
+++ b/vhdlpp/Makefile.in
@@ -131,7 +131,7 @@ install: all installdirs installfiles
 
 F = vhdlpp@EXEEXT@
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vhdlpp@EXEEXT@ "$(DESTDIR)$(libdir)/ivl$(suffix)/vhdlpp@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/vpi/Makefile.in
+++ b/vpi/Makefile.in
@@ -187,38 +187,25 @@ stamp-vpi_config-h: $(srcdir)/vpi_config.h.in ../config.status
 	cd ..; ./config.status --header=vpi/vpi_config.h
 vpi_config.h: stamp-vpi_config-h
 
-install: all installdirs \
-    $(libdir)/libvpi$(suffix).a \
-    $(vpidir)/system.vpi \
-    $(vpidir)/va_math.vpi \
-    $(vpidir)/v2005_math.vpi \
-    $(vpidir)/v2009.vpi \
-    $(vpidir)/vhdl_sys.vpi \
-    $(vpidir)/vhdl_textio.vpi \
-    $(vpidir)/vpi_debug.vpi
+install: all installdirs installfiles
 
-$(libdir)/libvpi$(suffix).a : ./libvpi.a
-	$(INSTALL_DATA) libvpi.a "$(DESTDIR)$(libdir)/libvpi$(suffix).a"
+F = ./libvpi.a \
+	./system.vpi \
+	./va_math.vpi \
+	./v2005_math.vpi \
+	./v2009.vpi \
+	./vhdl_sys.vpi \
+	./vhdl_textio.vpi \
+	./vpi_debug.vpi
 
-$(vpidir)/system.vpi: ./system.vpi
+installfiles: $(F) installdirs
+	$(INSTALL_DATA) ./libvpi.a "$(DESTDIR)$(libdir)/libvpi$(suffix).a"
 	$(INSTALL_PROGRAM) ./system.vpi "$(DESTDIR)$(vpidir)/system.vpi"
-
-$(vpidir)/va_math.vpi: ./va_math.vpi
 	$(INSTALL_PROGRAM) ./va_math.vpi "$(DESTDIR)$(vpidir)/va_math.vpi"
-
-$(vpidir)/v2005_math.vpi: ./v2005_math.vpi
 	$(INSTALL_PROGRAM) ./v2005_math.vpi "$(DESTDIR)$(vpidir)/v2005_math.vpi"
-
-$(vpidir)/v2009.vpi: ./v2009.vpi
 	$(INSTALL_PROGRAM) ./v2009.vpi "$(DESTDIR)$(vpidir)/v2009.vpi"
-
-$(vpidir)/vhdl_sys.vpi: ./vhdl_sys.vpi
 	$(INSTALL_PROGRAM) ./vhdl_sys.vpi "$(DESTDIR)$(vpidir)/vhdl_sys.vpi"
-
-$(vpidir)/vhdl_textio.vpi: ./vhdl_textio.vpi
 	$(INSTALL_PROGRAM) ./vhdl_textio.vpi "$(DESTDIR)$(vpidir)/vhdl_textio.vpi"
-
-$(vpidir)/vpi_debug.vpi: ./vpi_debug.vpi
 	$(INSTALL_PROGRAM) ./vpi_debug.vpi "$(DESTDIR)$(vpidir)/vpi_debug.vpi"
 
 installdirs: $(srcdir)/../mkinstalldirs

--- a/vpi/Makefile.in
+++ b/vpi/Makefile.in
@@ -198,7 +198,7 @@ F = ./libvpi.a \
 	./vhdl_textio.vpi \
 	./vpi_debug.vpi
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_DATA) ./libvpi.a "$(DESTDIR)$(libdir)/libvpi$(suffix).a"
 	$(INSTALL_PROGRAM) ./system.vpi "$(DESTDIR)$(vpidir)/system.vpi"
 	$(INSTALL_PROGRAM) ./va_math.vpi "$(DESTDIR)$(vpidir)/va_math.vpi"

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -162,18 +162,18 @@ vvp.pdf: vvp.ps
 
 ifeq (@MINGW32@,yes)
 ifeq ($(MAN),none)
-INSTALL_DOC = $(mandir)/man1/vvp$(suffix).1
+INSTALL_DOC = installman
 else
 ifeq ($(PS2PDF),none)
-INSTALL_DOC = $(mandir)/man1/vvp$(suffix).1
+INSTALL_DOC = installman
 else
-INSTALL_DOC = $(prefix)/vvp$(suffix).pdf $(mandir)/man1/vvp$(suffix).1
+INSTALL_DOC = installpdf installman
 all: vvp.pdf
 endif
 endif
 INSTALL_DOCDIR = $(mandir)/man1
 else
-INSTALL_DOC = $(mandir)/man1/vvp$(suffix).1
+INSTALL_DOC = installman
 INSTALL_DOCDIR = $(mandir)/man1
 endif
 
@@ -182,16 +182,18 @@ stamp-config-h: $(srcdir)/config.h.in ../config.status
 	cd ..; ./config.status --header=vvp/config.h
 config.h: stamp-config-h
 
-install: all installdirs $(bindir)/vvp$(suffix)@EXEEXT@ $(INSTALL_DOC)
+install: all installdirs installfiles
 
-$(bindir)/vvp$(suffix)@EXEEXT@: ./vvp@EXEEXT@
-	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
+F = ./vvp@EXEEXT@ $(INSTALL_DOC)
 
-$(mandir)/man1/vvp$(suffix).1: vvp.man
+installman: installdirs
 	$(INSTALL_DATA) vvp.man "$(DESTDIR)$(mandir)/man1/vvp$(suffix).1"
 
-$(prefix)/vvp$(suffix).pdf: vvp.pdf
+installpdf: installdirs
 	$(INSTALL_DATA) vvp.pdf "$(DESTDIR)$(prefix)/vvp$(suffix).pdf"
+
+installfiles: $(F) installdirs
+	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" "$(DESTDIR)$(INSTALL_DOCDIR)"

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -186,10 +186,10 @@ install: all installdirs installfiles
 
 F = ./vvp@EXEEXT@ $(INSTALL_DOC)
 
-installman: installdirs
+installman: vvp.man installdirs
 	$(INSTALL_DATA) vvp.man "$(DESTDIR)$(mandir)/man1/vvp$(suffix).1"
 
-installpdf: installdirs
+installpdf: vvp.pdf installdirs
 	$(INSTALL_DATA) vvp.pdf "$(DESTDIR)$(prefix)/vvp$(suffix).pdf"
 
 installfiles: $(F) installdirs

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -192,7 +192,7 @@ installman: vvp.man installdirs
 installpdf: vvp.pdf installdirs
 	$(INSTALL_DATA) vvp.pdf "$(DESTDIR)$(prefix)/vvp$(suffix).pdf"
 
-installfiles: $(F) installdirs
+installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
 
 installdirs: $(srcdir)/../mkinstalldirs


### PR DESCRIPTION
The most original detailed information is here: https://bugs.gentoo.org/705412

## Detailed Description:

The original Makefile used a very unusual installation method, e.g., 

https://github.com/steveicarus/iverilog/blob/master/Makefile.in#L356

```Makefile
$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h installdirs
        $(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
```
It checks $(includedir)/vpi_user.h but installed to "$(DESTDIR)$(includedir)/vpi_user.h"

If an old version of iverilog is already installed, when download a new released compressed package and decompress it, the timestamp of source code may old and when doing overwrite installation, the old file may not update due to the installed file have new timestamp.

This causes some problems, which can happen in the following cases:

- bump version form source tar ball
- reinstallation form source tar ball

I'm thinking about how to fix it, firstly I've tried update the timestamp of all source

```bash
find . -exec touch {} +
```

It success but too dirty, I don't want recompile every time and it may cause other problem.

Also I'm thinking about change code like this:

```Makefile
e.g.,
$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h installdirs
        $(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
changed to
$(DESTDIR)$(includedir)/vpi_user.h: $(srcdir)/vpi_user.h installdirs
        $(INSTALL_DATA) $(srcdir)/vpi_user.h "$(DESTDIR)$(includedir)/vpi_user.h"
```
But it only fix the problem on gentoo Linux, In general the problem exist.

I also think about how to install by checksum files, but Makefile can't beautifully do it. 

Add ``.PHONY`` to ``install`` also too weird.

So, I don't use the above method.

In order to install correctly every time, the installation (```INSTALL_DATA/INSTALL_PROGRAM/INSTALL_SCRIPT```) should not just check the results based on timestamp, Instead, perform a true overwrite installation to ensure that the program behaves correctly.

Even if I install the new version first and then overwrite installation the old version of the iverilog, It is unreasonable not to install it due to timestamp is old.

I changed 20 `` Makefile.in `` files and use traditional method to do ```INSTALL_DATA/INSTALL_PROGRAM/INSTALL_SCRIPT```, by the way fix some hidden parallel compilation problem, improve the maintainability of the installation script to make it look simpler.


-----------------------------------


- Fix bug: https://bugs.gentoo.org/705412
- Fix bug: https://github.com/gentoo/gentoo/pull/14096
- Related: https://github.com/steveicarus/iverilog/pull/294