### PR TITLE
Add Dockerfile that builds iverilog in an alpine linux container

### DIFF
--- a/dockerfiles/alpine312/Dockerfile
+++ b/dockerfiles/alpine312/Dockerfile
@@ -1,0 +1,68 @@
+FROM alpine:3.12 as builder
+
+# The following will be cached by the docker layer caching mechanism the first time this
+# dockerfile is built, and these commands will never execute again unless you force them
+# to with the --no-cache option:
+# docker build --no-cache . -t iverilog:latest
+RUN apk add --no-cache \
+	autoconf \
+	build-base \
+	bison \
+	bzip2-dev \
+	flex \
+	git \
+	gperf \
+	readline-dev \
+	zlib-dev
+
+# This clone command results in a bare repo that will remain at the state it
+# is at when this Dockerfile is first built and cached by docker. 
+# This leverages the caching to avoid repeated full clones, saving bandwidth.
+RUN git clone --mirror https://github.com/steveicarus/iverilog iverilog.git
+
+# Bust the cache here or the following 'git remote update' will not execute.
+# Pass a random value to the BUST_THE_CAST ENV declared below for 
+# every build where you want to bust the cache.  As an alternative to a 
+# random variable, you could use a version string or git hash or similar
+# to bust the cache only when your (branch, source, whatever) is updated.
+# The following build command is a good way to bust the cache here.
+# docker build --build-arg IVERILOG_BRANCH=master --build-arg BUST_THE_CACHE=$(date +%s) . -t iverilog:latest
+ARG BUST_THE_CACHE="cache not busted"
+RUN echo "${BUST_THE_CACHE}" > bust_the_cache.txt
+RUN cd iverilog.git && \
+    git remote update && \
+    cd ..
+
+# The branch to build may be overridden to any git branch or tag 
+# using --build-arg on the command line:  
+# docker build --build-arg IVERILOG_BRANCH=v10_3 . -t iverilog:10.3
+ARG IVERILOG_BRANCH=master
+
+RUN git clone --branch=${IVERILOG_BRANCH} iverilog.git iverilog && \
+    cd iverilog && \
+    sh autoconf.sh && \
+    ./configure && \
+    make -j4 && \
+    make install && \
+    cd && \
+    rm -rf iverilog
+
+FROM alpine:3.12
+
+RUN apk add --no-cache \
+        bzip2 \
+        libbz2 \
+        libgcc \
+        libhistory \
+        libstdc++ \
+        make \
+        readline \
+        zlib
+
+COPY --from=builder /usr/local /usr/local/
+
+RUN adduser --disabled-password ic
+USER ic
+WORKDIR /home/ic
+
+ENTRYPOINT [ "make" ]

--- a/dockerfiles/readme.txt
+++ b/dockerfiles/readme.txt
@@ -1,0 +1,20 @@
+To build this Dockerfile with the latest code in master, from
+its location within the alpine312 subdirectory:
+cd alpine312
+docker build . -t iverilog
+
+If you prefer, you can tag it with the release number, or latest:
+docker build . -t iverilog:latest
+
+The line in the Dockerfile that sets the default branch to build is: 
+ARG IVERILOG_BRANCH=master
+
+To build this Dockerfile with the code in the v10_3 tagged release, use 
+--build-arg to override IVERILOG_BRANCH to pull the v10_3 tag with:
+docker build --build-arg IVERILOG_BRANCH=v10_3 . -t iverilog:10.3
+
+This docker container's entrypoint runs make, with an optional command passed 
+as an argument at the end of the command line.  See the readme.txt file
+in the test subdirectory for an example, and instructions on using 
+a Makefile to run icarus tools within the container.
+

--- a/dockerfiles/test/Makefile
+++ b/dockerfiles/test/Makefile
@@ -1,0 +1,14 @@
+CC = iverilog
+PROG = hello
+PROG_TB = $(PROG)_tb
+
+$(PROG_TB).vcd: $(PROG_TB).vvp
+	vvp $(PROG_TB).vvp
+
+$(PROG_TB).vvp: $(PROG).v $(PROG_TB).v
+	$(CC) -o $(PROG_TB).vvp $(PROG_TB).v
+
+clean:
+	rm $(PROG_TB).vvp $(PROG_TB).vcd
+	
+ 

--- a/dockerfiles/test/hello.v
+++ b/dockerfiles/test/hello.v
@@ -1,0 +1,9 @@
+module hello( A, B );
+
+input A;
+output B;
+
+assign B = A;
+
+endmodule
+

--- a/dockerfiles/test/hello_tb.v
+++ b/dockerfiles/test/hello_tb.v
@@ -1,0 +1,29 @@
+`timescale 1ns / 1ns
+`include "hello.v"
+
+module hello_tb;
+
+reg A;
+wire B;
+
+hello uut(A, B);
+
+initial begin
+
+	$dumpfile("hello_tb.vcd");
+	$dumpvars(0, hello_tb);
+
+	A = 0;
+	#20;
+
+	A = 1;
+	#20;
+
+	A = 0;
+	#20;
+
+	$display("Hello World test complete");
+
+end
+
+endmodule

--- a/dockerfiles/test/readme.txt
+++ b/dockerfiles/test/readme.txt
@@ -1,0 +1,24 @@
+The following presumes you have built the docker container and 
+tagged it with an iverilog:10.3 release tag.  Use the 
+'docker image ls' command to list the images on your machine,
+and determine the name of your particular image.
+   
+The following command runs Make within the Docker container on 
+the Makefile in the working (current) directory, which is mapped 
+through the volume -v parameter to /home/ic inside the container:
+
+docker run -v $(pwd):/home/ic iverilog:10.3
+
+The Dockerfile entrypoint runs make, with an optional command 
+passed as an argument.  To run 'make clean' on Makefile, 
+add 'clean' to the end of the docker run command:
+
+docker run -v $(pwd):/home/ic iverilog:10.3 clean
+
+Add a Makefile to your own project's working directory and 
+modify the Makefile as you see fit.  The Makefile executes 
+the icarus verilog tools inside the container, and stores
+the results in the container's /home/ic directory which 
+is volume mapped to the working directory containing the 
+Makefile by the docker run -v command. 
+


### PR DESCRIPTION
Add Dockerfile that builds iverilog in an alpine linux container for CI/CD use.  The Dockerfile uses a two stage build, building the binaries in the first stage, and copying them to a fresh alpine container in the second to reduce the size to less than 90 Mbytes.  There are a pair of readme.txt files that give instructions for building and running the container.