### PR TITLE
aclocal.m4: fix issue in cross-compiling

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -23,10 +23,10 @@ AC_SUBST(install_suffix)
 # ------------------------------
 # Sub-macro for AX_C_UNDERSCORES_LEADING and AX_C_UNDERSCORES_TRAILING.
 # Unwarranted assumptions:
-#   - the object file produced by AC_COMPILE_IFELSE is called "conftest.$ac_objext"
-#   - the nm(1) utility is available, and its name is "nm".
-# Here use $NM because they can cause issue in cross-compiling and because is
-# not possible use a different NM implementation (like llvm-nm)
+#   - the object file produced by AC_COMPILE_IFELSE is called
+#     "conftest.$ac_objext"
+#   - the nm(1) utility or an equivalent is available, and its name
+#     is defined by the $NM variable.
 AC_DEFUN([_AX_C_UNDERSCORES_MATCH_IF],
 [AC_COMPILE_IFELSE([AC_LANG_SOURCE([void underscore(void){}])],
 [AS_IF([$NM conftest.$ac_objext|grep $1 >/dev/null 2>/dev/null],[$2],[$3])],

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -25,9 +25,11 @@ AC_SUBST(install_suffix)
 # Unwarranted assumptions:
 #   - the object file produced by AC_COMPILE_IFELSE is called "conftest.$ac_objext"
 #   - the nm(1) utility is available, and its name is "nm".
+# Here use $NM because they can cause issue in cross-compiling and because is
+# not possible use a different NM implementation (like llvm-nm)
 AC_DEFUN([_AX_C_UNDERSCORES_MATCH_IF],
 [AC_COMPILE_IFELSE([AC_LANG_SOURCE([void underscore(void){}])],
-[AS_IF([nm conftest.$ac_objext|grep $1 >/dev/null 2>/dev/null],[$2],[$3])],
+[AS_IF([$NM conftest.$ac_objext|grep $1 >/dev/null 2>/dev/null],[$2],[$3])],
 [AC_MSG_ERROR([underscore test crashed])]
 )])
 


### PR DESCRIPTION
The aclocal.m4 called nm directly.

It can cause issue in cross-compiling and because is not possible use a different NM implementation (like llvm-nm).

The compile error log:
https://bugs.gentoo.org/attachment.cgi?id=648556

Closes: https://bugs.gentoo.org/731906
