### PR TITLE
Initialize LexicalScope::has_parameter_port_list

### DIFF
--- a/PScope.h
+++ b/PScope.h
@@ -57,7 +57,8 @@ class LexicalScope {
       enum lifetime_t { INHERITED, STATIC, AUTOMATIC };
 
       explicit LexicalScope(LexicalScope*parent)
-        : default_lifetime(INHERITED), generate_counter(0), parent_(parent) { }
+        : default_lifetime(INHERITED), has_parameter_port_list(false),
+	  generate_counter(0), parent_(parent) { }
 	// A virtual destructor is so that dynamic_cast can work.
       virtual ~LexicalScope() { }
 


### PR DESCRIPTION
The has_parameter_port_list member of the LexicalScope class is not
initialized, which means its default value is undefined. This leads to
random failures where a parameter is marked as non-overridable when it
shouldn't.

Make sure has_parameter_port_list is properly initialized to false.

Fixes: 673b40b78ce0 ("Elaborate `parameter` as non-overridable where required")
Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>