### PR TITLE
Support direct packed arrays of struct and enums and packed arrays of scoped types

### DIFF
--- a/ivtest/ivltests/array_packed.v
+++ b/ivtest/ivltests/array_packed.v
@@ -1,6 +1,10 @@
 // Check that packed arrays of all sorts get elaborated without an error and
 // that the resulting type has the right packed width.
 
+package p;
+  typedef logic [2:0] vector;
+endpackage
+
 module test;
 
 typedef bit bit2;
@@ -8,6 +12,7 @@ typedef logic [1:0] vector;
 
 bit2 [1:0] b;
 vector [2:0] l;
+p::vector [3:0] scoped_pa;
 
 typedef enum logic [7:0] {
   A
@@ -68,6 +73,7 @@ initial begin
   // Packed arrays of basic types
   failed |= $bits(b) !== 2;
   failed |= $bits(l) !== 2 * 3;
+  failed |= $bits(scoped_pa) !== 3 * 4;
 
   // Packed arrays of enums
   failed |= $bits(e) !== 8;

--- a/ivtest/ivltests/array_packed.v
+++ b/ivtest/ivltests/array_packed.v
@@ -23,6 +23,10 @@ EP [2:0] epp1;
 EPP epp2;
 EPP [3:0] eppp;
 
+enum logic [7:0] {
+  B
+} [1:0] ep3;
+
 typedef struct packed {
   longint x;
 } S1;
@@ -54,6 +58,10 @@ SP [9:0] spp1;
 SPP spp2;
 SPP [1:0] sppp;
 
+struct packed {
+  S2 s;
+} [3:0] sp3;
+
 bit failed = 1'b0;
 
 initial begin
@@ -65,17 +73,19 @@ initial begin
   failed |= $bits(e) !== 8;
   failed |= $bits(ep1) !== $bits(e) * 2;
   failed |= $bits(ep2) !== $bits(ep1);
+  failed |= $bits(ep3) !== $bits(ep1);
   failed |= $bits(epp1) !== $bits(ep1) * 3;
   failed |= $bits(epp2) !== $bits(epp1);
   failed |= $bits(eppp) !== $bits(epp1) * 4;
 
   // Packed arrays of structs
   failed |= $bits(s) !== S_SIZE;
-  failed |= $bits(sp1) != $bits(s) * 4;
-  failed |= $bits(sp2) != $bits(sp1);
-  failed |= $bits(spp1) != $bits(sp1) * 10;
-  failed |= $bits(spp1) != $bits(spp2);
-  failed |= $bits(sppp) != $bits(spp1) * 2;
+  failed |= $bits(sp1) !== $bits(s) * 4;
+  failed |= $bits(sp2) !== $bits(sp1);
+  failed |= $bits(sp3) !== $bits(sp1);
+  failed |= $bits(spp1) !== $bits(sp1) * 10;
+  failed |= $bits(spp1) !== $bits(spp2);
+  failed |= $bits(sppp) !== $bits(spp1) * 2;
 
   if (failed)
     $display("FAILED");

--- a/parse.y
+++ b/parse.y
@@ -1186,6 +1186,13 @@ packed_array_data_type /* IEEE1800-2005: A.2.2.1 */
 	delete[]$1.text;
 	$$ = $1.type;
       }
+  | PACKAGE_IDENTIFIER K_SCOPE_RES
+      { lex_in_package_scope($1); }
+    TYPE_IDENTIFIER
+      { lex_in_package_scope(0);
+	$$ = $4.type;
+	delete[]$4.text;
+      }
   ;
 
 data_type /* IEEE1800-2005: A.2.2.1 */
@@ -1232,13 +1239,6 @@ data_type /* IEEE1800-2005: A.2.2.1 */
         } else {
 	      $$ = $1;
         }
-      }
-  | PACKAGE_IDENTIFIER K_SCOPE_RES
-      { lex_in_package_scope($1); }
-    TYPE_IDENTIFIER
-      { lex_in_package_scope(0);
-	$$ = $4.type;
-	delete[]$4.text;
       }
   | K_string
       { string_type_t*tmp = new string_type_t;


### PR DESCRIPTION
Add support for two more cases where packed arrays are allowed.

1) Direct packed arrays of structs and enums without a typedef of the struct or enum

E.g.
```systemverilog
struct packed {
  int x;
} [1:0] pa;
```

2) Using a scoped type identifier as the base type for the packed array

E.g.
```systemverilog
package p;
  typedef logic [1:0] vector;
endpackage

module test;
  p::vector [1:0] pa;
endmodule
```

Both is already supported just fine during elaboration, just needs some minor changes to the parser to support this.