### PR TITLE
Skip all removed VPI callbacks

### DIFF
--- a/vvp/vpi_callback.cc
+++ b/vvp/vpi_callback.cc
@@ -514,7 +514,9 @@ void vpiEndOfCompile(void) {
       while (EndOfCompile) {
 	    cur = EndOfCompile;
 	    EndOfCompile = dynamic_cast<simulator_callback*>(cur->next);
-	    (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    if (cur->cb_data.cb_rtn != 0) {
+	        (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    }
 	    delete cur;
       }
 
@@ -534,7 +536,9 @@ void vpiStartOfSim(void) {
       while (StartOfSimulation) {
 	    cur = StartOfSimulation;
 	    StartOfSimulation = dynamic_cast<simulator_callback*>(cur->next);
-	    (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    if (cur->cb_data.cb_rtn != 0) {
+	        (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    }
 	    delete cur;
       }
 
@@ -553,10 +557,12 @@ void vpiPostsim(void) {
       while (EndOfSimulation) {
 	    cur = EndOfSimulation;
 	    EndOfSimulation = dynamic_cast<simulator_callback*>(cur->next);
-	      /* Only set the time if it is not NULL. */
-	    if (cur->cb_data.time)
-	          vpip_time_to_timestruct(cur->cb_data.time, schedule_simtime());
-	    (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    if (cur->cb_data.cb_rtn != 0) {
+	        /* Only set the time if it is not NULL. */
+	        if (cur->cb_data.time)
+	            vpip_time_to_timestruct(cur->cb_data.time, schedule_simtime());
+	        (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    }
 	    delete cur;
       }
 
@@ -577,7 +583,9 @@ void vpiNextSimTime(void)
       while (NextSimTime) {
 	    cur = NextSimTime;
 	    NextSimTime = dynamic_cast<simulator_callback*>(cur->next);
-	    (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    if (cur->cb_data.cb_rtn != 0) {
+	        (cur->cb_data.cb_rtn)(&cur->cb_data);
+	    }
 	    delete cur;
       }
 


### PR DESCRIPTION
Segfault occurs if a `cbNextSimTime` callback is removed. This PR adds a check and skips the callback if it was removed for the rest of the VPI callbacks.

```gdb
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) where
#0  0x0000000000000000 in ?? ()
#1  0x000055555564b523 in vpiNextSimTime () at vpi_callback.cc:580
#2  0x0000555555617ddd in schedule_simulate () at schedule.cc:1179
#3  0x00005555555c7c35 in main (argc=<optimized out>, argv=<optimized out>) at main.cc:465
```