### PR TITLE
 Put enum type into scope when declaring it

### DIFF
--- a/ivtest/ivltests/enum_in_class.v
+++ b/ivtest/ivltests/enum_in_class.v
@@ -1,0 +1,52 @@
+// Check that when a enum type is declared inside a class that the enum is
+// properly installed in the scope and the enum items are available.
+//
+// Also check that when using a typedef of a enum inside a class that the enum
+// is not elaborated inside the class and it is possible to have a enum with the
+// same names inside the class scope.
+
+module test;
+
+typedef enum integer {
+  A = 1
+} e1_t;
+
+class C;
+  typedef enum integer {
+    A = 10
+  } e2_t;
+  e1_t e1;
+  e2_t e2;
+
+  function new();
+    e1 = test.A;
+    e2 = A;
+  endfunction
+
+  function void set(e2_t new_e2);
+    e2 = new_e2;
+  endfunction
+
+endclass
+
+C c;
+
+initial begin
+  c = new;
+  c.e1 = A;
+  c.set(c.e2);
+
+  // Not yet supported
+  // c.e2 = C::A;
+  // c.e2 = c.A;
+
+  // Check that they have the numerical value from the right scope
+  if (c.e1 == 1 && c.e2 == 10) begin
+    $display("PASSED");
+  end else begin
+    $display("FAILED");
+  end
+end
+
+
+endmodule

--- a/ivtest/ivltests/enum_in_class_name_coll.v
+++ b/ivtest/ivltests/enum_in_class_name_coll.v
@@ -1,0 +1,13 @@
+// Check that the enum names are added to the lexor scope of the class and
+// name collisions with other symbols are reported as errors.
+
+module test;
+
+class C;
+  enum {
+    A = 10
+  } e;
+  typedef int A;
+endclass
+
+endmodule

--- a/ivtest/ivltests/enum_in_struct.v
+++ b/ivtest/ivltests/enum_in_struct.v
@@ -1,0 +1,21 @@
+// Check that when a enum type is declared inside a struct that the enum is
+// properly installed in the scope and the enum items are available
+
+module test;
+
+struct packed {
+  enum integer {
+    A
+  } e;
+} s;
+
+initial begin
+  s.e = A;
+  if (s.e == A) begin
+    $display("PASSED");
+  end else begin
+    $display("FAILED");
+  end
+end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -231,6 +231,9 @@ edge			normal,-g2009		ivltests
 enum_base_range		normal,-g2005-sv	ivltests
 enum_elem_ranges	normal,-g2005-sv	ivltests
 enum_dims_invalid	CE,-g2005-sv		ivltests
+enum_in_struct		normal,-g2005-sv	ivltests
+enum_in_class		normal,-g2005-sv	ivltests
+enum_in_class_name_coll	CE,-g2005-sv		ivltests
 enum_next		normal,-g2005-sv	ivltests
 enum_ports		normal,-g2005-sv	ivltests
 enum_test1		normal,-g2005-sv	ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -336,6 +336,8 @@ br_gh391		CE,-g2009		ivltests
 br_gh437		CE,-g2009		ivltests
 br_gh445		CE,-g2009		ivltests
 br_gh461		CE,-g2009		ivltests
+enum_in_class		CE,-g2005-sv		ivltests
+enum_in_class_name_coll	CE,-g2005-sv		ivltests
 sv_class1		CE,-g2009		ivltests
 sv_class2		CE,-g2009		ivltests
 sv_class3		CE,-g2009		ivltests

--- a/ivtest/regression_report-devel.txt
+++ b/ivtest/regression_report-devel.txt
@@ -2006,6 +2006,9 @@ test_mos_strength_reduction: Passed.
             enum_base_range: Passed.
            enum_elem_ranges: Passed.
           enum_dims_invalid: Passed - CE.
