### PR TITLE
Add more types to vvp-stop

### DIFF
--- a/vvp/vpi_priv.cc
+++ b/vvp/vpi_priv.cc
@@ -39,6 +39,24 @@ FILE*vpi_trace = 0;
 static s_vpi_vlog_info  vpi_vlog_info;
 static s_vpi_error_info vpip_last_error = { 0, 0, 0, 0, 0, 0, 0 };
 
+const char* direction_as_string(int dir)
+{
+      switch (dir) {
+	  case vpiInput:
+	    return "input";
+	  case vpiOutput:
+	    return "output";
+	  case vpiInout:
+	    return "inout";
+	  case vpiMixedIO:
+	    return "mixed io";
+	  case vpiNoDirection:
+	    return "no direction";
+	  default:
+	    return "INVALID-DIRECTION";
+      }
+}
+
 __vpiHandle::~__vpiHandle()
 { }
 
@@ -305,7 +323,7 @@ static const char* vpi_property_str(PLI_INT32 code)
       return buf;
 }
 
-static const char* vpi_type_values(PLI_INT32 code)
+const char* vpi_type_as_string(PLI_INT32 code)
 {
       static char buf[32];
       switch (code) {
@@ -398,7 +416,7 @@ PLI_INT32 vpi_get(int property, vpiHandle ref)
       if (property == vpiType) {
 	    if (vpi_trace) {
 		  fprintf(vpi_trace, "vpi_get(vpiType, %p) --> %s\n",
-			  ref, vpi_type_values(ref->get_type_code()));
+			  ref, vpi_type_as_string(ref->get_type_code()));
 	    }
 
 	    if (ref->get_type_code() == vpiMemory && is_net_array(ref))
@@ -442,7 +460,7 @@ char* vpi_get_str(PLI_INT32 property, vpiHandle ref)
       if (property == vpiType) {
 	    if (vpi_trace) {
 		  fprintf(vpi_trace, "vpi_get(vpiType, %p) --> %s\n",
-			  ref, vpi_type_values(ref->get_type_code()));
+			  ref, vpi_type_as_string(ref->get_type_code()));
 	    }
 
             PLI_INT32 type;
@@ -450,7 +468,7 @@ char* vpi_get_str(PLI_INT32 property, vpiHandle ref)
 		  type = vpiNetArray;
 	    else
 		  type = ref->get_type_code();
-	    return (char *)vpi_type_values(type);
+	    return (char *)vpi_type_as_string(type);
       }
 
       char*res = ref->vpi_get_str(property);

--- a/vvp/vpi_priv.h
+++ b/vvp/vpi_priv.h
@@ -65,6 +65,18 @@ extern vpiHandle vpip_build_file_line(char*description,
                                       long file_idx, long lineno);
 
 /*
+ * vpi_type_values returns the text form of the vpi type. If the type name
+ * is unknown, then return the number stringified. Note that the return
+ * value may return to a static buffer.
+ */
+extern const char* vpi_type_as_string(PLI_INT32 code);
+
+/*
+ * Return the port direction as a string.
+ */
+extern const char* direction_as_string(int dir);
+
+/*
  * Private VPI properties that are only used in the cleanup code.
  */
 #if defined(CHECK_WITH_VALGRIND) && !defined(BR916_STOPGAP_FIX)


### PR DESCRIPTION
Several scope types were not understood by the push command, and
a few types were not displayed reasonably. Flesh these out.

(cherry picked from commit de579f26501e892d30edc1b86210e1a727ae2814)