### PR TITLE
Support signals of packed arrays of packed types

### DIFF
--- a/elab_type.cc
+++ b/elab_type.cc
@@ -35,44 +35,6 @@
 using namespace std;
 
 /*
- * Some types have a list of ranges that need to be elaborated. This
- * function elaborates the ranges referenced by "dims" into the vector
- * "ranges".
- */
-static void elaborate_array_ranges(Design*des, NetScope*scope,
-				   vector<netrange_t>&ranges,
-				   const list<pform_range_t>*dims)
-{
-      if (dims == 0)
-	    return;
-
-      for (list<pform_range_t>::const_iterator cur = dims->begin()
-		 ; cur != dims->end() ; ++ cur) {
-
-	    NetExpr*me = elab_and_eval(des, scope, cur->first, 0, true);
-
-	    NetExpr*le = elab_and_eval(des, scope, cur->second, 0, true);
-
-	      /* If elaboration failed for either expression, we
-		 should have already reported the error, so just
-		 skip the following evaluation to recover. */
-
-	    long mnum = 0, lnum = 0;
-	    if ( me && ! eval_as_long(mnum, me) ) {
-		  assert(0);
-		  des->errors += 1;
-	    }
-
-	    if ( le && ! eval_as_long(lnum, le) ) {
-		  assert(0);
-		  des->errors += 1;
-	    }
-
-	    ranges.push_back(netrange_t(mnum, lnum));
-      }
-}
-
-/*
  * Elaborations of types may vary depending on the scope that it is
  * done in, so keep a per-scope cache of the results.
  */
@@ -164,7 +126,8 @@ ivl_type_s* enum_type_t::elaborate_type_raw(Design*, NetScope*scope) const
 ivl_type_s* vector_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
       vector<netrange_t> packed;
-      elaborate_array_ranges(des, scope, packed, pdims.get());
+      if (pdims.get())
+	    evaluate_ranges(des, scope, this, packed, *pdims);
 
       netvector_t*tmp = new netvector_t(packed, base_type);
       tmp->set_signed(signed_flag);
@@ -192,7 +155,8 @@ ivl_type_s* string_type_t::elaborate_type_raw(Design*, NetScope*) const
 ivl_type_s* parray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
       vector<netrange_t>packed;
-      elaborate_array_ranges(des, scope, packed, dims.get());
+      if (dims.get())
+	    evaluate_ranges(des, scope, this, packed, *dims);
 
       ivl_type_t etype = base_type->elaborate_type(des, scope);
 

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -158,6 +158,18 @@ ivl_type_s* parray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
       if (dims.get())
 	    evaluate_ranges(des, scope, this, packed, *dims);
 
+      if (base_type->figure_packed_base_type() == IVL_VT_NO_TYPE) {
+		cerr << this->get_fileline() << " error: Packed array ";
+		if (!name.nil())
+		      cerr << "`" << name << "` ";
+		cerr << "base-type `";
+		if (base_type->name.nil())
+		      cerr << *base_type;
+		else
+		      cerr << base_type->name;
+		cerr << "` is not packed." << endl;
+		des->errors++;
+      }
       ivl_type_t etype = base_type->elaborate_type(des, scope);
 
       return new netparray_t(packed, etype);

--- a/pform.cc
+++ b/pform.cc
@@ -3549,9 +3549,6 @@ static void pform_set_integer_2atom(const struct vlltype&li, uint64_t width, boo
 template <class T> static void pform_set2_data_type(const struct vlltype&li, T*data_type, perm_string name, NetNet::Type net_type, list<named_pexpr_t>*attr)
 {
       ivl_variable_type_t base_type = data_type->figure_packed_base_type();
-      if (base_type == IVL_VT_NO_TYPE) {
-	    VLerror(li, "Compound type is not PACKED in this context.");
-      }
 
       PWire*net = pform_get_make_wire_in_scope(li, name, net_type, NetNet::NOT_A_PORT, base_type);
       assert(net);

--- a/pform_types.cc
+++ b/pform_types.cc
@@ -48,6 +48,16 @@ ivl_variable_type_t vector_type_t::figure_packed_base_type(void) const
       return base_type;
 }
 
+ivl_variable_type_t enum_type_t::figure_packed_base_type() const
+{
+      return base_type;
+}
+
+ivl_variable_type_t atom2_type_t::figure_packed_base_type() const
+{
+      return IVL_VT_BOOL;
+}
+
 atom2_type_t size_type (32, true);
 
 PNamedItem::SymbolType enum_type_t::symbol_type() const

--- a/pform_types.h
+++ b/pform_types.h
@@ -182,6 +182,8 @@ struct enum_type_t : public data_type_t {
 	// Return the elaborated version of the type.
       virtual ivl_type_s*elaborate_type_raw(Design*des, NetScope*scope) const;
 
+      ivl_variable_type_t figure_packed_base_type() const;
+
       SymbolType symbol_type() const;
 
       ivl_variable_type_t base_type;
@@ -217,6 +219,8 @@ struct atom2_type_t : public data_type_t {
       virtual std::ostream& debug_dump(std::ostream&out) const;
 
       ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+
+      ivl_variable_type_t figure_packed_base_type() const;
 };
 
 extern atom2_type_t size_type;


### PR DESCRIPTION
Currently it is only possible to declare packed array variables with a struct type as the element type. And only if the struct does not contain any atom2 or enum types.

Add support for packed arrays of other packed types. This includes packed arrays of enums and vectors as well as packed arrays of packed arrays.

Since packed arrays of packed types are already supported for class members the infrastructure for elaborating all types of packed arrays exists. It just needs to be called when elaborating a signal.

For this to work with enums and atom2 types it is also necessary to define figure_packed_base_type() for these two.

In addition this PR adds a fix to handle invalid packed dimensions correctly and report an elaboration error rather than crash when they are encountered.

Regression tests for this PR: https://github.com/steveicarus/ivtest/pull/18