### PR TITLE
Implement the enum.name() method

### DIFF
--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -222,13 +222,23 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
       ivl_assert(*this, reg);
 
       if (debug_elaborate) {
-	    cerr << get_fileline() << ": PEIdent::elaborate_lval: "
+	    cerr << get_fileline() << ": " << __func__ << ": "
 		 << "Found l-value path_=" << path_
-		 << " as reg=" << reg->name()
-		 << ", reg->type()=" << reg->type()
+		 << " as reg=" << reg->name() << endl;
+	    cerr << get_fileline() << ": " << __func__ << ": "
+		 << "reg->type()=" << reg->type()
+		 << ", reg->unpacked_dimensions()=" << reg->unpacked_dimensions()
+		 << endl;
+	    if (reg->net_type())
+		  cerr << get_fileline() << ": " << __func__ << ": "
+		       << "reg->net_type()=" << *reg->net_type() << endl;
+	    else
+		  cerr << get_fileline() << ": " << __func__ << ": "
+		       << "reg->net_type()=<nil>" << endl;
+	    cerr << get_fileline() << ": " << __func__ << ": "
 		 << " base_path=" << base_path
 		 << ", member_path=" << member_path
-		 << " unpacked_dimensions()=" << reg->unpacked_dimensions() << endl;
+		 << endl;
       }
 
 	// We are processing the tail of a string of names. For

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -42,6 +42,7 @@
 # include  "netdarray.h"
 # include  "netparray.h"
 # include  "netqueue.h"
+# include  "netscalar.h"
 # include  "util.h"
 # include  "ivl_assert.h"
 
@@ -1231,7 +1232,8 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 	    const netenum_t*use_enum = base_type_scope->find_enumeration_for_name(des, sample_name->name);
 
 	    if (debug_elaborate) {
-		  cerr << get_fileline() << ": debug: Create signal " << wtype
+		  cerr << get_fileline() << ": " << __func__ << ": "
+		       << "Create signal " << wtype
 		       << " enumeration "
 		       << name_ << " in scope " << scope_path(scope)
 		       << " with packed_dimensions=" << packed_dimensions
@@ -1245,7 +1247,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
       } else if (netdarray) {
 
 	    if (debug_elaborate) {
-	          cerr << get_fileline() << ": PWire::elaborate_sig: "
+	          cerr << get_fileline() << ": " << __func__ << ": "
 		       << "Create signal " << wtype
 		       << " dynamic array " << name_
 		       << " in scope " << scope_path(scope) << endl;
@@ -1254,6 +1256,20 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 	    ivl_assert(*this, packed_dimensions.empty());
 	    ivl_assert(*this, unpacked_dimensions.empty());
 	    sig = new NetNet(scope, name_, wtype, netdarray);
+
+      } else if (dynamic_cast<string_type_t*>(set_data_type_)) {
+
+	    // Signal declared as: string foo;
+	    if (debug_elaborate) {
+		  cerr << get_fileline() << ": " << __func__ << ": "
+		       << "Create signal " << wtype
+		       << " string "
+		       << name_ << " in scope " << scope_path(scope)
+		       << endl;
+	    }
+
+	    sig = new NetNet(scope, name_, wtype, unpacked_dimensions,
+			     &netstring_t::type_string);
 
       } else if (parray_type_t*parray_type = dynamic_cast<parray_type_t*>(set_data_type_)) {
 	      // The pform gives us a parray_type_t for packed arrays
@@ -1279,7 +1295,9 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 
       } else {
 	    if (debug_elaborate) {
-		  cerr << get_fileline() << ": debug: Create signal " << wtype;
+		  cerr << get_fileline() << ": " << __func__ << ": "
+		       << "Create signal " << wtype
+		       << " data_type=" << data_type_;
 		  if (!get_scalar()) {
 			cerr << " " << packed_dimensions;
 		  }
@@ -1291,7 +1309,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 	    if (use_data_type == IVL_VT_NO_TYPE) {
 		  use_data_type = IVL_VT_LOGIC;
 		  if (debug_elaborate) {
-			cerr << get_fileline() << ": debug: "
+			cerr << get_fileline() << ": " << __func__ << ": "
 			     << "Signal " << name_
 			     << " in scope " << scope_path(scope)
 			     << " defaults to data type " << use_data_type << endl;

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -22,6 +22,7 @@
 # include  "netenum.h"
 # include  "netclass.h"
 # include  "netdarray.h"
+# include  "netscalar.h"
 # include  "compiler.h"
 # include  "netmisc.h"
 # include  <iostream>
@@ -495,6 +496,8 @@ NetESFunc::NetESFunc(const char*n, ivl_type_t rtype, unsigned np)
 	    type_ = IVL_VT_DARRAY;
       else if (dynamic_cast<const netclass_t*>(rtype))
 	    type_ = IVL_VT_CLASS;
+      else if (dynamic_cast<const netstring_t*>(rtype))
+	    type_ = IVL_VT_STRING;
       else
 	    ivl_assert(*this, 0);
 }

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1066,8 +1066,9 @@ NetExpr* elab_sys_task_arg(Design*des, NetScope*scope, perm_string name,
       pe->test_width(des, scope, mode);
 
       if (debug_elaborate) {
-            cerr << pe->get_fileline() << ": debug: test_width of "
-                 << name << " argument " << (arg_idx+1) << " " << *pe << endl;
+	    cerr << pe->get_fileline() << ": " << __func__ << ": "
+		 << "test_width of " << name
+                 << " argument " << (arg_idx+1) << " " << *pe << endl;
             cerr << pe->get_fileline() << ":        "
                  << "returns type=" << pe->expr_type()
                  << ", width=" << pe->expr_width()


### PR DESCRIPTION
This method returns the name of the enumeration, as a string. This was partially implemented, but wasn't finished at the time since string functions seemed to not work. That's OK now, so finish the implementation.

And while I'm at it, make many debug messages more uniform in format.

This fixes issue #453 .
