### PR TITLE
Rework parsing of parameter types

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -434,11 +434,10 @@ bool PEIdent::has_aa_term(Design*des, NetScope*scope) const
 {
       NetNet*       net = 0;
       const NetExpr*par = 0;
+      ivl_type_t    par_type;
       NetEvent*     eve = 0;
 
-      const NetExpr*ex1, *ex2;
-
-      scope = symbol_search(this, des, scope, path_, net, par, eve, ex1, ex2);
+      scope = symbol_search(this, des, scope, path_, net, par, eve, par_type);
 
       if (scope)
             return scope->is_auto();

--- a/PExpr.h
+++ b/PExpr.h
@@ -407,10 +407,6 @@ class PEIdent : public PExpr {
 	// flag is set to *false*.
       bool calculate_parts_(Design*, NetScope*, long&msb, long&lsb, bool&defined) const;
       NetExpr* calculate_up_do_base_(Design*, NetScope*, bool need_const) const;
-      bool calculate_param_range_(Design*, NetScope*,
-				  const NetExpr*msb_ex, long&msb,
-				  const NetExpr*lsb_ex, long&lsb,
-				  long length) const;
 
       bool calculate_up_do_width_(Design*, NetScope*, unsigned long&wid) const;
 
@@ -450,37 +446,32 @@ class PEIdent : public PExpr {
 				    NetScope*scope,
 				    const NetExpr*par,
 				    NetScope*found_in,
-				    const NetExpr*par_msb,
-				    const NetExpr*par_lsb,
+				    ivl_type_t par_type,
 				    unsigned expr_wid,
                                     unsigned flags) const;
       NetExpr*elaborate_expr_param_bit_(Design*des,
 					NetScope*scope,
 					const NetExpr*par,
 					NetScope*found_in,
-					const NetExpr*par_msb,
-					const NetExpr*par_lsb,
+					ivl_type_t par_type,
                                         bool need_const) const;
       NetExpr*elaborate_expr_param_part_(Design*des,
 					 NetScope*scope,
 					 const NetExpr*par,
 					 NetScope*found_in,
-					 const NetExpr*par_msb,
-					 const NetExpr*par_lsb,
+					 ivl_type_t par_type,
 				         unsigned expr_wid) const;
       NetExpr*elaborate_expr_param_idx_up_(Design*des,
 					   NetScope*scope,
 					   const NetExpr*par,
 					   NetScope*found_in,
-					   const NetExpr*par_msb,
-					   const NetExpr*par_lsb,
+					   ivl_type_t par_type,
                                            bool need_const) const;
       NetExpr*elaborate_expr_param_idx_do_(Design*des,
 					   NetScope*scope,
 					   const NetExpr*par,
 					   NetScope*found_in,
-					   const NetExpr*par_msb,
-					   const NetExpr*par_lsb,
+					   ivl_type_t par_type,
                                            bool need_const) const;
       NetExpr*elaborate_expr_net(Design*des,
 				 NetScope*scope,

--- a/PExpr.h
+++ b/PExpr.h
@@ -935,11 +935,12 @@ class PECallFunction : public PExpr {
       NetExpr*elaborate_expr_method_(Design*des, NetScope*scope,
 				     unsigned expr_wid,
 				     bool add_this_flag = false) const;
-#if 0
-      NetExpr*elaborate_expr_string_method_(Design*des, NetScope*scope) const;
-      NetExpr*elaborate_expr_enum_method_(Design*des, NetScope*scope,
-					  unsigned expr_wid) const;
-#endif
+      NetExpr*elaborate_expr_method_net_(Design*des, NetScope*scope,
+					 NetNet*net, unsigned expr_wid) const;
+      NetExpr*elaborate_expr_method_par_(Design*des, NetScope*scope,
+					 const NetExpr *par, ivl_type_t par_type,
+					 unsigned expr_wid) const;
+
 
       NetExpr* elaborate_sfunc_(Design*des, NetScope*scope,
                                 unsigned expr_wid,

--- a/PScope.h
+++ b/PScope.h
@@ -98,12 +98,9 @@ class LexicalScope {
 	   is elaborated. During parsing, I put the parameters into
 	   this map. */
       struct param_expr_t : public PNamedItem {
-	    param_expr_t() : type(IVL_VT_NO_TYPE), msb(0), lsb(0), signed_flag(false), expr(0), range(0) { }
-	      // Type information
-	    ivl_variable_type_t type;
-	    PExpr*msb;
-	    PExpr*lsb;
-	    bool signed_flag;
+            inline param_expr_t() : data_type(0), expr(0), range(0) { }
+	      // Type information.
+	    data_type_t*data_type;
 	      // Value expression
 	    PExpr*expr;
 	      // If there are range constraints, list them here

--- a/design_dump.cc
+++ b/design_dump.cc
@@ -31,6 +31,7 @@
 # include  "netclass.h"
 # include  "netdarray.h"
 # include  "netqueue.h"
+# include  "netscalar.h"
 # include  "netvector.h"
 # include  "ivl_assert.h"
 # include  "PExpr.h"
@@ -235,6 +236,17 @@ ostream& netqueue_t::debug_dump(ostream&fd) const
       fd << "queue of ";
       if (max_idx_ >= 0) fd << "(maximum of " << max_idx_+1 << " elements) ";
       fd << *element_type();
+      return fd;
+}
+
+ostream& netreal_t::debug_dump(ostream&fd) const
+{
+      fd << "real";
+      return fd;
+}
+ostream& netstring_t::debug_dump(ostream&fd) const
+{
+      fd << "string";
       return fd;
 }
 

--- a/design_dump.cc
+++ b/design_dump.cc
@@ -1465,14 +1465,8 @@ void NetScope::dump(ostream&o) const
 		  else
 			o << "    parameter ";
 
-		  o << pp->second.type << " ";
-
-		  if ((*pp).second.signed_flag)
-			o << "signed ";
-
-		  if ((*pp).second.msb)
-			o << "[" << *(*pp).second.msb
-			  << ":" << *(*pp).second.lsb << "] ";
+		  if (pp->second.ivl_type)
+			pp->second.ivl_type->debug_dump(o);
 
 		  o << (*pp).first << " = ";
 		  if (pp->second.val)

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -1333,11 +1333,10 @@ unsigned PECallFunction::test_width_method_(Design*des, NetScope*scope,
 
       NetNet *net = 0;
       const NetExpr *par;
+      ivl_type_t par_type = 0;
       NetEvent *eve;
-      const NetExpr *ex1, *ex2;
 
-      symbol_search(this, des, scope, use_path,
-		    net, par, eve, ex1, ex2);
+      symbol_search(this, des, scope, use_path, net, par, eve, par_type);
 
       const netdarray_t*use_darray = 0;
 
@@ -1354,7 +1353,7 @@ unsigned PECallFunction::test_width_method_(Design*des, NetScope*scope,
 
 	    net = 0;
 	    symbol_search(this, des, scope, tmp_path,
-			  net, par, eve, ex1, ex2);
+			  net, par, eve, par_type);
 	    if (net && net->class_type()) {
 		  if (debug_elaborate) {
 			cerr << get_fileline() << ": PECallFunction::test_width_method_: "
@@ -2647,11 +2646,10 @@ NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 
       NetNet *net = 0;
       const NetExpr *par;
+      ivl_type_t par_type;
       NetEvent *eve;
-      const NetExpr *ex1, *ex2;
 
-      symbol_search(this, des, scope, use_path,
-		    net, par, eve, ex1, ex2);
+      symbol_search(this, des, scope, use_path, net, par, eve, par_type);
 
       if (net == 0)
 	    return 0;
@@ -3429,33 +3427,6 @@ NetExpr* PEIdent::calculate_up_do_base_(Design*des, NetScope*scope,
       return tmp;
 }
 
-bool PEIdent::calculate_param_range_(Design*, NetScope*,
-				     const NetExpr*par_msb, long&par_msv,
-				     const NetExpr*par_lsb, long&par_lsv,
-				     long length) const
-{
-      if (par_msb == 0) {
-	      // If the parameter doesn't have an explicit range, then
-	      // just return range values of [length-1:0].
-	    ivl_assert(*this, par_lsb == 0);
-	    par_msv = length-1;
-	    par_lsv = 0;
-	    return true;
-      }
-
-      const NetEConst*tmp = dynamic_cast<const NetEConst*> (par_msb);
-      ivl_assert(*this, tmp);
-
-      par_msv = tmp->value().as_long();
-
-      tmp = dynamic_cast<const NetEConst*> (par_lsb);
-      ivl_assert(*this, tmp);
-
-      par_lsv = tmp->value().as_long();
-
-      return true;
-}
-
 unsigned PEIdent::test_width_method_(Design*des, NetScope*scope, width_mode_t&)
 {
       if (!gn_system_verilog())
@@ -3475,9 +3446,9 @@ unsigned PEIdent::test_width_method_(Design*des, NetScope*scope, width_mode_t&)
 
       NetNet*net = 0;
       const NetExpr*par = 0;
+      ivl_type_t par_type = 0;
       NetEvent*eve = 0;
-      const NetExpr*ex1 = 0, *ex2 = 0;
-      symbol_search(this, des, scope, use_path, net, par, eve, ex1, ex2);
+      symbol_search(this, des, scope, use_path, net, par, eve, par_type);
       if (net == 0) {
 	    if (debug_elaborate)
 		  cerr << get_fileline() << ": PEIdent::test_width_method_: "
@@ -3521,9 +3492,8 @@ unsigned PEIdent::test_width(Design*des, NetScope*scope, width_mode_t&mode)
 {
       NetNet*       net = 0;
       const NetExpr*par = 0;
+      ivl_type_t    par_type = 0;
       NetEvent*     eve = 0;
-
-      const NetExpr*ex1, *ex2;
 
       NetScope*use_scope = scope;
       if (package_) {
@@ -3536,8 +3506,7 @@ unsigned PEIdent::test_width(Design*des, NetScope*scope, width_mode_t&mode)
       }
 
       NetScope*found_in = symbol_search(this, des, use_scope, path_,
-					net, par, eve,
-                                        ex1, ex2);
+					net, par, eve, par_type);
 
 	// If there is a part/bit select expression, then process it
 	// here. This constrains the results no matter what kind the
@@ -3713,7 +3682,7 @@ unsigned PEIdent::test_width(Design*des, NetScope*scope, width_mode_t&mode)
 	    use_path.pop_back();
 
 	    ivl_assert(*this, net == 0);
-	    symbol_search(this, des, scope, use_path, net, par, eve, ex1, ex2);
+	    symbol_search(this, des, scope, use_path, net, par, eve, par_type);
 
 	      // Check to see if we have a net and if so is it a structure?
 	    if (net != 0) {
@@ -3775,8 +3744,8 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 
       NetNet*       net = 0;
       const NetExpr*par = 0;
+      ivl_type_t    par_type = 0;
       NetEvent*     eve = 0;
-      const NetExpr*ex1, *ex2;
 
       NetScope*use_scope = scope;
       if (package_) {
@@ -3788,9 +3757,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 	    return tmp;
       }
 
-      /* NetScope*found_in = */ symbol_search(this, des, use_scope, path_,
-					      net, par, eve,
-					      ex1, ex2);
+      symbol_search(this, des, use_scope, path_, net, par, eve, par_type);
 
       if (net == 0 && gn_system_verilog() && path_.size() >= 2) {
 	      // NOTE: this is assuming the member_path is only one
@@ -3802,7 +3769,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 	    use_path.pop_back();
 
 	    ivl_assert(*this, net == 0);
-	    symbol_search(this, des, use_scope, use_path, net, par, eve, ex1, ex2);
+	    symbol_search(this, des, use_scope, use_path, net, par, eve, par_type);
 
 	    if (net == 0) {
 		    // Nope, no struct/class with member.
@@ -4051,9 +4018,8 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 
       NetNet*       net = 0;
       const NetExpr*par = 0;
+      ivl_type_t    par_type = 0;
       NetEvent*     eve = 0;
-
-      const NetExpr*ex1, *ex2;
 
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PEIdent::elaborate_expr: "
@@ -4112,7 +4078,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
       NetScope*found_in = 0;
       while (net==0 && par==0 && eve==0 && base_path.size()>0) {
 	    found_in = symbol_search(this, des, use_scope, base_path,
-				     net, par, eve, ex1, ex2);
+				     net, par, eve, par_type);
 	    if (net) break;
 	    if (par) break;
 	    if (eve) break;
@@ -4144,7 +4110,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 	    }
 
 	    NetExpr*tmp = elaborate_expr_param_(des, scope, par, found_in,
-                                                ex1, ex2, expr_wid, flags);
+                                                par_type, expr_wid, flags);
 
             if (!tmp) return 0;
 
@@ -4463,17 +4429,15 @@ static verinum param_part_select_bits(const verinum&par_val, long wid,
 NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 					    const NetExpr*par,
 					    NetScope*found_in,
-					    const NetExpr*par_msb,
-					    const NetExpr*par_lsb,
+					    ivl_type_t par_type,
                                             bool need_const) const
 {
       const NetEConst*par_ex = dynamic_cast<const NetEConst*> (par);
       ivl_assert(*this, par_ex);
 
       long par_msv, par_lsv;
-      if(! calculate_param_range_(des, scope, par_msb, par_msv,
-                                  par_lsb, par_lsv,
-                                  par_ex->value().len())) return 0;
+      if(! calculate_param_range(*this, par_type, par_msv, par_lsv,
+				 par_ex->value().len())) return 0;
 
       const name_component_t&name_tail = path_.back();
       ivl_assert(*this, !name_tail.index.empty());
@@ -4559,8 +4523,7 @@ NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 NetExpr* PEIdent::elaborate_expr_param_part_(Design*des, NetScope*scope,
 					     const NetExpr*par,
 					     NetScope*,
-					     const NetExpr*par_msb,
-					     const NetExpr*par_lsb,
+					     ivl_type_t par_type,
                                              unsigned expr_wid) const
 {
       long msv, lsv;
@@ -4574,9 +4537,8 @@ NetExpr* PEIdent::elaborate_expr_param_part_(Design*des, NetScope*scope,
 
 
       long par_msv, par_lsv;
-      if (! calculate_param_range_(des, scope, par_msb, par_msv,
-                                   par_lsb, par_lsv,
-                                   par_ex->value().len())) return 0;
+      if (! calculate_param_range(*this, par_type, par_msv, par_lsv,
+				  par_ex->value().len())) return 0;
 
       if (! parts_defined_flag) {
 	    if (warn_ob_select) {
@@ -4685,17 +4647,15 @@ static void warn_param_ob(long par_msv, long par_lsv, bool defined,
 NetExpr* PEIdent::elaborate_expr_param_idx_up_(Design*des, NetScope*scope,
 					       const NetExpr*par,
 					       NetScope*found_in,
-					       const NetExpr*par_msb,
-					       const NetExpr*par_lsb,
+					       ivl_type_t par_type,
                                                bool need_const) const
 {
       const NetEConst*par_ex = dynamic_cast<const NetEConst*> (par);
       ivl_assert(*this, par_ex);
 
       long par_msv, par_lsv;
-      if(! calculate_param_range_(des, scope, par_msb, par_msv,
-                                  par_lsb, par_lsv,
-                                  par_ex->value().len())) return 0;
+      if(! calculate_param_range(*this, par_type, par_msv, par_lsv,
+				 par_ex->value().len())) return 0;
 
       NetExpr*base = calculate_up_do_base_(des, scope, need_const);
       if (base == 0) return 0;
@@ -4737,8 +4697,7 @@ NetExpr* PEIdent::elaborate_expr_param_idx_up_(Design*des, NetScope*scope,
 	    if (warn_ob_select) {
                   bool defined = true;
 		    // Check to see if the parameter has a defined range.
-                  if (par_msb == 0) {
-			assert(par_lsb == 0);
+                  if (par_type == 0) {
 			defined = false;
                   }
 		    // Get the parameter values width.
@@ -4769,17 +4728,15 @@ NetExpr* PEIdent::elaborate_expr_param_idx_up_(Design*des, NetScope*scope,
 NetExpr* PEIdent::elaborate_expr_param_idx_do_(Design*des, NetScope*scope,
 					       const NetExpr*par,
 					       NetScope*found_in,
-					       const NetExpr*par_msb,
-					       const NetExpr*par_lsb,
+					       ivl_type_t par_type,
                                                bool need_const) const
 {
       const NetEConst*par_ex = dynamic_cast<const NetEConst*> (par);
       ivl_assert(*this, par_ex);
 
       long par_msv, par_lsv;
-      if(! calculate_param_range_(des, scope, par_msb, par_msv,
-                                  par_lsb, par_lsv,
-                                  par_ex->value().len())) return 0;
+      if(! calculate_param_range(*this, par_type, par_msv, par_lsv,
+				 par_ex->value().len())) return 0;
 
       NetExpr*base = calculate_up_do_base_(des, scope, need_const);
       if (base == 0) return 0;
@@ -4821,8 +4778,7 @@ NetExpr* PEIdent::elaborate_expr_param_idx_do_(Design*des, NetScope*scope,
 	    if (warn_ob_select) {
                   bool defined = true;
 		    // Check to see if the parameter has a defined range.
-                  if (par_msb == 0) {
-			assert(par_lsb == 0);
+                  if (par_type == 0) {
 			defined = false;
                   }
 		    // Get the parameter values width.
@@ -4860,8 +4816,7 @@ NetExpr* PEIdent::elaborate_expr_param_(Design*des,
 					NetScope*scope,
 					const NetExpr*par,
 					NetScope*found_in,
-					const NetExpr*par_msb,
-					const NetExpr*par_lsb,
+					ivl_type_t par_type,
 					unsigned expr_wid, unsigned flags) const
 {
       bool need_const = NEED_CONST & flags;
@@ -4894,19 +4849,19 @@ NetExpr* PEIdent::elaborate_expr_param_(Design*des,
 
       if (use_sel == index_component_t::SEL_BIT)
 	    return elaborate_expr_param_bit_(des, scope, par, found_in,
-					     par_msb, par_lsb, need_const);
+					     par_type, need_const);
 
       if (use_sel == index_component_t::SEL_PART)
 	    return elaborate_expr_param_part_(des, scope, par, found_in,
-					      par_msb, par_lsb, expr_wid);
+					      par_type, expr_wid);
 
       if (use_sel == index_component_t::SEL_IDX_UP)
 	    return elaborate_expr_param_idx_up_(des, scope, par, found_in,
-						par_msb, par_lsb, need_const);
+						par_type, need_const);
 
       if (use_sel == index_component_t::SEL_IDX_DO)
 	    return elaborate_expr_param_idx_do_(des, scope, par, found_in,
-						par_msb, par_lsb, need_const);
+						par_type, need_const);
 
       NetExpr*tmp = 0;
 

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3780,8 +3780,8 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 
       NetNet *net;
       const NetExpr *par;
+      ivl_type_t par_type = 0;
       NetEvent *eve;
-      const NetExpr *ex1, *ex2;
 
 	/* Add the implicit this reference when requested. */
       if (add_this_flag) {
@@ -3796,8 +3796,7 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 	// resolve to a class object. Note that the "this" symbol
 	// (internally represented as "@") is handled by there being a
 	// "this" object in the instance scope.
-      symbol_search(this, des, scope, use_path,
-		    net, par, eve, ex1, ex2);
+      symbol_search(this, des, scope, use_path, net, par, eve, par_type);
 
       if (net == 0)
 	    return 0;

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -320,6 +320,19 @@ const NetScope* NetECRealParam::scope() const
       return scope_;
 }
 
+NetECString::NetECString(const std::string& val)
+: NetEConst(verinum(val))
+{
+}
+
+NetECString::~NetECString()
+{
+}
+
+ivl_variable_type_t NetECString::expr_type() const
+{
+      return IVL_VT_STRING;
+}
 
 NetELast::NetELast(NetNet*s)
 : sig_(s)

--- a/netlist.h
+++ b/netlist.h
@@ -1252,6 +1252,7 @@ class NetScope : public Definitions, public Attrib {
     private:
       void evaluate_parameter_logic_(Design*des, param_ref_t cur);
       void evaluate_parameter_real_(Design*des, param_ref_t cur);
+      void evaluate_parameter_string_(Design*des, param_ref_t cur);
       void evaluate_parameter_(Design*des, param_ref_t cur);
 
     private:
@@ -2217,6 +2218,15 @@ class NetECReal  : public NetExpr {
 
     private:
       verireal value_;
+};
+
+class NetECString  : public NetEConst {
+    public:
+      explicit NetECString(const std::string& val);
+      ~NetECString();
+
+      // The type of a string is IVL_VT_STRING
+      ivl_variable_type_t expr_type() const;
 };
 
 class NetECRealParam  : public NetECReal {

--- a/netlist.h
+++ b/netlist.h
@@ -79,6 +79,7 @@ class PExpr;
 class PFunction;
 class PPackage;
 class PTaskFunc;
+class data_type_t;
 struct enum_type_t;
 class netclass_t;
 class netdarray_t;
@@ -965,22 +966,17 @@ class NetScope : public Definitions, public Attrib {
 
       struct range_t;
       void set_parameter(perm_string name, bool is_annotatable,
-			 PExpr*val, ivl_variable_type_t type,
-			 PExpr*msb, PExpr*lsb, bool signed_flag,
+			 PExpr*val, data_type_t*data_type,
 			 bool local_flag,
 			 NetScope::range_t*range_list,
 			 const LineInfo&file_line);
       void set_parameter(perm_string name, NetExpr*val,
 			 const LineInfo&file_line);
 
-      const NetExpr*get_parameter(Design*des,
-				  const char* name,
-				  const NetExpr*&msb,
-				  const NetExpr*&lsb);
-      const NetExpr*get_parameter(Design*des,
-				  perm_string name,
-				  const NetExpr*&msb,
-				  const NetExpr*&lsb);
+      const NetExpr*get_parameter(Design*des, const char* name,
+				  ivl_type_t&ivl_type);
+      const NetExpr*get_parameter(Design*des, perm_string name,
+				  ivl_type_t&ivl_type);
 
 	/* These are used by defparam elaboration to replace the
 	   expression with a new expression, without affecting the
@@ -1072,6 +1068,9 @@ class NetScope : public Definitions, public Attrib {
       perm_string get_def_file() const { return def_file_; };
       unsigned get_lineno() const { return lineno_; };
       unsigned get_def_lineno() const { return def_lineno_; };
+
+      std::string get_fileline() const;
+      std::string get_def_fileline() const;
 
       bool in_func() const;
 
@@ -1210,31 +1209,26 @@ class NetScope : public Definitions, public Attrib {
 	/* After everything is all set up, the code generators like
 	   access to these things to make up the parameter lists. */
       struct param_expr_t : public LineInfo {
-	    param_expr_t() : msb_expr(0), lsb_expr(0), val_expr(0), val_scope(0),
-                             solving(false), is_annotatable(false),
-                             type(IVL_VT_NO_TYPE), signed_flag(false),
-                             local_flag(false),
-                             msb(0), lsb(0), range(0), val(0) { }
-              // Source expressions
-	    PExpr*msb_expr;
-	    PExpr*lsb_expr;
+	    param_expr_t() : val_expr(0), val_type(0), val_scope(0),
+		             solving(false), is_annotatable(false),
+		             local_flag(false),
+		             range(0), val(0), ivl_type(0) { }
+	    // Source expression and data type (before elaboration)
 	    PExpr*val_expr;
-              // Scope information
+	    data_type_t*val_type;
+	    // Scope information
             NetScope*val_scope;
-	      // Evaluation status
+	    // Evaluation status
 	    bool solving;
-	      // specparam status
+	    // specparam status
 	    bool is_annotatable;
-	      // Type information
-	    ivl_variable_type_t type;
-	    bool signed_flag;
-            bool  local_flag;
-	    NetExpr*msb;
-	    NetExpr*lsb;
-	      // range constraints
+	    // Is this a localparam?
+	    bool local_flag;
+	    // range constraints
 	    struct range_t*range;
-	      // Expression value
+	    // Expression value and type (elaborated versoins of val_expr/val_type)
 	    NetExpr*val;
+	    ivl_type_t ivl_type;
       };
       map<perm_string,param_expr_t>parameters;
 

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1809,3 +1809,52 @@ void check_for_inconsistent_delays(NetScope*scope)
 	    display_ts_dly_warning = false;
       }
 }
+
+
+/*
+ * Calculate the bit vector range for a parameter, from the type of the
+ * parameter. This is expecting that the type is a vector type. The parameter
+ * is presumably declared something like this:
+ *
+ *    parameter [4:1] foo = <value>;
+ *
+ * In this case, the par_type is a netvector with a single dimension. The
+ * par_msv gets 4, and par_lsv get 1. The caller uses these values to
+ * interpret things like bit selects.
+ */
+bool calculate_param_range(const LineInfo&line, ivl_type_t par_type,
+			   long&par_msv, long&par_lsv, long length)
+{
+      const netvector_t*vector_type = dynamic_cast<const netvector_t*> (par_type);
+      if (vector_type == 0) {
+	    // If the parameter doesn't have an explicit range, then
+	    // just return range values of [length-1:0].
+	    par_msv = length-1;
+	    par_lsv = 0;
+	    return true;
+      }
+
+      ivl_assert(line, vector_type->packed());
+      const std::vector<netrange_t>& packed_dims = vector_type->packed_dims();
+
+      // This is a netvector_t with 0 dimensions, then the parameter was
+      // declared with a statement like this:
+      //
+      //    parameter signed foo = <value>;
+      //
+      // The netvector_t is just here to carry the signed-ness, which we don't
+      // even need here. So act like the type is defined by the r-value
+      // length.
+      if (packed_dims.size() == 0) {
+	    par_msv = length-1;
+	    par_lsv = 0;
+	    return true;
+      }
+      ivl_assert(line, packed_dims.size() == 1);
+
+      netrange_t use_range = packed_dims[0];
+      par_msv = use_range.get_msb();
+      par_lsv = use_range.get_lsb();
+
+      return true;
+}

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1004,7 +1004,7 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 		       ivl_type_t lv_net_type, bool need_const)
 {
       if (debug_elaborate) {
-	    cerr << pe->get_fileline() << ": elab_and_eval: "
+	    cerr << pe->get_fileline() << ": " << __func__ << ": "
 		 << "pe=" << *pe
 		 << ", lv_net_type=" << *lv_net_type << endl;
       }

--- a/netmisc.h
+++ b/netmisc.h
@@ -45,7 +45,7 @@ extern NetScope* symbol_search(const LineInfo*li,
 			       NetNet*&net,       /* net/reg */
 			       const NetExpr*&par,/* parameter/expr */
 			       NetEvent*&eve,     /* named event */
-			       const NetExpr*&ex1, const NetExpr*&ex2);
+			       ivl_type_t&par_type);
 
 inline NetScope* symbol_search(const LineInfo*li,
                                Design*des,
@@ -55,8 +55,8 @@ inline NetScope* symbol_search(const LineInfo*li,
 			       const NetExpr*&par,/* parameter/expr */
 			       NetEvent*&eve      /* named event */)
 {
-      const NetExpr*ex1, *ex2;
-      return symbol_search(li, des, start, path, net, par, eve, ex1, ex2);
+      ivl_type_t par_type;
+      return symbol_search(li, des, start, path, net, par, eve, par_type);
 }
 
 /*

--- a/netscalar.h
+++ b/netscalar.h
@@ -29,6 +29,8 @@ class netreal_t : public ivl_type_s {
 
       ivl_variable_type_t base_type() const;
 
+      std::ostream& debug_dump(std::ostream&) const;
+
     public:
       static netreal_t type_real;
       static netreal_t type_shortreal;
@@ -41,6 +43,8 @@ class netstring_t : public ivl_type_s {
       ~netstring_t();
 
       ivl_variable_type_t base_type() const;
+
+      std::ostream& debug_dump(std::ostream&) const;
 
     public:
       static netstring_t type_string;

--- a/nettypes.cc
+++ b/nettypes.cc
@@ -160,3 +160,4 @@ bool prefix_to_slice(const std::vector<netrange_t>&dims,
 
       return true;
 }
+

--- a/nettypes.h
+++ b/nettypes.h
@@ -27,6 +27,7 @@
 # include  <cassert>
 
 class netrange_t;
+class LineInfo;
 
 /*
  * This is a fully abstract type that is a type that can be attached
@@ -134,6 +135,15 @@ extern std::ostream&operator << (std::ostream&out, const std::list<netrange_t>&r
 extern std::ostream&operator << (std::ostream&out, const std::vector<netrange_t>&rlist);
 
 extern unsigned long netrange_width(const std::vector<netrange_t>&dims);
+
+/*
+ * There are a few cases where we need to know about the single-level
+ * dimensions of a parameter declaration, for example:
+ *
+ *   parameter [msv:lsv] foo ...;
+ */
+extern bool calculate_param_range(const LineInfo&line, ivl_type_t par_type,
+				  long&par_msv, long&par_lsv, long length);
 
 /*
  * Take as input a list of packed dimensions and a list of prefix

--- a/netvector.cc
+++ b/netvector.cc
@@ -18,6 +18,7 @@
  */
 
 # include  "netvector.h"
+# include  "compiler.h"
 # include  <iostream>
 
 using namespace std;
@@ -30,6 +31,17 @@ netvector_t netvector_t::atom2s16 (IVL_VT_BOOL, 15, 0, true);
 netvector_t netvector_t::atom2u16 (IVL_VT_BOOL, 15, 0, false);
 netvector_t netvector_t::atom2s8  (IVL_VT_BOOL,  7, 0, true);
 netvector_t netvector_t::atom2u8  (IVL_VT_BOOL,  7, 0, false);
+
+static netvector_t* save_integer_type = 0;
+const netvector_t* netvector_t::integer_type()
+{
+      if (save_integer_type)
+	    return save_integer_type;
+
+      save_integer_type = new netvector_t(IVL_VT_LOGIC, integer_width-1, 0, true);
+      save_integer_type->set_isint(true);
+      return save_integer_type;
+}
 
 //netvector_t netvector_t::scalar_bool (IVL_VT_BOOL);
 netvector_t netvector_t::scalar_logic (IVL_VT_LOGIC);

--- a/netvector.h
+++ b/netvector.h
@@ -78,6 +78,7 @@ class netvector_t : public ivl_type_s {
       static netvector_t atom2u8;
       static netvector_t scalar_bool;
       static netvector_t scalar_logic;
+      static const netvector_t*integer_type();
 
     private:
       bool test_compatibility(ivl_type_t that) const;

--- a/pform.cc
+++ b/pform.cc
@@ -3168,8 +3168,7 @@ LexicalScope::range_t* pform_parameter_value_range(bool exclude_flag,
 }
 
 void pform_set_parameter(const struct vlltype&loc,
-			 perm_string name, ivl_variable_type_t type,
-			 bool signed_flag, list<pform_range_t>*range, PExpr*expr,
+			 perm_string name, data_type_t*data_type, PExpr*expr,
 			 LexicalScope::range_t*value_range)
 {
       LexicalScope*scope = lexical_scope;
@@ -3190,20 +3189,7 @@ void pform_set_parameter(const struct vlltype&loc,
       scope->parameters[name] = parm;
 
       parm->expr = expr;
-
-      parm->type = type;
-      if (range) {
-	    assert(range->size() == 1);
-	    pform_range_t&rng = range->front();
-	    assert(rng.first);
-	    assert(rng.second);
-	    parm->msb = rng.first;
-	    parm->lsb = rng.second;
-      } else {
-	    parm->msb = 0;
-	    parm->lsb = 0;
-      }
-      parm->signed_flag = signed_flag;
+      parm->data_type = data_type;
       parm->range = value_range;
 
 	// Only a Module keeps the position of the parameter.
@@ -3212,8 +3198,7 @@ void pform_set_parameter(const struct vlltype&loc,
 }
 
 void pform_set_localparam(const struct vlltype&loc,
-			  perm_string name, ivl_variable_type_t type,
-			  bool signed_flag, list<pform_range_t>*range, PExpr*expr)
+			  perm_string name, data_type_t*data_type, PExpr*expr)
 {
       LexicalScope*scope = lexical_scope;
       if (is_compilation_unit(scope) && !gn_system_verilog()) {
@@ -3229,20 +3214,7 @@ void pform_set_localparam(const struct vlltype&loc,
       scope->localparams[name] = parm;
 
       parm->expr = expr;
-
-      parm->type = type;
-      if (range) {
-	    assert(range->size() == 1);
-	    pform_range_t&rng = range->front();
-	    assert(rng.first);
-	    assert(rng.second);
-	    parm->msb = rng.first;
-	    parm->lsb = rng.second;
-      } else {
-	    parm->msb  = 0;
-	    parm->lsb  = 0;
-      }
-      parm->signed_flag = signed_flag;
+      parm->data_type = data_type;
       parm->range = 0;
 }
 
@@ -3261,22 +3233,13 @@ void pform_set_specparam(const struct vlltype&loc, perm_string name,
       pform_cur_module.front()->specparams[name] = parm;
 
       parm->expr = expr;
+      parm->range = 0;
 
       if (range) {
 	    assert(range->size() == 1);
-	    pform_range_t&rng = range->front();
-	    assert(rng.first);
-	    assert(rng.second);
-	    parm->type = IVL_VT_LOGIC;
-	    parm->msb = rng.first;
-	    parm->lsb = rng.second;
-      } else {
-	    parm->type = IVL_VT_NO_TYPE;
-	    parm->msb  = 0;
-	    parm->lsb  = 0;
+	    parm->data_type = new vector_type_t(IVL_VT_LOGIC, false, range);
+	    parm->range = 0;
       }
-      parm->signed_flag = false;
-      parm->range = 0;
 }
 
 void pform_set_defparam(const pform_name_t&name, PExpr*expr)

--- a/pform.h
+++ b/pform.h
@@ -418,15 +418,11 @@ extern LexicalScope::range_t* pform_parameter_value_range(bool exclude_flag,
 
 extern void pform_set_parameter(const struct vlltype&loc,
 				perm_string name,
-				ivl_variable_type_t type,
-				bool signed_flag,
-				list<pform_range_t>*range,
+				data_type_t*data_type,
 				PExpr*expr, LexicalScope::range_t*value_range);
 extern void pform_set_localparam(const struct vlltype&loc,
 				 perm_string name,
-				 ivl_variable_type_t type,
-				 bool signed_flag,
-				 list<pform_range_t>*range,
+				 data_type_t*data_type,
 				 PExpr*expr);
 extern void pform_set_specparam(const struct vlltype&loc,
 				 perm_string name,

--- a/pform_types.h
+++ b/pform_types.h
@@ -141,11 +141,14 @@ class data_type_t : public PNamedItem {
     public:
       inline explicit data_type_t() { }
       virtual ~data_type_t() = 0;
-	// This method is used to figure out the base type of a packed
-	// compound object. Return IVL_VT_NO_TYPE if the type is not packed.
+      // This method is used to figure out the base type of a packed
+      // compound object. Return IVL_VT_NO_TYPE if the type is not packed.
       virtual ivl_variable_type_t figure_packed_base_type(void)const;
-	// This method is used by the pform dumper to diagnostic dump.
+      // This method is used by the pform dumper to diagnostic dump. The
+      //  pform_dump dumps type type in pform format, and the debug_dump
+      // prints the output in a linear form.
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
+      virtual std::ostream& debug_dump(std::ostream&out) const;
 
       ivl_type_s* elaborate_type(Design*des, NetScope*scope);
 
@@ -237,6 +240,7 @@ struct vector_type_t : public data_type_t {
       : base_type(bt), signed_flag(sf), reg_flag(false), integer_flag(false), implicit_flag(false), pdims(pd) { }
       virtual ivl_variable_type_t figure_packed_base_type(void)const;
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
+      virtual std::ostream& debug_dump(std::ostream&out) const;
       ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
 
       ivl_variable_type_t base_type;
@@ -388,6 +392,11 @@ inline perm_string peek_tail_name(const pform_name_t&that)
  */
 # define SUPER_TOKEN "#"
 # define THIS_TOKEN  "@"
+
+static inline std::ostream& operator<< (std::ostream&out, const data_type_t&that)
+{
+      return that.debug_dump(out);
+}
 
 extern std::ostream& operator<< (std::ostream&out, const pform_name_t&);
 extern std::ostream& operator<< (std::ostream&out, const name_component_t&that);

--- a/symbol_search.cc
+++ b/symbol_search.cc
@@ -31,8 +31,7 @@ struct symbol_search_results {
 	    scope = 0;
 	    net = 0;
 	    par_val = 0;
-	    par_msb = 0;
-	    par_lsb = 0;
+	    par_type = 0;
 	    eve = 0;
       }
 
@@ -52,8 +51,7 @@ struct symbol_search_results {
 	// If this was a parameter, the value expression and the
 	// optional value dimensions.
       const NetExpr*par_val;
-      const NetExpr*par_msb;
-      const NetExpr*par_lsb;
+      ivl_type_t par_type;
 	// If this is a named event, ...
       NetEvent*eve;
 };
@@ -129,7 +127,7 @@ static bool symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 		  return true;
 	    }
 
-	    if (const NetExpr*par = scope->get_parameter(des, path_tail.name, res->par_msb, res->par_lsb)) {
+	    if (const NetExpr*par = scope->get_parameter(des, path_tail.name, res->par_type)) {
 		  res->scope = scope;
 		  res->par_val = par;
 		  return true;
@@ -191,14 +189,13 @@ NetScope*symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 		       NetNet*&net,
 		       const NetExpr*&par,
 		       NetEvent*&eve,
-		       const NetExpr*&ex1, const NetExpr*&ex2)
+		       ivl_type_t&par_type)
 {
       symbol_search_results recurse;
       bool flag = symbol_search(li, des, scope, path, &recurse);
       net = recurse.net;
       par = recurse.par_val;
-      ex1 = recurse.par_msb;
-      ex2 = recurse.par_lsb;
+      par_type = recurse.par_type;
       eve = recurse.eve;
       if (! flag) {
 	    return 0;

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -506,26 +506,19 @@ void dll_target::make_scope_parameters(ivl_scope_t scop, const NetScope*net)
 	    ivl_parameter_t cur_par = &scop->param[idx];
 	    cur_par->basename = cur_pit->first;
             cur_par->local = cur_pit->second.local_flag;
-	      /* Either both the MSB and LSB expressions are provided or
-	       * neither are provided. */
-	    if (cur_pit->second.msb) {
-		  assert(cur_pit->second.lsb);
-		  /* The MSB and LSB expressions must be integral constants. */
-		  const NetEConst *msbc =
-		         dynamic_cast<const NetEConst*>(cur_pit->second.msb);
-		  const NetEConst *lsbc =
-		         dynamic_cast<const NetEConst*>(cur_pit->second.lsb);
-		  assert(msbc);
-		  assert(lsbc);
-		  cur_par->msb = msbc->value().as_long();
-		  cur_par->lsb = lsbc->value().as_long();
-	    } else {
-		  assert(! cur_pit->second.lsb);
-		  cur_par->msb = cur_pit->second.val->expr_width() - 1;
-		  assert(cur_par->msb >= 0);
-		  cur_par->lsb = 0;
+	    calculate_param_range(cur_pit->second,
+				  cur_pit->second.ivl_type,
+				  cur_par->msb, cur_par->lsb,
+				  cur_pit->second.val->expr_width());
+
+	    if (cur_pit->second.ivl_type == 0) {
+		  cerr << "?:?: internal error: "
+		       << "No type for parameter " << cur_pit->first
+		       << " in scope " << net->fullname() << "?" << endl;
 	    }
-	    cur_par->signed_flag = cur_pit->second.signed_flag;
+	    assert(cur_pit->second.ivl_type);
+
+	    cur_par->signed_flag = cur_pit->second.ivl_type->get_signed();
 	    cur_par->scope = scop;
 	    FILE_NAME(cur_par, &(cur_pit->second));
 


### PR DESCRIPTION
Use the common data_type_or_implicit rules to support type
definitions for parameters. This eliminates a bunch of special
rules in parse.y, and opens the door for parameters having
more complex types.