### PR TITLE
 Support scoped base class type

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -514,7 +514,7 @@ static void elaborate_scope_class(Design*des, NetScope*scope, PClass*pclass)
 
       netclass_t*use_base_class = 0;
       if (base_class) {
-	    use_base_class = scope->find_class(des, base_class->name);
+	    use_base_class = base_class->save_elaborated_type;
 	    if (use_base_class == 0) {
 		  cerr << pclass->get_fileline() << ": error: "
 		       << "Base class " << base_class->name

--- a/ivtest/ivltests/sv_class_extends_scoped.v
+++ b/ivtest/ivltests/sv_class_extends_scoped.v
@@ -1,0 +1,29 @@
+// Check that base class defined in a package is handled correctly
+
+package P;
+  class B;
+    task check;
+      $display("PASSED");
+    endtask
+  endclass
+endpackage
+
+module test;
+
+  class B;
+    task check;
+      $display("FAILED");
+    endtask
+  endclass
+
+  class C extends P::B;
+  endclass
+
+  C c;
+
+  initial begin
+    c = new;
+    c.check();
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -424,6 +424,7 @@ sv_class21		normal,-g2009		ivltests
 sv_class22		normal,-g2009		ivltests
 sv_class23		normal,-g2009		ivltests
 sv_class24		normal,-g2009		ivltests
+sv_class_extends_scoped	normal,-g2009		ivltests
 sv_darray1		normal,-g2009		ivltests
 sv_darray2		normal,-g2009		ivltests
 sv_darray3		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -363,6 +363,7 @@ sv_class21		CE,-g2009		ivltests
 sv_class22		CE,-g2009		ivltests
 sv_class23		CE,-g2009		ivltests
 sv_class24		CE,-g2009		ivltests
+sv_class_extends_scoped	CE,-g2009		ivltests
 sv_end_label		CE,-g2009		ivltests  # Also generate
 sv_foreach2		CE,-g2009,-pallowsigned=1	ivltests
 sv_foreach3		CE,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -851,17 +851,13 @@ class_declaration_endlabel_opt
      a data_type. */
 
 class_declaration_extends_opt /* IEEE1800-2005: A.1.2 */
-  : K_extends TYPE_IDENTIFIER
-      { pform_set_type_referenced(@2, $2.text);
-	$$.type = $2.type;
-	$$.exprs= 0;
-	delete[]$2.text;
+  : K_extends ps_type_identifier
+      { $$.type  = $2;
+	$$.exprs = 0;
       }
-  | K_extends TYPE_IDENTIFIER '(' expression_list_with_nuls ')'
-      { pform_set_type_referenced(@2, $2.text);
-	$$.type  = $2.type;
+  | K_extends ps_type_identifier '(' expression_list_with_nuls ')'
+      { $$.type  = $2;
 	$$.exprs = $4;
-	delete[]$2.text;
       }
   |
       { $$.type = 0; $$.exprs = 0; }


### PR DESCRIPTION
A base class can be referenced by scope. E.g. if the base class is in a
package.

```SystemVerilog
package P;
  class B;
  endclass
endpackage

module test;
  class C extends P::B;
  endlcass
endmodule
```

To support this let the parser accept a scope identifier for the base
class.

A small change is also necessary to how the base class lockup is done
during elaboration. At the moment the code will search for the base class
by name in the current scope. This doesn't work with scoped identifiers.

But we already have a reference to the base class data type, so we don't
have to search for it by name.

To enable this add a shared parser rule that handles both type identifiers and scoped type identifiers.