### PR TITLE
Set correct line info for enums and structs

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -203,7 +203,7 @@ static void elaborate_scope_enumeration(Design*des, NetScope*scope,
 					 enum_type->names->size(),
 					 enum_type);
 
-      use_enum->set_line(enum_type->li);
+      use_enum->set_line(*enum_type);
       scope->add_enumeration_set(enum_type, use_enum);
 
       size_t name_idx = 0;

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -179,6 +179,8 @@ netstruct_t* struct_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
       netstruct_t*res = new netstruct_t;
 
+      res->set_line(*this);
+
       res->packed(packed_flag);
       res->set_signed(signed_flag);
 

--- a/ivtest/gold/enum_line_info.gold
+++ b/ivtest/gold/enum_line_info.gold
@@ -1,0 +1,5 @@
+./ivltests/enum_line_info.v:7: error: Enumeration name B and A have the same value: 1'd0
+./ivltests/enum_line_info.v:12: error: Enumeration name D and C have the same value: 1'd0
+./ivltests/enum_line_info.v:17: error: Enumeration name F and E have the same value: 1'd0
+./ivltests/enum_line_info.v:22: error: Enumeration name H and G have the same value: 1'd0
+5 error(s) during elaboration.

--- a/ivtest/gold/struct_line_info.gold
+++ b/ivtest/gold/struct_line_info.gold
@@ -1,0 +1,4 @@
+./ivltests/struct_line_info.v:7: error: Member r of packed struct/union must be packed.
+./ivltests/struct_line_info.v:12: error: Member r of packed struct/union must be packed.
+./ivltests/struct_line_info.v:17: error: Member r of packed struct/union must be packed.
+3 error(s) during elaboration.

--- a/ivtest/ivltests/enum_line_info.v
+++ b/ivtest/ivltests/enum_line_info.v
@@ -1,0 +1,32 @@
+// Checks that the line and file information is correctly attached to a enum
+// data type and will be used when printing an error message about the enum.
+
+module test;
+
+// Direct
+enum logic {
+  A, B = A
+} e1;
+
+// Used in a struct
+typedef enum logic {
+  C, D = C
+} enum1_type;
+
+// Used as a signal type
+typedef enum logic {
+  E, F = E
+} enum2_type;
+
+// Unreferenced
+typedef enum logic {
+  G, H = G
+} enum3_type;
+
+struct packed {
+  enum1_type e;
+} s;
+
+enum2_type e2;
+
+endmodule

--- a/ivtest/ivltests/struct_line_info.v
+++ b/ivtest/ivltests/struct_line_info.v
@@ -1,0 +1,24 @@
+// Checks that the line and file information is correctly attached to a struct
+// data type and will be used when printing an error message about the struct.
+
+module test;
+
+// Direct
+struct packed {
+  real r;
+} s1;
+
+// Used in a struct
+typedef struct packed {
+  real r;
+} struct1_type;
+
+// Used as a signal type
+typedef struct packed {
+  struct1_type s;
+  real r;
+} struct2_type;
+
+struct2_type s2;
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -236,6 +236,7 @@ enum_dims_invalid	CE,-g2005-sv		ivltests
 enum_in_struct		normal,-g2005-sv	ivltests
 enum_in_class		normal,-g2005-sv	ivltests
 enum_in_class_name_coll	CE,-g2005-sv		ivltests
+enum_line_info		CE,-g2005-sv		ivltests gold=enum_line_info.gold
 enum_next		normal,-g2005-sv	ivltests
 enum_order		normal,-g2005-sv	ivltests
 enum_ports		normal,-g2005-sv	ivltests
@@ -381,6 +382,7 @@ struct6			normal,-g2009		ivltests
 struct7			normal,-g2009		ivltests
 struct8			normal,-g2009		ivltests
 struct9			normal,-g2009		ivltests
+struct_line_info	CE,-g2009		ivltests gold=struct_line_info.gold
 struct_packed_array	normal,-g2009		ivltests
 struct_packed_array2	normal,-g2009		ivltests
 struct_packed_sysfunct	normal,-g2009		ivltests

--- a/pform.cc
+++ b/pform.cc
@@ -3588,9 +3588,6 @@ static void pform_set_enum(const struct vlltype&li, enum_type_t*enum_type,
 	// IVL_VT_BOOL.
       assert(enum_type->base_type==IVL_VT_LOGIC || enum_type->base_type==IVL_VT_BOOL);
 
-	// Add the file and line information to the enumeration type.
-      FILE_NAME(&(enum_type->li), li);
-
 	// Now apply the checked enumeration type to the variables
 	// that are being declared with this type.
       for (list<perm_string>::iterator cur = names->begin()

--- a/pform_types.h
+++ b/pform_types.h
@@ -191,7 +191,6 @@ struct enum_type_t : public data_type_t {
       bool integer_flag; // True if "integer" was used
       std::unique_ptr< std::list<pform_range_t> > range;
       std::unique_ptr< std::list<named_pexpr_t> > names;
-      LineInfo li;
 };
 
 struct struct_member_t : public LineInfo {


### PR DESCRIPTION
Both `netenum_t` and and `netstruct_t` inherit from `LineInfo`. This information is used when generating error messages relating to these types. But the line info is not always set correctly, which can result in confusing error messages. E.g.

```
:0: error: Member r of packed struct/union must be packed.
```

For structs the line info is never set.

For enums the line info is set to the location where a signal of that type is declared. This works OK when it is a direction enum signal declaration since the declaration location of the signal and the type are the same. But if the enum is declared inside an aggregate type such as a class or struct it is never set. If the enum is a typedef it will be set to the location of the last signal declaration using that type.

Set the LineInfo for both of them so that it always points to the location of the declaration of the data type.