### PR TITLE
parse.y: Mark enum output ports always as IMPLICT_REG

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -4659,9 +4659,8 @@ port_declaration
 		    use_type = NetNet::IMPLICIT_REG;
 	      } else if (dynamic_cast<struct_type_t*> ($4)) {
 		    use_type = NetNet::IMPLICIT_REG;
-	      } else if (enum_type_t*etype = dynamic_cast<enum_type_t*> ($4)) {
-		    if(etype->base_type == IVL_VT_LOGIC)
-			use_type = NetNet::IMPLICIT_REG;
+	      } else if (dynamic_cast<enum_type_t*> ($4)) {
+		    use_type = NetNet::IMPLICIT_REG;
 	      }
 	}
 	ptmp = pform_module_port_reference(name, @2.text, @2.first_line);


### PR DESCRIPTION
Unless explicitly declared a wire an enum output port is of variable type
and should be marked as IMPLICT_REG.

Currently this is only done when the base type of the enum is `logic`. But
it should be done for all enums regardless of their base type.

Without this change for example the following snippet

```systemverilog
  typedef enum {
      A,
      B
  } E;

  module M (
      input E ei,
      output E eo
  );

      always_comb eo = ei;

  endmodule
```

fails with the following error message
```
  test_enum.sv:11: error: eo is not a valid l-value in M.
  test_enum.sv:8:       : eo is declared here as wire.
```