### PR TITLE
Allow unnamed parallel block with only variable declarations

### DIFF
--- a/ivtest/ivltests/unnamed_fork_var_decl.v
+++ b/ivtest/ivltests/unnamed_fork_var_decl.v
@@ -1,0 +1,29 @@
+// Check variable declarations in unnamed forks
+// All of these should pass in SystemVerilog and all should fail in Verilog
+
+module test;
+
+initial fork
+  integer x;
+join
+
+initial fork
+  integer x;
+  integer y;
+join
+
+initial fork
+  integer x, y;
+join
+
+initial fork
+  integer x;
+  integer y;
+  x = y;
+join
+
+initial begin
+  $display("PASSED");
+end
+
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -83,6 +83,7 @@ resetall		normal,-Wtimescale	ivltests gold=resetall-fsv.gold
 scope2b			normal			ivltests
 sys_func_task_error	RE			ivltests gold=sys_func_task_error-fsv.gold
 unnamed_block_var_decl	normal			ivltests
+unnamed_fork_var_decl	normal			ivltests
 
 # We do not run synthesis when forcing SystemVerilog so these pass
 br995			normal			ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -1677,6 +1677,7 @@ undef_lval_select4c	CE			ivltests
 undef_lval_select5	normal			ivltests
 undefined_shift		normal			ivltests
 unnamed_block_var_decl	CE			ivltests
+unnamed_fork_var_decl	CE			ivltests
 urand_r			normal			ivltests gold=urand_r.gold
 urand_r2		normal			ivltests gold=urand_r.gold
 urand_r3		normal			ivltests gold=urand_r.gold

--- a/parse.y
+++ b/parse.y
@@ -6652,11 +6652,6 @@ statement_item /* This is roughly statement_item in the LRM */
      need to do is remember that this is a parallel block so that the
      code generator can do the right thing. */
 
-  | K_fork join_keyword
-      { PBlock*tmp = new PBlock($2);
-	FILE_NAME(tmp, @1);
-	$$ = tmp;
-      }
   /* In SystemVerilog an unnamed block can contain variable declarations. */
   | K_fork
       { PBlock*tmp = pform_push_block_scope(@1, 0, PBlock::BL_PAR);
@@ -6677,7 +6672,7 @@ statement_item /* This is roughly statement_item in the LRM */
 	    delete tmp;
 	}
       }
-    statement_or_null_list join_keyword
+    statement_or_null_list_opt join_keyword
       { PBlock*tmp;
 	if ($3) {
 	    pform_pop_scope();


### PR DESCRIPTION
While it is not a particular useful construct it is legal to have
parallel blocks with just variable declarations and no statements. E.g.

```SystemVerilog
fork
  int x;
join
```

At the moment there is a special rule for completely empty parallel
blocks. Remove that rule and change the statement_or_null_list in the
fork/join parser section to a statement_or_null_list_opt. This way it
covers both completely empty parallel blocks as well as parallel blocks
with only variable declarations.

Note that this already works as expected for named parallel blocks.

This is similar to https://github.com/steveicarus/iverilog/pull/594 which made the same change for sequential blocks.