### PR TITLE
Restrict edge event to SV

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3403,6 +3403,7 @@ event_expression
 		  svector<PEEvent*>*tl = new svector<PEEvent*>(1);
 		  (*tl)[0] = tmp;
 		  $$ = tl;
+		  pform_requires_sv(@1, "Edge event");
 		}
 	| expression
 		{ PEEvent*tmp = new PEEvent(PEEvent::ANYEDGE, $1);


### PR DESCRIPTION
Is there interest in ensuring features like this are properly restricted to SystemVerilog? I've seen that there is some inconsistency here, so I'm curious what the desired behavior is.