### PR TITLE
Support parameters without default value

### DIFF
--- a/Module.cc
+++ b/Module.cc
@@ -139,3 +139,19 @@ PNamedItem::SymbolType Module::symbol_type() const
 
       return MODULE;
 }
+
+bool Module::can_be_toplevel() const
+{
+      // Don't choose library modules.
+      if (library_flag)
+	    return false;
+
+      // Don't choose modules with parameters without default value
+      for (std::map<perm_string,param_expr_t*>::const_iterator cur =
+	    parameters.begin(); cur != parameters.end(); cur++) {
+	    if (cur->second->expr == 0)
+		  return false;
+      }
+
+      return true;
+}

--- a/Module.h
+++ b/Module.h
@@ -166,6 +166,8 @@ class Module : public PScopeExtra, public PNamedItem {
 
       SymbolType symbol_type() const;
 
+      bool can_be_toplevel() const;
+
     private:
       void dump_specparams_(std::ostream&out, unsigned indent) const;
       std::list<PGate*> gates_;

--- a/ivtest/ivltests/parameter_no_default.v
+++ b/ivtest/ivltests/parameter_no_default.v
@@ -1,0 +1,20 @@
+// SystemVerilog allows parameters without default values in the parameter port
+// list. Check that this is supported. The test should fail in Verilog mode.
+
+module a #(
+  parameter A
+);
+
+initial begin
+  if (A == 1) begin
+    $display("PASSED");
+  end else begin
+    $display("FAILED");
+  end
+end
+
+endmodule
+
+module test;
+  a #(.A(1)) i_a();
+endmodule

--- a/ivtest/ivltests/parameter_no_default_fail1.v
+++ b/ivtest/ivltests/parameter_no_default_fail1.v
@@ -1,0 +1,16 @@
+// Check that not providing a value during module instantiation for a parameter
+// without a default value generates an error.
+
+module a #(
+  parameter A
+);
+
+initial begin
+  $display("FAILED");
+end
+
+endmodule
+
+module test;
+  a i_a();
+endmodule

--- a/ivtest/ivltests/parameter_no_default_fail2.v
+++ b/ivtest/ivltests/parameter_no_default_fail2.v
@@ -1,0 +1,16 @@
+// Check that parameters without default values outside the parameter port list
+// generate an error.
+
+module a;
+
+parameter A;
+
+initial begin
+  $display("FAILED");
+end
+
+endmodule
+
+module test;
+  a #(.A(10)) i_a();
+endmodule

--- a/ivtest/ivltests/parameter_no_default_toplvl.v
+++ b/ivtest/ivltests/parameter_no_default_toplvl.v
@@ -1,0 +1,14 @@
+// Check that modules with undefined parameters do not get picked as top-level
+// modules.
+
+module a #(
+      parameter A
+);
+      initial $display("FAILED");
+endmodule
+
+module b #(
+      parameter B = 1
+);
+      initial $display("PASSED");
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -78,6 +78,7 @@ br_gh567		normal			ivltests
 check_constant_3	normal			ivltests
 function4		normal			ivltests
 parameter_in_generate1	normal			ivltests
+parameter_no_default	normal			ivltests
 parameter_omit1		normal			ivltests
 parameter_omit2		normal			ivltests
 parameter_omit3		normal			ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -317,6 +317,10 @@ packeda			normal,-g2009		ivltests
 packeda2		normal,-g2009		ivltests
 parameter_in_generate2	CE,-g2005-sv		ivltests
 parameter_invalid_override CE,-g2005-sv		ivltests gold=parameter_invalid_override.gold
+parameter_no_default	CE,-g2005-sv		ivltests
+parameter_no_default_fail1 CE			ivltests
+parameter_no_default_fail2 CE			ivltests
+parameter_no_default_toplvl normal,-g2005-sv	ivltests
 parameter_type2		normal,-g2009		ivltests
 parpkg_test		normal,-g2009		ivltests
 parpkg_test2		normal,-g2009		ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -696,6 +696,7 @@ param_test4		normal			ivltests
 param_times		normal			ivltests # param has multiplication.
 parameter_type		normal			ivltests gold=parameter_type.gold
 parameter_in_generate1	CE			ivltests
