### PR TITLE
 Allow unnamed begin/end block with only variable declarations

### DIFF
--- a/ivtest/ivltests/unnamed_block_var_decl.v
+++ b/ivtest/ivltests/unnamed_block_var_decl.v
@@ -1,0 +1,30 @@
+// Check variable declarations in unnamed blocks
+// All of these should pass in SystemVerilog and all but the last should fail in
+// Verilog
+
+module test;
+
+initial begin
+  integer x;
+end
+
+initial begin
+  integer x;
+  integer y;
+end
+
+initial begin
+  integer x, y;
+end
+
+initial begin
+  integer x;
+  integer y;
+  x = y;
+end
+
+initial begin
+  $display("PASSED");
+end
+
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -82,6 +82,7 @@ pr3015421		CE			ivltests gold=pr3015421-fsv.gold
 resetall		normal,-Wtimescale	ivltests gold=resetall-fsv.gold
 scope2b			normal			ivltests
 sys_func_task_error	RE			ivltests gold=sys_func_task_error-fsv.gold
+unnamed_block_var_decl	normal			ivltests
 
 # We do not run synthesis when forcing SystemVerilog so these pass
 br995			normal			ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -1675,6 +1675,7 @@ undef_lval_select4b	CE			ivltests
 undef_lval_select4c	CE			ivltests
 undef_lval_select5	normal			ivltests
 undefined_shift		normal			ivltests
+unnamed_block_var_decl	CE			ivltests
 urand_r			normal			ivltests gold=urand_r.gold
 urand_r2		normal			ivltests gold=urand_r.gold
 urand_r3		normal			ivltests gold=urand_r.gold

--- a/parse.y
+++ b/parse.y
@@ -6593,11 +6593,6 @@ statement_item /* This is roughly statement_item in the LRM */
      name. These are handled by pushing the scope name, then matching
      the declarations. The scope is popped at the end of the block. */
 
-  | K_begin K_end
-      { PBlock*tmp = new PBlock(PBlock::BL_SEQ);
-	FILE_NAME(tmp, @1);
-	$$ = tmp;
-      }
   /* In SystemVerilog an unnamed block can contain variable declarations. */
   | K_begin
       { PBlock*tmp = pform_push_block_scope(@1, 0, PBlock::BL_SEQ);
@@ -6618,7 +6613,7 @@ statement_item /* This is roughly statement_item in the LRM */
 	    delete tmp;
 	}
       }
-    statement_or_null_list K_end
+    statement_or_null_list_opt K_end
       { PBlock*tmp;
 	if ($3) {
 	    pform_pop_scope();


### PR DESCRIPTION
While it is not a particular useful construct it is legal to have a
begin/end block with just variable declarations and no statements. E.g.

```systemverilog
begin
  int x;
end
```

At the moment there is a special rule for completely empty begin/end
blocks. Remove that rule and change the statement_or_null_list in the
begin/end block parser section to a statement_or_null_list_opt. This way it
covers both completely empty blocks as well as blocks with only variable
declarations.

Note that this already works as expected for named begin/end blocks