### PR TITLE
Fix port-list-less declaration-less functions for SystemVerilog

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1411,7 +1411,7 @@ function_declaration /* IEEE1800-2005: A.2.6 */
       { assert(current_function == 0);
 	current_function = pform_push_function_scope(@1, $4, $2);
       }
-    function_item_list statement_or_null_list_opt
+    function_item_list_opt statement_or_null_list_opt
     K_endfunction
       { current_function->set_ports($7);
 	current_function->set_return($3);


### PR DESCRIPTION
For functions without a port list in parantheses, declarations are optional in SystemVerilog.
This is true even in IEEE1800-2005, but not in IEEE1364-2005
