### PR TITLE
Fix unique0 keyword/token mapping

### DIFF
--- a/lexor_keyword.gperf
+++ b/lexor_keyword.gperf
@@ -322,7 +322,7 @@ type,			GN_KEYWORDS_1800_2005,		K_type
 typedef,		GN_KEYWORDS_1800_2005,		K_typedef
 union,			GN_KEYWORDS_1800_2005,		K_union
 unique,			GN_KEYWORDS_1800_2005,		K_unique
-unique0,		GN_KEYWORDS_1800_2009,		K_unique
+unique0,		GN_KEYWORDS_1800_2009,		K_unique0
 units,			GN_KEYWORDS_VAMS_2_3,		K_units
 # Reserved for future use!
 unsigned,		GN_KEYWORDS_1364_2001,		K_unsigned


### PR DESCRIPTION
I use `unique0` alot and always get the warning "value is unhandled for priority or unique case statement" when there is no default case (which there normally isn't in combination with `unique0`). I found that this is because the keyword `unique0` was mapped to the `K_unique` token instead of `K_unique0`.
I don't know if this was done intentionally to workaround another problem or if it was just a typo.