### PR TITLE
output ports of real type are variables, not wires.

### DIFF
--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -225,6 +225,7 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 	    cerr << get_fileline() << ": PEIdent::elaborate_lval: "
 		 << "Found l-value path_=" << path_
 		 << " as reg=" << reg->name()
+		 << ", reg->type()=" << reg->type()
 		 << " base_path=" << base_path
 		 << ", member_path=" << member_path
 		 << " unpacked_dimensions()=" << reg->unpacked_dimensions() << endl;

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -175,7 +175,7 @@ ivl_type_s* vector_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 
 ivl_type_s* real_type_t::elaborate_type_raw(Design*, NetScope*) const
 {
-      switch (type_code) {
+      switch (type_code_) {
 	  case REAL:
 	    return &netreal_t::type_real;
 	  case SHORTREAL:

--- a/parse.y
+++ b/parse.y
@@ -4621,6 +4621,8 @@ port_declaration
 		      // here.
 	      } else if (dynamic_cast<atom2_type_t*> ($4)) {
 		    use_type = NetNet::IMPLICIT_REG;
+	      } else if (dynamic_cast<real_type_t*> ($4)) {
+		    use_type = NetNet::IMPLICIT_REG;
 	      } else if (dynamic_cast<struct_type_t*> ($4)) {
 		    use_type = NetNet::IMPLICIT_REG;
 	      } else if (dynamic_cast<enum_type_t*> ($4)) {

--- a/pform.cc
+++ b/pform.cc
@@ -2577,7 +2577,7 @@ void pform_module_define_port(const struct vlltype&li,
 	    signed_flag = true;
 	    prange = 0;
 
-	    if (rtype->type_code != real_type_t::REAL) {
+	    if (rtype->type_code() != real_type_t::REAL) {
 		  VLerror(li, "sorry: Only real (not shortreal) supported here (%s:%d).",
 			  __FILE__, __LINE__);
 	    }

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -171,6 +171,16 @@ ostream& data_type_t::debug_dump(ostream&out) const
       return out;
 }
 
+ostream& atom2_type_t::debug_dump(ostream&out) const
+{
+      if (signed_flag)
+	    out << "signed-";
+      else
+	    out << "unsigned-";
+      out << "int(" << type_code << ")";
+      return out;
+}
+
 void void_type_t::pform_dump(ostream&out, unsigned indent) const
 {
       out << setw(indent) << "" << "void" << endl;
@@ -181,6 +191,19 @@ void parray_type_t::pform_dump(ostream&out, unsigned indent) const
       out << setw(indent) << "" << "Packed array " << "[...]"
 	  << " of:" << endl;
       base_type->pform_dump(out, indent+4);
+}
+
+ostream& real_type_t::debug_dump(ostream&out) const
+{
+      switch (type_code_) {
+	  case REAL:
+	    out << "real";
+	    break;
+	  case SHORTREAL:
+	    out << "shortreal";
+	    break;
+      }
+      return out;
 }
 
 void struct_type_t::pform_dump(ostream&out, unsigned indent) const
@@ -563,7 +586,7 @@ void PWire::dump(ostream&out, unsigned ind) const
 	    out << " scalar";
       }
       if (set_data_type_) {
-	    out << " set_data_type_=" << typeid(*set_data_type_).name();
+	    out << " set_data_type_=" << *set_data_type_;
       }
 
       if (discipline_) {

--- a/pform_types.h
+++ b/pform_types.h
@@ -210,6 +210,8 @@ struct atom2_type_t : public data_type_t {
       int type_code;
       bool signed_flag;
 
+      virtual std::ostream& debug_dump(std::ostream&out) const;
+
       ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
 };
 
@@ -288,11 +290,17 @@ struct uarray_type_t : public array_base_t {
 };
 
 struct real_type_t : public data_type_t {
+ public:
       enum type_t { REAL, SHORTREAL };
-      inline explicit real_type_t(type_t tc) : type_code(tc) { }
-      type_t type_code;
+      inline explicit real_type_t(type_t tc) : type_code_(tc) { }
+      virtual std::ostream& debug_dump(std::ostream&out) const;
 
       ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+
+      inline type_t type_code() const { return type_code_; }
+
+ private:
+      type_t type_code_;
 };
 
 struct string_type_t : public data_type_t {


### PR DESCRIPTION
output ports declared like this:

    ..., output real out, ...

are not wires unless the net type is explicitly given. The actual fix is in parse.y, the port_declaration rule. The rest of this PR is debug code improvements.

Fixes issue #456.
