### PR TITLE
Bison includes its generated header in *.cc. Generate with correct name.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -256,10 +256,8 @@ parse.o: parse.cc
 
 # Build this in two steps to avoid parallel build issues (see pr3462585)
 parse.cc: $(srcdir)/parse.y
-	$(YACC) --verbose -t -p VL -d -o $@ $<
+	$(YACC) --verbose -t -p VL --defines=parse.h -o $@ $<
 parse.h: parse.cc
-	mv parse.cc.h $@ 2>/dev/null || mv parse.hh $@
-	touch $@
 
 syn-rules.cc: $(srcdir)/syn-rules.y
 	$(YACC) --verbose -t -p syn_ -o $@ $<

--- a/tgt-pcb/Makefile.in
+++ b/tgt-pcb/Makefile.in
@@ -89,10 +89,8 @@ fp_lex.cc: $(srcdir)/fp.lex
 	$(LEX) -s -ofp_lex.cc $(srcdir)/fp.lex
 
 fp.cc: $(srcdir)/fp.y
-	$(YACC) --verbose -t -p fp -d -o $@ $<
+	$(YACC) --verbose -t -p fp --defines=fp.h -o $@ $<
 fp.h: fp.cc
-	mv fp.cc.h $@ 2>/dev/null || mv fp.hh $@
-	touch $@
 
 ifeq (@WIN32@,yes)
   TGTLDFLAGS=-L.. -livl

--- a/vhdlpp/Makefile.in
+++ b/vhdlpp/Makefile.in
@@ -117,10 +117,8 @@ lexor.cc: $(srcdir)/lexor.lex
 
 # Build this in two steps to avoid parallel build issues (see pr3462585)
 parse.cc: $(srcdir)/parse.y
-	$(YACC) --verbose -t -d -o $@ $<
+	$(YACC) --verbose -t --defines=parse.h -o $@ $<
 parse.h: parse.cc
-	mv parse.cc.h $@ 2>/dev/null || mv parse.hh $@
-	touch $@
 
 lexor_keyword.o: lexor_keyword.cc parse.h
 

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -142,10 +142,8 @@ tables.o: tables.cc
 
 # Build this in two steps to avoid parallel build issues (see pr3462585)
 parse.cc: $(srcdir)/parse.y
-	$(YACC) --verbose -t -d -o $@ $<
+	$(YACC) --verbose -t --defines=parse.h -o $@ $<
 parse.h: parse.cc
-	mv parse.cc.h $@ 2>/dev/null || mv parse.hh $@
-	touch $@
 
 lexor.cc: $(srcdir)/lexor.lex
 	$(LEX) -s -olexor.cc $(srcdir)/lexor.lex


### PR DESCRIPTION
The current bison (3.7) generates a *.cc file that includes the header
it generated. For parse.cc this would be parse.hh. Right now, we rename
this header to have a common name used in other files, but this results
in a compile error for the parse.cc file:

parse.cc:462:10: fatal error: parse.hh: No such file or directory
  462 | #include "parse.hh"
      |          ^~~~~~~~~~

Fix this by telling bison to output the header file to the correct
filename in the first place so that we don't have to rename it.
(using the --defines instead of -d option).

This looks like a bison specific option not available in Posix yacc;
but looks like we're requiring bison anyway.

Signed-off-by: Henner Zeller <h.zeller@acm.org>