### PR TITLE
Allow parameter in generate blocks for SystemVerilog

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -415,8 +415,6 @@ void PEIdent::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
             while (ss) {
                   if (ss->wires.find(name) != ss->wires.end())
                         return;
-                  if (ss->localparams.find(name) != ss->localparams.end())
-                        return;
                   if (ss->parameters.find(name) != ss->parameters.end())
                         return;
                   if (ss->genvars.find(name) != ss->genvars.end())

--- a/PScope.h
+++ b/PScope.h
@@ -101,7 +101,7 @@ class LexicalScope {
 	   this map. */
       struct param_expr_t : public PNamedItem {
             inline param_expr_t() : data_type(0), expr(0), range(0),
-	                            local_flag(false) { }
+				    local_flag(false), overridable(true) { }
 	      // Type information.
 	    data_type_t*data_type;
 	      // Value expression
@@ -110,6 +110,8 @@ class LexicalScope {
 	    range_t*range;
 	      // Whether it is a local parameter
 	    bool local_flag;
+	      // Whether the parameter can be overridden
+	    bool overridable;
 
 	    SymbolType symbol_type() const;
       };

--- a/PScope.h
+++ b/PScope.h
@@ -100,18 +100,20 @@ class LexicalScope {
 	   is elaborated. During parsing, I put the parameters into
 	   this map. */
       struct param_expr_t : public PNamedItem {
-            inline param_expr_t() : data_type(0), expr(0), range(0) { }
+            inline param_expr_t() : data_type(0), expr(0), range(0),
+	                            local_flag(false) { }
 	      // Type information.
 	    data_type_t*data_type;
 	      // Value expression
 	    PExpr*expr;
 	      // If there are range constraints, list them here
 	    range_t*range;
+	      // Whether it is a local parameter
+	    bool local_flag;
 
 	    SymbolType symbol_type() const;
       };
       std::map<perm_string,param_expr_t*>parameters;
-      std::map<perm_string,param_expr_t*>localparams;
 
 	// Defined types in the scope.
       std::map<perm_string,data_type_t*>typedefs;
@@ -154,8 +156,6 @@ class LexicalScope {
       void dump_typedefs_(std::ostream&out, unsigned indent) const;
 
       void dump_parameters_(std::ostream&out, unsigned indent) const;
-
-      void dump_localparams_(std::ostream&out, unsigned indent) const;
 
       void dump_enumerations_(std::ostream&out, unsigned indent) const;
 

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -126,7 +126,7 @@ static void collect_parm_item(Design*des, NetScope*scope, perm_string name,
       // don't try to elaborate it here, because there may be references to
       // other parameters still being located during scope elaboration.
       scope->set_parameter(name, is_annotatable, cur.expr, cur.data_type,
-			   cur.local_flag, range_list, cur);
+			   cur.local_flag, cur.overridable, range_list, cur);
 
 }
 

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -68,7 +68,7 @@ typedef map<perm_string,LexicalScope::param_expr_t*>::const_iterator mparm_it_t;
 
 static void collect_parm_item(Design*des, NetScope*scope, perm_string name,
 			      const LexicalScope::param_expr_t&cur,
-			      bool is_annotatable, bool local_flag)
+			      bool is_annotatable)
 {
       if (debug_scopes) {
 	    cerr << cur.get_fileline() << ": " << __func__  << ": "
@@ -125,7 +125,8 @@ static void collect_parm_item(Design*des, NetScope*scope, perm_string name,
       // not yet known, don't try to guess here, put the type guess off. Also
       // don't try to elaborate it here, because there may be references to
       // other parameters still being located during scope elaboration.
-      scope->set_parameter(name, is_annotatable, cur.expr, cur.data_type, local_flag, range_list, cur);
+      scope->set_parameter(name, is_annotatable, cur.expr, cur.data_type,
+			   cur.local_flag, range_list, cur);
 
 }
 
@@ -140,22 +141,7 @@ static void collect_scope_parameters(Design*des, NetScope*scope,
       for (mparm_it_t cur = parameters.begin()
 		 ; cur != parameters.end() ;  ++ cur ) {
 
-	    collect_parm_item(des, scope, cur->first, *(cur->second), false, false);
-      }
-}
-
-static void collect_scope_localparams(Design*des, NetScope*scope,
-      const map<perm_string,LexicalScope::param_expr_t*>&localparams)
-{
-      if (debug_scopes) {
-	    cerr << scope->get_fileline() << ": " << __func__ << ": "
-		 << "collect localparams for " << scope_path(scope) << "." << endl;
-      }
-
-      for (mparm_it_t cur = localparams.begin()
-		 ; cur != localparams.end() ;  ++ cur ) {
-
-	    collect_parm_item(des, scope, cur->first, *(cur->second), false, true);
+	    collect_parm_item(des, scope, cur->first, *(cur->second), false);
       }
 }
 
@@ -170,7 +156,7 @@ static void collect_scope_specparams(Design*des, NetScope*scope,
       for (mparm_it_t cur = specparams.begin()
 		 ; cur != specparams.end() ;  ++ cur ) {
 
-	    collect_parm_item(des, scope, cur->first, *(cur->second), true, false);
+	    collect_parm_item(des, scope, cur->first, *(cur->second), true);
       }
 }
 
@@ -765,7 +751,6 @@ bool PPackage::elaborate_scope(Design*des, NetScope*scope)
       scope->add_typedefs(&typedefs);
 
       collect_scope_parameters(des, scope, parameters);
-      collect_scope_localparams(des, scope, localparams);
 
       if (debug_scopes) {
 	    cerr << get_fileline() << ": PPackage::elaborate_scope: "
@@ -804,8 +789,6 @@ bool Module::elaborate_scope(Design*des, NetScope*scope,
 	// module have been done.
 
       collect_scope_parameters(des, scope, parameters);
-
-      collect_scope_localparams(des, scope, localparams);
 
       collect_scope_specparams(des, scope, specparams);
 
@@ -1278,11 +1261,11 @@ void PGenerate::elaborate_subscope_(Design*des, NetScope*scope)
 	    scope->add_genvar((*cur).first, (*cur).second);
       }
 
-	// Scan the localparams in this scope, and store the information
+	// Scan the parameters in this scope, and store the information
         // needed to evaluate the parameter expressions. The expressions
 	// will be evaluated later, once all parameter overrides for this
 	// module have been done.
-      collect_scope_localparams(des, scope, localparams);
+      collect_scope_parameters(des, scope, parameters);
 
 	// Run through the defparams for this scope and save the result
 	// in a table for later final override.
@@ -1621,8 +1604,6 @@ void PFunction::elaborate_scope(Design*des, NetScope*scope) const
 
       collect_scope_parameters(des, scope, parameters);
 
-      collect_scope_localparams(des, scope, localparams);
-
 	// Scan through all the named events in this scope.
       elaborate_scope_events_(des, scope, events);
 
@@ -1640,8 +1621,6 @@ void PTask::elaborate_scope(Design*des, NetScope*scope) const
         // needed to evaluate the parameter expressions.
 
       collect_scope_parameters(des, scope, parameters);
-
-      collect_scope_localparams(des, scope, localparams);
 
 	// Scan through all the named events in this scope.
       elaborate_scope_events_(des, scope, events);
@@ -1690,8 +1669,6 @@ void PBlock::elaborate_scope(Design*des, NetScope*scope) const
 	      // needed to evaluate the parameter expressions.
 
             collect_scope_parameters(des, my_scope, parameters);
-
-            collect_scope_localparams(des, my_scope, localparams);
 
               // Scan through all the named events in this scope.
             elaborate_scope_events_(des, my_scope, events);

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -6958,7 +6958,6 @@ static void check_timescales()
 		    // We don't need a timescale if the compilation unit
 		    // contains no items outside a design element.
 		  if (pp->parameters.empty() &&
-		      pp->localparams.empty() &&
 		      pp->wires.empty() &&
 		      pp->tasks.empty() &&
 		      pp->funcs.empty() &&
@@ -7018,7 +7017,6 @@ static void check_timescales()
 		  continue;
 
 	    if (pp->parameters.empty() &&
-		pp->localparams.empty() &&
 		pp->wires.empty() &&
 		pp->tasks.empty() &&
 		pp->funcs.empty() &&

--- a/ivtest/ivltests/parameter_in_generate1.v
+++ b/ivtest/ivltests/parameter_in_generate1.v
@@ -1,0 +1,23 @@
+// Check whether it is possible to declare a parameter in a generate block
+// In Verilog this should fail, in SystemVerilog the parameter is elaborated as
+// localparam and the test should pass.
+
+module test;
+
+  generate
+    genvar i;
+    for (i = 0; i < 2; i = i + 1) begin : loop
+      parameter A = i;
+      reg [A:0] r = A+1;
+    end
+  endgenerate
+
+  initial begin
+    if (loop[0].r == 1 && loop[1].r == 2) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/parameter_in_generate2.v
+++ b/ivtest/ivltests/parameter_in_generate2.v
@@ -1,0 +1,16 @@
+// Check that it is not possible to override parameters in generate blocks
+
+module test;
+
+  generate
+    genvar i;
+    for (i = 0; i < 2; i = i + 1) begin : loop
+      parameter A = i;
+      reg [A:0] r = A+1;
+    end
+  endgenerate
+
+  defparam loop[0].A = 10;
+  defparam loop[1].A = 20;
+
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -77,6 +77,7 @@ br_gh25b		normal			ivltests
 br_gh567		normal			ivltests
 check_constant_3	normal			ivltests
 function4		normal			ivltests
+parameter_in_generate1	normal			ivltests
 pr1963962		normal			ivltests gold=pr1963962-fsv.gold
 pr3015421		CE			ivltests gold=pr3015421-fsv.gold
 resetall		normal,-Wtimescale	ivltests gold=resetall-fsv.gold

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -313,6 +313,7 @@ named_fork		normal,-g2009		ivltests
 named_fork_fail		CE,-g2009		ivltests
 packeda			normal,-g2009		ivltests
 packeda2		normal,-g2009		ivltests
+parameter_in_generate2	CE,-g2005-sv		ivltests
 parameter_invalid_override CE,-g2005-sv		ivltests gold=parameter_invalid_override.gold
 parameter_type2		normal,-g2009		ivltests
 parpkg_test		normal,-g2009		ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -694,6 +694,7 @@ param_test3		normal			ivltests gold=param_test3.gold # PR#293
 param_test4		normal			ivltests
 param_times		normal			ivltests # param has multiplication.
 parameter_type		normal			ivltests gold=parameter_type.gold
+parameter_in_generate1	CE			ivltests
 patch1268		normal			ivltests
 pca1			normal			ivltests # Procedural Continuous Assignment in a mux
 pic			normal			contrib  pictest gold=pic.gold

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -305,7 +305,7 @@ const netenum_t*NetScope::find_enumeration_for_name(const Design*des, perm_strin
  */
 void NetScope::set_parameter(perm_string key, bool is_annotatable,
 			     PExpr*val, data_type_t*val_type,
-			     bool local_flag,
+			     bool local_flag, bool overridable,
 			     NetScope::range_t*range_list,
 			     const LineInfo&file_line)
 {
@@ -315,6 +315,7 @@ void NetScope::set_parameter(perm_string key, bool is_annotatable,
       ref.val_type = val_type;
       ref.val_scope = this;
       ref.local_flag = local_flag;
+      ref.overridable = overridable;
       ivl_assert(file_line, ref.range == 0);
       ref.range = range_list;
       ref.val = 0;
@@ -397,6 +398,15 @@ void NetScope::replace_parameter(Design *des, perm_string key, PExpr*val, NetSco
 	    cerr << val->get_fileline() << ": error: "
 	         << "Cannot override localparam `" << key << "` in `"
 	         << scope_path(this) << "`." << endl;
+	    des->errors++;
+	    return;
+      }
+      if (!ref.overridable) {
+	    cerr << val->get_fileline() << ": error: "
+		 << "Cannot override parameter `" << key << "` in `"
+		 << scope_path(this) << "`. Parameter cannot be overriden "
+		 << "in the scope it has been declared in."
+		 << endl;
 	    des->errors++;
 	    return;
       }

--- a/netlist.h
+++ b/netlist.h
@@ -968,7 +968,7 @@ class NetScope : public Definitions, public Attrib {
       struct range_t;
       void set_parameter(perm_string name, bool is_annotatable,
 			 PExpr*val, data_type_t*data_type,
-			 bool local_flag,
+			 bool local_flag, bool overridable,
 			 NetScope::range_t*range_list,
 			 const LineInfo&file_line);
       void set_parameter(perm_string name, NetExpr*val,
@@ -1227,6 +1227,8 @@ class NetScope : public Definitions, public Attrib {
 	    bool is_annotatable;
 	    // Is this a localparam?
 	    bool local_flag;
+	    // Can it be overriden?
+	    bool overridable;
 	    // range constraints
 	    struct range_t*range;
 	    // Expression value and type (elaborated versoins of val_expr/val_type)

--- a/pform.cc
+++ b/pform.cc
@@ -3232,6 +3232,9 @@ void pform_set_parameter(const struct vlltype&loc,
 		         is_local ? "localparam" : "parameter");
 	    return;
       }
+
+      bool overridable = !is_local;
+
       if (scope == pform_cur_generate && !is_local) {
             VLerror("parameter declarations are not permitted in generate blocks");
             return;
@@ -3247,11 +3250,12 @@ void pform_set_parameter(const struct vlltype&loc,
       parm->data_type = data_type;
       parm->range = value_range;
       parm->local_flag = is_local;
+      parm->overridable = overridable;
 
       scope->parameters[name] = parm;
 
       // Only a module keeps the position of the parameter.
-      if (!is_local &&
+      if (overridable &&
           (dynamic_cast<Module*>(scope)) && (scope == pform_cur_module.front()))
 	    pform_cur_module.front()->param_names.push_back(name);
 }

--- a/pform.cc
+++ b/pform.cc
@@ -3236,8 +3236,13 @@ void pform_set_parameter(const struct vlltype&loc,
       bool overridable = !is_local;
 
       if (scope == pform_cur_generate && !is_local) {
-            VLerror("parameter declarations are not permitted in generate blocks");
-            return;
+	    if (!gn_system_verilog()) {
+		  VLerror(loc, "parameter declarations are not permitted in generate blocks");
+		  return;
+	    }
+	    // SystemVerilog allows `parameter` in generate blocks, but it has
+	    // the same semantics as `localparam` in that scope.
+	    overridable = false;
       }
 
       assert(expr);

--- a/pform.cc
+++ b/pform.cc
@@ -3246,16 +3246,14 @@ void pform_set_parameter(const struct vlltype&loc,
       parm->expr = expr;
       parm->data_type = data_type;
       parm->range = value_range;
+      parm->local_flag = is_local;
 
-      if (is_local) {
-	    scope->localparams[name] = parm;
-      } else {
-	    scope->parameters[name] = parm;
+      scope->parameters[name] = parm;
 
-	    // Only a Module keeps the position of the parameter.
-	    if ((dynamic_cast<Module*>(scope)) && (scope == pform_cur_module.front()))
-		  pform_cur_module.front()->param_names.push_back(name);
-      }
+      // Only a module keeps the position of the parameter.
+      if (!is_local &&
+          (dynamic_cast<Module*>(scope)) && (scope == pform_cur_module.front()))
+	    pform_cur_module.front()->param_names.push_back(name);
 }
 
 void pform_set_specparam(const struct vlltype&loc, perm_string name,

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -863,8 +863,6 @@ void PBlock::dump(ostream&out, unsigned ind) const
       if (pscope_name() != 0) {
             dump_parameters_(out, ind+2);
 
-            dump_localparams_(out, ind+2);
-
             dump_events_(out, ind+2);
 
 	    dump_wires_(out, ind+2);
@@ -1133,8 +1131,6 @@ void PFunction::dump(ostream&out, unsigned ind) const
 
       dump_parameters_(out, ind+2);
 
-      dump_localparams_(out, ind+2);
-
       dump_events_(out, ind+2);
 
       dump_wires_(out, ind+2);
@@ -1206,8 +1202,6 @@ void PTask::dump(ostream&out, unsigned ind) const
       dump_ports_(out, ind+2);
 
       dump_parameters_(out, ind+2);
-
-      dump_localparams_(out, ind+2);
 
       dump_events_(out, ind+2);
 
@@ -1412,7 +1406,7 @@ void PGenerate::dump(ostream&out, unsigned indent) const
 
       out << endl;
 
-      dump_localparams_(out, indent+2);
+      dump_parameters_(out, indent+2);
 
       typedef list<PGenerate::named_expr_t>::const_iterator parm_hiter_t;
       for (parm_hiter_t cur = defparms.begin()
@@ -1482,7 +1476,11 @@ void LexicalScope::dump_parameters_(ostream&out, unsigned indent) const
       typedef map<perm_string,param_expr_t*>::const_iterator parm_iter_t;
       for (parm_iter_t cur = parameters.begin()
 		 ; cur != parameters.end() ; ++ cur ) {
-	    out << setw(indent) << "" << "parameter ";
+	    out << setw(indent) << "";
+	    if (cur->second->local_flag)
+		  out << "localparam ";
+	    else
+		  out << "parameter ";
 	    if (cur->second->data_type)
 	          cur->second->data_type->debug_dump(out);
 	    else
@@ -1521,24 +1519,6 @@ void LexicalScope::dump_parameters_(ostream&out, unsigned indent) const
 			out << "]";
 	    }
 	    out << ";" << endl;
-      }
-}
-
-void LexicalScope::dump_localparams_(ostream&out, unsigned indent) const
-{
-      typedef map<perm_string,param_expr_t*>::const_iterator parm_iter_t;
-      for (parm_iter_t cur = localparams.begin()
-		 ; cur != localparams.end() ; ++ cur ) {
-	    out << setw(indent) << "" << "localparam ";
-	    if (cur->second->data_type) {
-		  cur->second->data_type->debug_dump(out);
-		  out << " ";
-	    }
-	    out << (*cur).first << " = ";
-	    if ((*cur).second->expr)
-		  out << *(*cur).second->expr << ";" << endl;
-	    else
-		  out << "/* ERROR */;" << endl;
       }
 }
 
@@ -1695,8 +1675,6 @@ void Module::dump(ostream&out) const
 
       dump_parameters_(out, 4);
 
-      dump_localparams_(out, 4);
-
       dump_specparams_(out, 4);
 
       dump_enumerations_(out, 4);
@@ -1847,7 +1825,6 @@ void pform_dump(std::ostream&out, const PPackage*pac)
 void PPackage::pform_dump(std::ostream&out) const
 {
       out << "package " << pscope_name() << endl;
-      dump_localparams_(out, 4);
       dump_parameters_(out, 4);
       dump_typedefs_(out, 4);
       dump_enumerations_(out, 4);


### PR DESCRIPTION
SystemVerilog allows to use the `parameter` keyword in a generate
block. If used in a generate block it behaves like a `localparam` and
cannot be overridden.

This is described in section 27.2 ("Generate constructs - Overview") of the
LRM (1800-2017).

To be able to generate better error messages when trying to override such
a parameter track whether the parameter is overridable rather than converting
it to localparam.

Also keep parameters and localparams in the same list during parsing to
reduce some duplicated code.