### PR TITLE
Fix localparam_implicit.v test

### DIFF
--- a/ivtest/ivltests/localparam_implicit2.v
+++ b/ivtest/ivltests/localparam_implicit2.v
@@ -22,8 +22,8 @@ module b;
   a #(
     .A(10),
     .B(20),
-    // Cannot override localparam .C(30),
-    // Cannot override localparam .D(40),
+    .C(30), // This will cause an error
+    .D(40), // This will cause an error
     .E(50)
   ) i_a();
 

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -301,6 +301,7 @@ l_equiv_ca		normal,-g2005-sv	ivltests
 l_equiv_const		normal,-g2005-sv	ivltests
 line_directive		normal,-g2009,-I./ivltests	ivltests gold=line_directive.gold
 localparam_implicit	normal,-g2005-sv	ivltests
+localparam_implicit2	CE,-g2005-sv	ivltests
 localparam_query	normal,-g2005-sv	ivltests
 localparam_type2	normal,-g2009		ivltests
 logical_short_circuit	normal,-g2012		ivltests


### PR DESCRIPTION
The localparam_implicit.v test was broken by a recent commit. Fix the test, since the commit is correct and the test really is broken.