### PR TITLE
 Allow omitting `parameter` in module parameter port list 

### DIFF
--- a/ivtest/ivltests/localparam_implicit3.v
+++ b/ivtest/ivltests/localparam_implicit3.v
@@ -1,0 +1,30 @@
+// Check that all parameters in a parameter port list after a `localparam` get
+// elaborated as localparams, until the next `parameter`. Check that this is the
+// case even when the data type of the parameter is redefined.
+
+module a #(
+  parameter A = 1, B = 2,
+  localparam C = 3, real D = 4,
+  parameter E = 5
+);
+
+initial begin
+  if (A == 10 && B == 20 && C == 3 && D == 4 && E == 50) begin
+    $display("PASSED");
+  end else begin
+    $display("FAILED");
+  end
+end
+
+endmodule
+
+module b;
+
+  a #(
+    .A(10),
+    .B(20),
+    .D(40), // This will cause an error
+    .E(50)
+  ) i_a();
+
+endmodule

--- a/ivtest/ivltests/parameter_omit1.v
+++ b/ivtest/ivltests/parameter_omit1.v
@@ -1,0 +1,17 @@
+// Tests that it possible to omit the initial `parameter` keyword in a parameter
+// port list in SystemVerilog. In Verilog this is not allowed and should result
+// in an error.
+
+module a #(A = 1);
+  initial begin
+    if (A == 10) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule
+
+module test;
+  a #(.A(10)) i_a();
+endmodule

--- a/ivtest/ivltests/parameter_omit2.v
+++ b/ivtest/ivltests/parameter_omit2.v
@@ -1,0 +1,17 @@
+// Tests that it possible to omit the initial `parameter` keyword in a parameter
+// port list in SystemVerilog. In Verilog this is not allowed and should result
+// in an error.
+
+module a #(integer A = 1);
+  initial begin
+    if (A == 10) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule
+
+module test;
+  a #(.A(10.1)) i_a();
+endmodule

--- a/ivtest/ivltests/parameter_omit3.v
+++ b/ivtest/ivltests/parameter_omit3.v
@@ -1,0 +1,17 @@
+// Tests that it possible to omit the `parameter` keyword in a parameter port
+// list before changing the parameter type in SystemVerilog. In Verilog this is
+// not allowed and should result in an error.
+
+module a #(parameter real A = 1.0, integer B = 2);
+  initial begin
+    if (A == 10.1 && B == 20) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule
+
+module test;
+  a #(.A(10.1), .B(20)) i_a();
+endmodule

--- a/ivtest/ivltests/parameter_omit_invalid1.v
+++ b/ivtest/ivltests/parameter_omit_invalid1.v
@@ -1,0 +1,8 @@
+// Check that implicit type in a parameter port list without `parameter`
+// generates an error.
+
+module test #([7:0] A = 1);
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/parameter_omit_invalid2.v
+++ b/ivtest/ivltests/parameter_omit_invalid2.v
@@ -1,0 +1,8 @@
+// Check that implicit type in a parameter port list without `parameter`
+// generates an error.
+
+module test #(signed A = 1);
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/parameter_omit_invalid3.v
+++ b/ivtest/ivltests/parameter_omit_invalid3.v
@@ -1,0 +1,8 @@
+// Check that declaring changing the parameter type to an implicit type without
+// the `parameter` keyword results in an error.
+
+module test #(parameter real A = 1.0, signed B = 2);
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -78,6 +78,9 @@ br_gh567		normal			ivltests
 check_constant_3	normal			ivltests
 function4		normal			ivltests
 parameter_in_generate1	normal			ivltests
+parameter_omit1		normal			ivltests
+parameter_omit2		normal			ivltests
+parameter_omit3		normal			ivltests
 pr1963962		normal			ivltests gold=pr1963962-fsv.gold
 pr3015421		CE			ivltests gold=pr3015421-fsv.gold
 resetall		normal,-Wtimescale	ivltests gold=resetall-fsv.gold

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -302,6 +302,7 @@ l_equiv_const		normal,-g2005-sv	ivltests
 line_directive		normal,-g2009,-I./ivltests	ivltests gold=line_directive.gold
 localparam_implicit	normal,-g2005-sv	ivltests
 localparam_implicit2	CE,-g2005-sv	ivltests
