### PR TITLE
Add missing include for malloc

### DIFF
--- a/vvp/config.h.in
+++ b/vvp/config.h.in
@@ -196,6 +196,7 @@ inline int64_t i64round(double x)
 #endif
 
 #ifdef __MINGW32__
+# include  <cstdlib>
 # include  <string.h>
 static inline char*strndup(const char*s, size_t n)
 {


### PR DESCRIPTION
Compilation failed for me due to missing include for `malloc`.

```
x86_64-w64-mingw32-g++ -I. -I..  -DHAVE_CONFIG_H -DICARUS_VPI_CONST=const -DIVL_SUFFIX='""' -DMODULE_DIR1='"/usr/local/lib/ivl"'  -Wall -Wextra -Wshadow  -D__USE_MINGW_ANSI_STDIO=1  -g -O2 -MD -c main.cc -o main.o
In file included from main.cc:22:0:
config.h: In function 'char* strndup(const char*, size_t)':
config.h:204:33: error: 'malloc' was not declared in this scope
       char*tmp = (char*)malloc(n);
```

Fix by including `cstdlib` for malloc