+             enum_in_struct: Passed.
+              enum_in_class: Passed.
+    enum_in_class_name_coll: Passed - CE.
                   enum_next: Passed.
                  enum_ports: Passed.
                  enum_test1: Passed.
@@ -2562,4 +2565,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2560, Passed=2554, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2563, Passed=2557, Failed=3, Not Implemented=0, Expected Fail=3

--- a/ivtest/regression_report-fsv.txt
+++ b/ivtest/regression_report-fsv.txt
@@ -2013,6 +2013,9 @@ test_mos_strength_reduction: Passed.
             enum_base_range: Passed.
            enum_elem_ranges: Passed.
           enum_dims_invalid: Passed - CE.
+             enum_in_struct: Passed.
+              enum_in_class: Passed.
+    enum_in_class_name_coll: Passed - CE.
                   enum_next: Passed.
                  enum_ports: Passed.
                  enum_test1: Passed.
@@ -2562,4 +2565,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2560, Passed=2540, Failed=17, Not Implemented=3, Expected Fail=0
+  Total=2563, Passed=2543, Failed=17, Not Implemented=3, Expected Fail=0

--- a/ivtest/regression_report-strict.txt
+++ b/ivtest/regression_report-strict.txt
@@ -2002,6 +2002,9 @@ test_mos_strength_reduction: Passed.
             enum_base_range: Passed.
            enum_elem_ranges: Passed.
           enum_dims_invalid: Passed - CE.
+             enum_in_struct: Passed.
+              enum_in_class: Passed.
+    enum_in_class_name_coll: Passed - CE.
                   enum_next: Passed.
                  enum_ports: Passed.
                  enum_test1: Passed.
@@ -2559,4 +2562,4 @@ test_mos_strength_reduction: Passed.
                 ufuncsynth1: Passed.
 ============================================================================
 Test results:
-  Total=2557, Passed=2551, Failed=3, Not Implemented=0, Expected Fail=3
+  Total=2560, Passed=2554, Failed=3, Not Implemented=0, Expected Fail=3

--- a/ivtest/regression_report-vlog95.txt
+++ b/ivtest/regression_report-vlog95.txt
@@ -248,6 +248,8 @@ Running vlog95 compiler/VVP tests for Icarus Verilog version: 12.
                    br_gh437: Passed - CE.
                    br_gh445: Passed - CE.
                    br_gh461: Passed - CE.
+              enum_in_class: Passed - CE.
+    enum_in_class_name_coll: Passed - CE.
                   sv_class1: Passed - CE.
                   sv_class2: Passed - CE.
                   sv_class3: Passed - CE.
@@ -2309,6 +2311,7 @@ test_mos_strength_reduction: Passed.
                        edge: Passed.
             enum_base_range: Passed.
           enum_dims_invalid: Passed - CE.
+             enum_in_struct: Passed.
                  enum_test2: Passed.
                  enum_test3: Passed - CE.
                  enum_test4: Passed.
@@ -2562,4 +2565,4 @@ test_mos_strength_reduction: Passed.
            synth_if_no_else: Passed.
 ============================================================================
 Test results:
-  Total=2560, Passed=2521, Failed=2, Not Implemented=3, Expected Fail=34
+  Total=2563, Passed=2524, Failed=2, Not Implemented=3, Expected Fail=34

--- a/parse.y
+++ b/parse.y
@@ -2907,6 +2907,7 @@ enum_data_type /* IEEE 1800-2012 A.2.2.1 */
       { enum_type_t*enum_type = $2;
 	FILE_NAME(enum_type, @1);
 	enum_type->names.reset($4);
+	pform_put_enum_type_in_scope(enum_type);
 	$$ = enum_type;
       }
   ;

--- a/pform.cc
+++ b/pform.cc
@@ -827,7 +827,7 @@ static void pform_put_wire_in_scope(perm_string name, PWire*net)
       lexical_scope->wires[name] = net;
 }
 
