### PR TITLE
Add assert to protect against potentially dereferencing null pointer.

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -5362,6 +5362,7 @@ NetProc* PReturn::elaborate(Design*des, NetScope*scope) const
       }
 
       NetNet*res = target->find_signal(target->basename());
+      ivl_assert(*this, res);
       ivl_variable_type_t lv_type = res->data_type();
       unsigned long wid = res->vector_width();
       NetAssign_*lv = new NetAssign_(res);


### PR DESCRIPTION
Assert is apropriate, since it's not expected that the returned value is NULL in this case.

This is a follow-up to https://github.com/steveicarus/iverilog/pull/335

Reproducing my comment there:
@martinwhitaker
Indeed, yours is a much simpler overall solution, however my gut is telling me, in addition to that to add an assert that res is not null, after the first line of this snippet:

NetNet*res = target->find_signal(target->basename());
ivl_variable_type_t lv_type = res->data_type();
This function can sometimes return NULL, and it may be true that at this point we know that we are not elaborating a void function, therefore it can't be NULL, but it's not obvious from this snippet.

Do you agree?