### PR TITLE
Support calling $bits() with built-in data types

### DIFF
--- a/ivtest/ivltests/bits3.v
+++ b/ivtest/ivltests/bits3.v
@@ -1,0 +1,34 @@
+// Check that passing a data type to $bits works as expected
+
+module test;
+
+bit failed = 1'b0;
+
+`define check(type, value) \
+  if ($bits(type) !== value) begin \
+    $display("FAILED: $bits(", `"type`", ") is %0d", $bits(type), " expected %0d", value); \
+    failed = 1'b1; \
+  end
+
+typedef int T1;
+typedef int T2[3:0];
+
+initial begin
+  `check(reg, 1);
+  `check(logic, 1);
+  `check(bit, 1);
+  `check(logic [3:0], 4);
+  `check(byte, 8);
+  `check(shortint, 16);
+  `check(int, 32);
+  `check(longint, 64);
+  `check(struct packed { int x; shortint y; }, 32 + 16);
+  `check(T1, 32);
+  `check(T2, 4 * 32);
+
+  if (failed == 1'b0) begin
+    $display("PASSED");
+  end
+end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -101,6 +101,7 @@ assign_op_type		normal,-g2009		ivltests
 bitp1			normal,-g2005-sv	ivltests
 bits			normal,-g2005-sv	ivltests
 bits2			normal,-g2005-sv	ivltests
+bits3			normal,-g2005-sv	ivltests
 br884			normal,-g2009		ivltests
 br917a			normal,-g2009		ivltests
 br917b			normal,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -3760,12 +3760,10 @@ expr_primary_or_typename
 
   /* There are a few special cases (notably $bits argument) where the
      expression may be a type name. Let the elaborator sort this out. */
-  | TYPE_IDENTIFIER
-      { pform_set_type_referenced(@1, $1.text);
-	PETypename*tmp = new PETypename($1.type);
-	FILE_NAME(tmp,@1);
+  | data_type
+      { PETypename*tmp = new PETypename($1);
+	FILE_NAME(tmp, @1);
 	$$ = tmp;
-	delete[]$1.text;
       }
 
   ;


### PR DESCRIPTION
The `$bits()` system function can be called with a data type.
At the moment only calling it with a typedef data type is supported,
but not built-in data types. E.g.
 * `typedef int T; ... $bits(T)` works
 * `$bits(int)` does not work

Add support for being able to pass all data types to `$bits()` by
allowing `data_type` to appear in a primary expression in the parser.

Also correctly handle unpacked array data types by taking
the unpacked dimensions into account.