### PR TITLE
Handle invalid struct members

### DIFF
--- a/ivtest/gold/struct_invalid_member.gold
+++ b/ivtest/gold/struct_invalid_member.gold
@@ -1,0 +1,8 @@
+./ivltests/struct_invalid_member.v:9: syntax error
+./ivltests/struct_invalid_member.v:9: Error in struct/union member.
+./ivltests/struct_invalid_member.v:10: syntax error
+./ivltests/struct_invalid_member.v:10: Error in struct/union member.
+./ivltests/struct_invalid_member.v:11: syntax error
+./ivltests/struct_invalid_member.v:11: Error in struct/union member.
+./ivltests/struct_invalid_member.v:12: syntax error
+./ivltests/struct_invalid_member.v:12: Error in struct/union member.

--- a/ivtest/ivltests/struct_invalid_member.v
+++ b/ivtest/ivltests/struct_invalid_member.v
@@ -1,0 +1,15 @@
+// Check that structs with invalid member declarations are deteceted, report an
+// error and do not cause a crash
+
+module test;
+
+struct packed {
+  logic x;      // OK
+  logic y, z;   // OK
+  logic bit;    // Invalid
+  logic a b c;  // Invalid
+  logc d;       // Invalid
+  e;            // Invalid
+} s;
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -379,6 +379,7 @@ struct_packed_array	normal,-g2009		ivltests
 struct_packed_array2	normal,-g2009		ivltests
 struct_packed_sysfunct	normal,-g2009		ivltests
 struct_packed_write_read2	normal,-g2009	ivltests
+struct_invalid_member	CE,-g2009		ivltests gold=struct_invalid_member.gold
 sv-constants		normal,-g2005-sv	ivltests
 sv_array_assign_pattern2	normal,-g2009	ivltests
 sv_cast_integer		normal,-g2005-sv	ivltests

--- a/ivtest/regression_report-devel.txt
+++ b/ivtest/regression_report-devel.txt
@@ -2154,6 +2154,7 @@ test_mos_strength_reduction: Passed.
        struct_packed_array2: Passed.
      struct_packed_sysfunct: Passed.
   struct_packed_write_read2: Passed.
+      struct_invalid_member: Passed - CE.
                sv-constants: Passed.
    sv_array_assign_pattern2: Passed.
             sv_cast_integer: Passed.
@@ -2561,4 +2562,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2559, Passed=2553, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2560, Passed=2554, Failed=3, Not Implemented=0, Expected Fail=3

--- a/ivtest/regression_report-fsv.txt
+++ b/ivtest/regression_report-fsv.txt
@@ -2161,6 +2161,7 @@ test_mos_strength_reduction: Passed.
        struct_packed_array2: Passed.
      struct_packed_sysfunct: Passed.
   struct_packed_write_read2: Passed.
+      struct_invalid_member: Passed - CE.
                sv-constants: Passed.
    sv_array_assign_pattern2: Passed.
             sv_cast_integer: Passed.
@@ -2561,4 +2562,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2559, Passed=2539, Failed=17, Not Implemented=3, Expected Fail=0
+  Total=2560, Passed=2540, Failed=17, Not Implemented=3, Expected Fail=0

--- a/ivtest/regression_report-strict.txt
+++ b/ivtest/regression_report-strict.txt
@@ -2150,6 +2150,7 @@ test_mos_strength_reduction: Passed.
        struct_packed_array2: Passed.
      struct_packed_sysfunct: Passed.
   struct_packed_write_read2: Passed.
+      struct_invalid_member: Passed - CE.
                sv-constants: Passed.
    sv_array_assign_pattern2: Passed.
             sv_cast_integer: Passed.
@@ -2558,4 +2559,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2556, Passed=2550, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2557, Passed=2551, Failed=3, Not Implemented=0, Expected Fail=3

--- a/ivtest/regression_report-vlog95.txt
+++ b/ivtest/regression_report-vlog95.txt
@@ -2370,6 +2370,7 @@ test_mos_strength_reduction: Passed.
                     struct9: Passed.
      struct_packed_sysfunct: Passed.
   struct_packed_write_read2: Passed.
+      struct_invalid_member: Passed - CE.
                sv-constants: Passed.
      sv_default_port_value1: Passed.
      sv_default_port_value2: Passed.
@@ -2561,4 +2562,4 @@ test_mos_strength_reduction: Passed.
            synth_if_no_else: Passed.
 ============================================================================
 Test results:
-  Total=2559, Passed=2520, Failed=2, Not Implemented=3, Expected Fail=34
+  Total=2560, Passed=2521, Failed=2, Not Implemented=3, Expected Fail=34

--- a/parse.y
+++ b/parse.y
@@ -3036,12 +3036,12 @@ struct_data_type
 struct_union_member_list
   : struct_union_member_list struct_union_member
       { std::list<struct_member_t*>*tmp = $1;
-	tmp->push_back($2);
+	if ($2) tmp->push_back($2);
 	$$ = tmp;
       }
   | struct_union_member
       { std::list<struct_member_t*>*tmp = new std::list<struct_member_t*>;
-	tmp->push_back($1);
+	if ($1) tmp->push_back($1);
 	$$ = tmp;
       }
   ;


### PR DESCRIPTION
When something goes wrong when parsing a struct member, e.g. the type does
not exist, a nullptr is added to the struct member list. This will cause a
crash when iterating over the list.

E.g.

```
struct packed {
  logc x;
} s;
```

Add a check so that nullptr members are not added to the list.