### PR TITLE
Remove NetNet::get_isint()

### DIFF
--- a/netlist.cc
+++ b/netlist.cc
@@ -716,14 +716,6 @@ bool NetNet::get_signed() const
       return net_type_->get_signed();
 }
 
-bool NetNet::get_isint() const
-{
-      if (const netvector_t*vec = dynamic_cast<const netvector_t*> (net_type_))
-	    return vec->get_isint();
-      else
-	    return false;
-}
-
 bool NetNet::get_scalar() const
 {
       if (const netvector_t*vec = dynamic_cast<const netvector_t*> (net_type_))

--- a/netlist.h
+++ b/netlist.h
@@ -705,10 +705,6 @@ class NetNet  : public NetObj, public PortType {
 	   signed. Otherwise, it is unsigned. */
       bool get_signed() const;
 
-	/* Used to maintain original type of net since integers are
-	   implemented as 'reg signed [31:0]' in Icarus */
-      bool get_isint() const;
-
       bool get_scalar() const;
 
       inline const ivl_type_s* net_type(void) const { return net_type_; }


### PR DESCRIPTION
NetNet::get_isint() is never used anywhere, remove it. The information
whether a signal is an integer is always directly queried from the signal
data type.