### PR TITLE
Fix for cross compile build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_CONFIG_HEADERS([tgt-pcb/pcb_config.h])
 AC_CANONICAL_HOST
 dnl Checks for programs.
 AC_PROG_CC
+AX_PROG_CC_FOR_BUILD
 AC_PREREQ([2.62])
 m4_version_prereq([2.70], [], [AC_PROG_CC_C99])
 AC_PROG_CXX
@@ -333,6 +334,5 @@ then
 AC_MSG_ERROR(cannot configure white space in libdir: $libdir)
 fi
 AC_MSG_RESULT(ok)
-AX_PROG_CC_FOR_BUILD
 AC_CONFIG_FILES([Makefile ivlpp/Makefile vhdlpp/Makefile vvp/Makefile vpi/Makefile driver/Makefile driver-vpi/Makefile cadpli/Makefile libveriuser/Makefile tgt-null/Makefile tgt-stub/Makefile tgt-vvp/Makefile tgt-vhdl/Makefile tgt-fpga/Makefile tgt-verilog/Makefile tgt-pal/Makefile tgt-vlog95/Makefile tgt-pcb/Makefile tgt-blif/Makefile tgt-sizer/Makefile])
 AC_OUTPUT

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -146,7 +146,7 @@ endif
 	mv $*.d dep/$*.d
 
 tables.cc: $(srcdir)/draw_tt.c
-	$(CC) $(CFLAGS) -o draw_tt$(BUILDEXT) $(srcdir)/draw_tt.c
+	$(BUILDCC) $(CFLAGS) -o draw_tt$(BUILDEXT) $(srcdir)/draw_tt.c
 	./draw_tt$(BUILDEXT) > tables.cc
 	rm draw_tt$(BUILDEXT)
 


### PR DESCRIPTION
Small explanation:
AX_PROG_CC_FOR_BUILD - moved from bottom to top of configure.ac, since all libraries tested for main compiler were also required in this case for native compiler, making a need of installation of zlib, bz2,... that were not used at all 

BUILDCC - previously wrong compiler was used for draw_tt, this change makes cross compile working fine.