+localparam_implicit3	CE,-g2005-sv	ivltests
 localparam_query	normal,-g2005-sv	ivltests
 localparam_type2	normal,-g2009		ivltests
 logical_short_circuit	normal,-g2012		ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -695,6 +695,12 @@ param_test4		normal			ivltests
 param_times		normal			ivltests # param has multiplication.
 parameter_type		normal			ivltests gold=parameter_type.gold
 parameter_in_generate1	CE			ivltests
+parameter_omit1		CE			ivltests
+parameter_omit2		CE			ivltests
+parameter_omit3		CE			ivltests
+parameter_omit_invalid1	CE			ivltests
+parameter_omit_invalid2	CE			ivltests
+parameter_omit_invalid3	CE			ivltests
 patch1268		normal			ivltests
 pca1			normal			ivltests # Procedural Continuous Assignment in a mux
 pic			normal			contrib  pictest gold=pic.gold

--- a/parse_misc.h
+++ b/parse_misc.h
@@ -57,6 +57,7 @@ extern YYLTYPE yylloc;
  */
 extern int  VLlex();
 extern void VLerror(const char*msg);
+extern void VLerror(const YYLTYPE&loc, va_list ap);
 extern void VLerror(const YYLTYPE&loc, const char*msg, ...) __attribute__((format(printf,2,3)));
 #define yywarn VLwarn
 extern void VLwarn(const char*msg);

--- a/pform.cc
+++ b/pform.cc
@@ -1334,10 +1334,9 @@ void pform_startmodule(const struct vlltype&loc, const char*name,
 	    error_count += 1;
       }
 
-      if (lifetime != LexicalScope::INHERITED && !gn_system_verilog()) {
-	    cerr << loc << ": error: Default subroutine lifetimes "
-		    "require SystemVerilog." << endl;
-	    error_count += 1;
+
+      if (lifetime != LexicalScope::INHERITED) {
+	    pform_requires_sv(loc, "Default subroutine lifetime");
       }
 
       if (gn_system_verilog() && ! pform_cur_module.empty()) {
@@ -3138,11 +3137,7 @@ PAssign* pform_compressed_assign_from_inc_dec(const struct vlltype&loc, PExpr*ex
 
 PExpr* pform_genvar_inc_dec(const struct vlltype&loc, const char*name, bool inc_flag)
 {
-      if (!gn_system_verilog()) {
-	    cerr << loc << ": error: Increment/decrement operators "
-		    "require SystemVerilog." << endl;
-	    error_count += 1;
-      }
+      pform_requires_sv(loc, "Increment/decrement operator");
 
       PExpr*lval = new PEIdent(lex_strings.make(name));
       PExpr*rval = new PENumber(new verinum(1));
@@ -3760,6 +3755,15 @@ void pform_add_modport_port(const struct vlltype&loc,
       pform_cur_modport->simple_ports[name] = make_pair(port_type, expr);
 }
 
+bool pform_requires_sv(const struct vlltype&loc, const char *feature)
+{
+      if (gn_system_verilog())
+	    return true;
+
+      VLerror(loc, "error: %s requires SystemVerilog.", feature);
+
+      return false;
+}
 
 FILE*vl_input = 0;
 extern void reset_lexor();

--- a/pform.h
+++ b/pform.h
@@ -612,4 +612,6 @@ extern bool allow_timeprec_decl;
 
 void pform_put_enum_type_in_scope(enum_type_t*enum_set);
 
+bool pform_requires_sv(const struct vlltype&loc, const char *feature);
+
 #endif /* IVL_pform_H */


### PR DESCRIPTION
SystemVerilog allows to completely omit the `parameter` keyword in a
module parameter port list. This is described in section 6.20.1 ("Parameter
declaration syntax") of the LRM (1800-2017).

E.g.

```SystemVerilog
module a #(X = 10) ...
module b #(int Y = 20) ...
```

It also allows to redefine the parameter type without having to have a
`parameter` or `localparam` before the type.

E.g.

```SystemVerilog
module a #(parameter int A = 1, real B = 2.0) ...
module b #(int X = 3, real Y = 4.0) ...
```

Extend the parser to support this.

Note that it is not possible to declare a parameter with an implicit data
type this way.

E.g. the following is not legal SystemVerilog
```SystemVerilog
module a #([3:0] A = 1) ...
module b #(int X = 2, signed Y = 3.0) ...
```

There are a few places where the parser has to check if SystemVerilog
mode is enabled and generate an error if not. Factor this into a common
helper function. This ensures consistent error messages and also
avoids a bit of boiler-plate code.