### PR TITLE
 Handle implicit `localparam`

### DIFF
--- a/ivtest/ivltests/localparam_implicit.v
+++ b/ivtest/ivltests/localparam_implicit.v
@@ -1,0 +1,30 @@
+// Check that all parameters in a parameter port list after a `localparam` get
+// elaborated as localparams, until the next `parameter`.
+
+module a #(
+  parameter A = 1, B = 2,
+  localparam C = 3, D = 4,
+  parameter E = 5
+);
+
+initial begin
+  if (A == 10 && B == 20 && C == 3 && D == 4 && E == 50) begin
+    $display("PASSED");
+  end else begin
+    $display("FAILED");
+  end
+end
+
+endmodule
+
+module b;
+
+  a #(
+    .A(10),
+    .B(20),
+    .C(30),
+    .D(40),
+    .E(50)
+  ) i_a();
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -300,6 +300,7 @@ l_equiv			normal,-g2005-sv	ivltests
 l_equiv_ca		normal,-g2005-sv	ivltests
 l_equiv_const		normal,-g2005-sv	ivltests
 line_directive		normal,-g2009,-I./ivltests	ivltests gold=line_directive.gold
+localparam_implicit	normal,-g2005-sv	ivltests
 localparam_query	normal,-g2005-sv	ivltests
 localparam_type2	normal,-g2009		ivltests
 logical_short_circuit	normal,-g2012		ivltests

--- a/parse.y
+++ b/parse.y
@@ -5688,10 +5688,10 @@ parameter_assign
   ;
 
 localparam_assign
-  : IDENTIFIER '=' expression
+  : IDENTIFIER '=' expression parameter_value_ranges_opt
       { PExpr*tmp = $3;
 	pform_set_parameter(@1, lex_strings.make($1), true, param_data_type,
-			    tmp, 0);
+			    tmp, $4);
 	delete[]$1;
       }
   ;

--- a/parse.y
+++ b/parse.y
@@ -5681,7 +5681,8 @@ localparam_assign_list
 parameter_assign
   : IDENTIFIER '=' expression parameter_value_ranges_opt
       { PExpr*tmp = $3;
-	pform_set_parameter(@1, lex_strings.make($1), param_data_type, tmp, $4);
+	pform_set_parameter(@1, lex_strings.make($1), false, param_data_type,
+			    tmp, $4);
 	delete[]$1;
       }
   ;
@@ -5689,7 +5690,8 @@ parameter_assign
 localparam_assign
   : IDENTIFIER '=' expression
       { PExpr*tmp = $3;
-	pform_set_localparam(@1, lex_strings.make($1), param_data_type, tmp);
+	pform_set_parameter(@1, lex_strings.make($1), true, param_data_type,
+			    tmp, 0);
 	delete[]$1;
       }
   ;

--- a/pform.h
+++ b/pform.h
@@ -432,12 +432,9 @@ extern LexicalScope::range_t* pform_parameter_value_range(bool exclude_flag,
 
 extern void pform_set_parameter(const struct vlltype&loc,
 				perm_string name,
+				bool is_local,
 				data_type_t*data_type,
 				PExpr*expr, LexicalScope::range_t*value_range);
-extern void pform_set_localparam(const struct vlltype&loc,
-				 perm_string name,
-				 data_type_t*data_type,
-				 PExpr*expr);
 extern void pform_set_specparam(const struct vlltype&loc,
 				 perm_string name,
 				 std::list<pform_range_t>*range,


### PR DESCRIPTION
When declaring module parameters in the ANSI style parameter list it is
possible to omit the `parameter` or `localparam` keyword. In this case
whether the parameter is local or non-local is inherited from the previous
parameter.

In the current implementation when the type of the parameter is not
specified it will always use parameter. E.g. the following will create a
localparam A and a parameter B, while it should be localparam A and B.

```systemverilog
module #(localparam A = 1, B = 2);
```

Fix this by remembering whether the previous entry was a parameter or
localparam. This is similar to how the parameter data type is already
remembered.

To enable this the handling of parameters and localparams is consolidated. This allows Verilog-AMS parameter value ranges to be specified on localparams (as specified by AMS).