### PR TITLE
ci/win: install MSYS2 packages through setup-msys2 (cached) 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,16 +50,26 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        msystem: MINGW64
+        install: >
+          base-devel
+          mingw-w64-x86_64-toolchain
+        update: true
+
     - name: Build and test
       shell: bash
       run: |
         git clone https://github.com/steveicarus/ivtest.git
+
         export msys2='cmd //C RefreshEnv.cmd '
         export msys2+='& set MSYS=winsymlinks:nativestrict '
         export msys2+='& C:\\msys64\\msys2_shell.cmd -defterm -no-start'
         export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
         export msys2+=" -msys2 -c "\"\$@"\" --"
-        $msys2 pacman --sync --noconfirm --needed base-devel mingw-w64-x86_64-toolchain
+
         $mingw64 ./autoconf.sh
         $mingw64 ./configure
         $mingw64 make install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           '20.04'
         ]
     runs-on: ubuntu-${{ matrix.os }}
-    name: '🐧 Ubuntu'
+    name: '🐧 Ubuntu ${{ matrix.os }}'
     steps:
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
As discussed in #400, this PR updates the Windows job in GitHub Actions, in order to use Action msys2/setup-msys2 for updating the built-in MSYS2 installation, and for adding dependencies. By default, the Action caches installed packages.