-static void pform_put_enum_type_in_scope(enum_type_t*enum_set)
+void pform_put_enum_type_in_scope(enum_type_t*enum_set)
 {
       if (lexical_scope->enum_sets.count(enum_set))
             return;
@@ -888,9 +888,6 @@ void pform_set_typedef(perm_string name, data_type_t*data_type, std::list<pform_
       ivl_assert(*data_type, ref == 0);
       ref = data_type;
       ref->name = name;
-
-      if (enum_type_t*enum_type = dynamic_cast<enum_type_t*>(data_type))
-	    pform_put_enum_type_in_scope(enum_type);
 }
 
 void pform_set_type_referenced(const struct vlltype&loc, const char*name)
@@ -3591,10 +3588,6 @@ static void pform_set_enum(const struct vlltype&li, enum_type_t*enum_type,
 
 	// Add the file and line information to the enumeration type.
       FILE_NAME(&(enum_type->li), li);
-
-	// If this is an anonymous enumeration, attach it to the current scope.
-      if (enum_type->name.nil())
-	    pform_put_enum_type_in_scope(enum_type);
 
 	// Now apply the checked enumeration type to the variables
 	// that are being declared with this type.

--- a/pform.h
+++ b/pform.h
@@ -613,4 +613,6 @@ extern void pform_set_timeprec(const char*txt, bool initial_decl);
 extern bool allow_timeunit_decl;
 extern bool allow_timeprec_decl;
 
+void pform_put_enum_type_in_scope(enum_type_t*enum_set);
+
 #endif /* IVL_pform_H */

--- a/pform_pclass.cc
+++ b/pform_pclass.cc
@@ -69,10 +69,6 @@ void pform_class_property(const struct vlltype&loc,
 {
       assert(pform_cur_class);
 
-      if (enum_type_t*enum_set = dynamic_cast<enum_type_t*>(data_type)) {
-	    pform_cur_class->enum_sets .insert(enum_set);
-      }
-
 	// Add the non-static properties to the class type
 	// object. Unwind the list of names to make a map of name to
 	// type.


### PR DESCRIPTION
When creating an enum type it must be added to the scope where it is
declared so it can later be elaborated and the enum and its names can
be referenced in expressions.

In addition the names of the enum must be added to the lexor scope so that
name collisions are detected and can be reported as errors.

This is done with pform_put_enum_type_in_scope() function.

At the moment the function is called from two different places
 * When adding a typedef of a enum type
 * When creating a signal of a enum type

In addition the enum_type_t is added to a class scope `enum_sets` when
declaring a enum property in a class. But this only makes sure that the
enum gets elaborated, its names are not added to the lexor scope.

This works fine for the most part, but breaks for a few corner cases.

E.g. it is possible to declare a enum type as part of the subtype of
another packed type such as structs or packed arrays. E.g.

```systemverilog
struct packed {
  enum {
    A
  } e;
} s;
```

This is not covered by either of the cases above and neither do the names
of the enum get added to the lexor scope, nor is the enum type elaborated.

Another corner case that is currently not working is declaring a class
property where the type is a typedef of a enum that is declared outside of
the class. In this case the enum is elaborated again inside the class
scope. E.g. the below is supposed to work, but fails with an already
declared symbol error.

```systemverilog
typedef enum {
  A
} e_t;

class C;
  typedef enum {
    A
  } e1;
  e_t e2;
endclass
```

In addition since for enums declared in classes they are only added to
`enum_sets`, but names are not added to the lexor scope, it is possible to
declare a different symbol in the class scope with the same name.

E.g. the following elaborates fine

```systemverilog
class C;
  enum {
    A
  } e;
  typedef int A;
endclass
```

To fix this call pform_put_enum_type_in_scope() when the enum_type_t is
created in the parser. This makes sure that it is handled the same
regardless where the type is declared or used.

To support this slightly refactor the parser rule of the enum to factor out common parts into a common rule.