### PR TITLE
 Let the parser recover from end label on unnamed block

### DIFF
--- a/ivtest/gold/sv_end_label_fail.gold
+++ b/ivtest/gold/sv_end_label_fail.gold
@@ -1,15 +1,15 @@
-./ivltests/sv_end_label_fail.v:4: error: End label doesn't match begin name
-./ivltests/sv_end_label_fail.v:7: error: End label doesn't match fork name
-./ivltests/sv_end_label_fail.v:10: error: End label doesn't match fork name
-./ivltests/sv_end_label_fail.v:13: error: End label doesn't match fork name
-./ivltests/sv_end_label_fail.v:16: error: End label doesn't match task name
-./ivltests/sv_end_label_fail.v:19: error: End label doesn't match task name
-./ivltests/sv_end_label_fail.v:23: error: End label doesn't match function name
-./ivltests/sv_end_label_fail.v:26: error: End label doesn't match function name
-./ivltests/sv_end_label_fail.v:28: error: End label doesn't match module name.
-./ivltests/sv_end_label_fail.v:38: error: End label doesn't match begin name
-./ivltests/sv_end_label_fail.v:40: error: End label doesn't match module name.
-./ivltests/sv_end_label_fail.v:43: error: End label doesn't match package name
-./ivltests/sv_end_label_fail.v:47: error: Class end label doesn't match class name.
-./ivltests/sv_end_label_fail.v:48: error: End label doesn't match program name.
-./ivltests/sv_end_label_fail.v:64: error: End label doesn't match primitive name
+./ivltests/sv_end_label_fail.v:4: error: block end label `b_label_f` doesn't match block name `b_label`.
+./ivltests/sv_end_label_fail.v:7: error: fork end label `fj_label_f` doesn't match fork name `fj_label`.
+./ivltests/sv_end_label_fail.v:10: error: fork end label `fja_label_f` doesn't match fork name `fja_label`.
+./ivltests/sv_end_label_fail.v:13: error: fork end label `fjn_label_f` doesn't match fork name `fjn_label`.
+./ivltests/sv_end_label_fail.v:16: error: task end label `t_label_f` doesn't match task name `t_label`.
+./ivltests/sv_end_label_fail.v:19: error: task end label `twa_label_f` doesn't match task name `twa_label`.
+./ivltests/sv_end_label_fail.v:23: error: function end label `fn_label_f` doesn't match function name `fn_label`.
+./ivltests/sv_end_label_fail.v:26: error: function end label `fa_label_f` doesn't match function name `fa_label`.
+./ivltests/sv_end_label_fail.v:28: error: module end label `top_f` doesn't match module name `top`.
+./ivltests/sv_end_label_fail.v:38: error: block end label `g_label_f` doesn't match block name `g_label`.
+./ivltests/sv_end_label_fail.v:40: error: module end label `extra_f` doesn't match module name `extra`.
+./ivltests/sv_end_label_fail.v:43: error: package end label `pkg_f` doesn't match package name `pkg`.
+./ivltests/sv_end_label_fail.v:47: error: class end label `foo_f` doesn't match class name `foo`.
+./ivltests/sv_end_label_fail.v:48: error: program end label `pgm_f` doesn't match program name `pgm`.
+./ivltests/sv_end_label_fail.v:64: error: primitive end label `pinv_f` doesn't match primitive name `pinv`.

--- a/ivtest/gold/sv_end_labels_bad.gold
+++ b/ivtest/gold/sv_end_labels_bad.gold
@@ -1,2 +1,2 @@
-./ivltests/sv_end_labels_bad.v:14: error: End label doesn't match begin name
-./ivltests/sv_end_labels_bad.v:16: error: End label doesn't match module name.
+./ivltests/sv_end_labels_bad.v:14: error: block end label `dummy_label_bad` doesn't match block name `dummy_label`.
+./ivltests/sv_end_labels_bad.v:16: error: module end label `test_bad` doesn't match module name `test`.

--- a/ivtest/gold/sv_end_labels_unnamed.gold
+++ b/ivtest/gold/sv_end_labels_unnamed.gold
@@ -1,0 +1,3 @@
+./ivltests/sv_end_labels_unnamed.v:7: error: unnamed block must not have end label.
+./ivltests/sv_end_labels_unnamed.v:11: error: unnamed block must not have end label.
+./ivltests/sv_end_labels_unnamed.v:14: error: unnamed fork must not have end label.

--- a/ivtest/ivltests/sv_end_labels_unnamed.v
+++ b/ivtest/ivltests/sv_end_labels_unnamed.v
@@ -1,0 +1,16 @@
+// Check that end labels on unnamed blocks generate an error
+
+module test;
+
+  generate
+    if (1) begin
+    end : label
+  endgenerate
+
+  initial begin
+  end : label
+
+  initial fork
+  join : label
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -451,6 +451,7 @@ sv_end_label		normal,-g2005-sv	ivltests
 sv_end_label_fail	CE,-g2009		ivltests gold=sv_end_label_fail.gold
 sv_end_labels		normal,-g2009		ivltests
 sv_end_labels_bad	CE,-g2009		ivltests gold=sv_end_labels_bad.gold
+sv_end_labels_unnamed	CE,-g2009		ivltests gold=sv_end_labels_unnamed.gold
 sv_enum1		normal,-g2009		ivltests
 sv_for_variable		normal,-g2009		ivltests
 sv_foreach1		normal,-g2009		ivltests


### PR DESCRIPTION
Currently when encountering an end label on a unnamed block
a 'syntax error' will be generated and the parser will give up.

Slightly refactor the parser so that this case is detected, a more specific
error message is generated and the parser can recover and continue.

This also slightly reduces the parser since it allows to merge the almost
identical rules for handling named and unnamed blocks.

To make this easier to implement add a common helper function that will
handle the end label checking. This helper function will emit consistent
error messages for the different types of end labels, which requires
refreshing of some test gold files.