### PR TITLE
Short circuit logical operator

### DIFF
--- a/eval_tree.cc
+++ b/eval_tree.cc
@@ -811,6 +811,36 @@ NetEConst* NetEBLogic::eval_arguments_(const NetExpr*l, const NetExpr*r) const
 
       const NetEConst*lc = dynamic_cast<const NetEConst*>(l);
       const NetEConst*rc = dynamic_cast<const NetEConst*>(r);
+
+      // If the left side is constant and the right side is short circuited
+      // replace the expression with a constant
+      if (rc == 0 && lc != 0) {
+	    verinum v = lc->value();
+	    verinum::V res = verinum::Vx;
+	    switch (op_) {
+		case 'a': // Logical AND (&&)
+		  if (v.is_zero())
+			res = verinum::V0;
+		  break;
+		case 'o': // Logical OR (||)
+		  if (! v.is_zero() && v.is_defined())
+			res = verinum::V1;
+		  break;
+		case 'q': // Logical implication (->)
+		  if (v.is_zero())
+			res = verinum::V1;
+		  break;
+		default:
+		  break;
+	    }
+	    if (res != verinum::Vx) {
+		  NetEConst*tmp = new NetEConst(verinum(res, 1));
+		  ivl_assert(*this, tmp);
+		  eval_debug(this, tmp, false);
+		  return tmp;
+	    }
+      }
+
       if (lc == 0 || rc == 0) return 0;
 
       verinum::V lv = verinum::V0;

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -435,36 +435,42 @@ static void draw_binary_vec4_lequiv(ivl_expr_t expr)
 static void draw_binary_vec4_logical(ivl_expr_t expr, char op)
 {
       const char *opcode;
+      const char *jmp_type;
 
       switch (op) {
 	  case 'a':
 	    opcode = "and";
+	    jmp_type = "0";
 	    break;
 	  case 'o':
 	    opcode = "or";
+	    jmp_type = "1";
 	    break;
 	  default:
 	    assert(0);
 	    break;
       }
 
+      unsigned label_out = local_count++;
+
       ivl_expr_t le = ivl_expr_oper1(expr);
       ivl_expr_t re = ivl_expr_oper2(expr);
 
-	/* Push the left expression. Reduce it to a single bit if
-	   necessary. */
-      draw_eval_vec4(le);
-      if (ivl_expr_width(le) > 1)
-	    fprintf(vvp_out, "    %%or/r;\n");
-
-	/* Now push the right expression. Again, reduce to a single
-	   bit if necessary. */
+      /* Evaluate the left expression as a conditon and skip the right expression
+       * if the left is false. */
+      int flag = draw_eval_condition(le);
+      fprintf(vvp_out, "    %%flag_get/vec4 %d;\n", flag);
+      fprintf(vvp_out, "    %%jmp/%s T_%u.%u, %d;\n", jmp_type, thread_count,
+	      label_out, flag);
+      clr_flag(flag);
+      /* Now push the right expression. Reduce to a single bit if necessary. */
       draw_eval_vec4(re);
       if (ivl_expr_width(re) > 1)
 	    fprintf(vvp_out, "    %%or/r;\n");
 
       fprintf(vvp_out, "    %%%s;\n", opcode);
 
+      fprintf(vvp_out, "T_%u.%u;\n", thread_count, label_out);
       if (ivl_expr_width(expr) > 1)
 	    fprintf(vvp_out, "    %%pad/u %u;\n", ivl_expr_width(expr));
 }

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -432,8 +432,22 @@ static void draw_binary_vec4_lequiv(ivl_expr_t expr)
       assert(ivl_expr_width(expr) == 1);
 }
 
-static void draw_binary_vec4_land(ivl_expr_t expr)
+static void draw_binary_vec4_logical(ivl_expr_t expr, char op)
 {
+      const char *opcode;
+
+      switch (op) {
+	  case 'a':
+	    opcode = "and";
+	    break;
+	  case 'o':
+	    opcode = "or";
+	    break;
+	  default:
+	    assert(0);
+	    break;
+      }
+
       ivl_expr_t le = ivl_expr_oper1(expr);
       ivl_expr_t re = ivl_expr_oper2(expr);
 
@@ -449,7 +463,7 @@ static void draw_binary_vec4_land(ivl_expr_t expr)
       if (ivl_expr_width(re) > 1)
 	    fprintf(vvp_out, "    %%or/r;\n");
 
-      fprintf(vvp_out, "    %%and;\n");
+      fprintf(vvp_out, "    %%%s;\n", opcode);
 
       if (ivl_expr_width(expr) > 1)
 	    fprintf(vvp_out, "    %%pad/u %u;\n", ivl_expr_width(expr));
@@ -632,29 +646,6 @@ static void draw_binary_vec4_le(ivl_expr_t expr)
       }
 }
 
-static void draw_binary_vec4_lor(ivl_expr_t expr)
-{
-      ivl_expr_t le = ivl_expr_oper1(expr);
-      ivl_expr_t re = ivl_expr_oper2(expr);
-
-	/* Push the left expression. Reduce it to a single bit if
-	   necessary. */
-      draw_eval_vec4(le);
-      if (ivl_expr_width(le) > 1)
-	    fprintf(vvp_out, "    %%or/r;\n");
-
-	/* Now push the right expression. Again, reduce to a single
-	   bit if necessary. */
-      draw_eval_vec4(re);
-      if (ivl_expr_width(re) > 1)
-	    fprintf(vvp_out, "    %%or/r;\n");
-
-      fprintf(vvp_out, "    %%or;\n");
-
-      if (ivl_expr_width(expr) > 1)
-	    fprintf(vvp_out, "    %%pad/u %u;\n", ivl_expr_width(expr));
-}
-
 static void draw_binary_vec4_lrs(ivl_expr_t expr)
 {
       ivl_expr_t le = ivl_expr_oper1(expr);
@@ -695,7 +686,8 @@ static void draw_binary_vec4(ivl_expr_t expr)
 {
       switch (ivl_expr_opcode(expr)) {
 	  case 'a': /* Logical && */
-	    draw_binary_vec4_land(expr);
+	  case 'o': /* || (logical or) */
+	    draw_binary_vec4_logical(expr, ivl_expr_opcode(expr));
 	    break;
 
 	  case '+':
@@ -736,10 +728,6 @@ static void draw_binary_vec4(ivl_expr_t expr)
 	  case 'r': /* >> */
 	  case 'R': /* >>> */
 	    draw_binary_vec4_lrs(expr);
-	    break;
-
-	  case 'o': /* || (logical or) */
-	    draw_binary_vec4_lor(expr);
 	    break;
 
 	  case 'q': /* -> (logical implication) */


### PR DESCRIPTION
Section 11.4.7 of the SystemVerilog standard states

```
The && and || operators shall use short circuit evaluation as follows:
  - The first operand expression shall always be evaluated.
  - For &&, if the first operand value is logically false then the second operand shall not be evaluated.
  - For ||, if the first operand value is logically true then the second operand shall not be evaluated.
```

vvp currently evaluates both operands of a logical operator. This works
fine as long as the right-hand side does not have a side effect. But if it has
the result might be incorrect.

E.g. for `a && b++` `b` must not be incremented if `a` evaluates to false.

The Verilog LRM mentions that it is allowed to short circuit any expression
"if the final result of an expression can be determined early". But there
is no requirement to do so.
    
So the new and the old behavior are both correct implementations in
Verilog.
    
Use the new behavior in both Verilog and SystemVerilog mode to make sure
the behavior is consistent when an expression has side effects.

Corresponding ivtest PR: https://github.com/steveicarus/ivtest/pull/17