+parameter_no_default	CE			ivltests
 parameter_omit1		CE			ivltests
 parameter_omit2		CE			ivltests
 parameter_omit3		CE			ivltests

--- a/main.cc
+++ b/main.cc
@@ -1187,8 +1187,7 @@ int main(int argc, char*argv[])
 	    for (mod = pform_modules.begin()
 		       ; mod != pform_modules.end() ; ++ mod ) {
 
-		    /* Don't choose library modules. */
-		  if ((*mod).second->library_flag)
+		  if (!(*mod).second->can_be_toplevel())
 			continue;
 
 		    /* Don't choose modules instantiated in other

--- a/net_design.cc
+++ b/net_design.cc
@@ -827,8 +827,18 @@ void NetScope::evaluate_parameter_(Design*des, param_ref_t cur)
       }
 
       // If the parameter has already been evaluated, quietly return.
-      if (cur->second.val_expr == 0)
+      if (cur->second.val != 0)
             return;
+
+      if (cur->second.val_expr == 0) {
+	    cerr << this->get_fileline() << ": error: "
+	         << "Missing value for parameter `"
+	         << cur->first << "`." << endl;
+	    des->errors += 1;
+
+	    cur->second.val = new NetEConst(verinum(verinum::Vx));
+	    return;
+      }
 
       // Guess the varaiable type of the parameter. If the parameter has no
       // given type, then guess the type from the expression and use that to

--- a/parse.y
+++ b/parse.y
@@ -4901,7 +4901,11 @@ module_port_list_opt
      that the port declarations may use them. */
 module_parameter_port_list_opt
   :
-  | '#' '(' module_parameter_port_list ')'
+  | '#' '('
+    { pform_start_parameter_port_list(); }
+    module_parameter_port_list
+    { pform_end_parameter_port_list(); }
+    ')'
   ;
 
 module_parameter
@@ -5580,7 +5584,12 @@ parameter_assign_list
   ;
 
 parameter_assign
-  : IDENTIFIER '=' expression parameter_value_ranges_opt
+  : IDENTIFIER parameter_value_ranges_opt
+      { pform_set_parameter(@1, lex_strings.make($1), param_is_local,
+			    param_data_type, 0, $2);
+	delete[]$1;
+      }
+  | IDENTIFIER '=' expression parameter_value_ranges_opt
       { PExpr*tmp = $3;
 	pform_set_parameter(@1, lex_strings.make($1), param_is_local,
 			    param_data_type, tmp, $4);

--- a/pform.h
+++ b/pform.h
@@ -614,4 +614,7 @@ void pform_put_enum_type_in_scope(enum_type_t*enum_set);
 
 bool pform_requires_sv(const struct vlltype&loc, const char *feature);
 
+void pform_start_parameter_port_list();
+void pform_end_parameter_port_list();
+
 #endif /* IVL_pform_H */

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -1485,11 +1485,9 @@ void LexicalScope::dump_parameters_(ostream&out, unsigned indent) const
 	          cur->second->data_type->debug_dump(out);
 	    else
 		  out << "(nil type)";
-	    out << " " << (*cur).first << " = ";
 	    if ((*cur).second->expr)
-		  out << *(*cur).second->expr;
-	    else
-		  out << "/* ERROR */";
+		  out << " " << (*cur).first << " = "
+		      << *(*cur).second->expr;
 	    for (LexicalScope::range_t*tmp = (*cur).second->range
 		       ; tmp ; tmp = tmp->next) {
 		  if (tmp->exclude_flag)


### PR DESCRIPTION
SystemVerilog allows to omit the default value of a parameter declared in a
parameter port list. In this case the parameter must be overridden for
every module instance. This is defined in section 6.20.1 ("Parameter
declaration syntax") of the LRM (1800-2017).
    
In addition a module that has a parameter without a default value does not
qualify for automatic toplevel module selection.
    
