### PR TITLE
 Make output ports with data type variables

### DIFF
--- a/ivtest/ivltests/module_output_port_sv_var1.v
+++ b/ivtest/ivltests/module_output_port_sv_var1.v
@@ -1,0 +1,40 @@
+// Check that ANSI output ports that have a SystemVerilog data type are
+// elaborated as variables and be assigned a value.
+
+typedef struct packed { int x; } T1;
+typedef enum { A } T2;
+typedef T1 [1:0] T3;
+
+module test (
+  output reg a,
+  output reg [1:0] b,
+  output integer c,
+  output time d,
+  output bit e,
+  output logic f,
+  output shortint g,
+  output int h,
+  output longint i,
+  output real r,
+  output T1 x,
+  output T2 y,
+  output T3 z
+);
+
+initial begin
+  a = '0;
+  b = '0;
+  c = '0;
+  d = '0;
+  e = '0;
+  f = '0;
+  g = '0;
+  h = '0;
+  r = 0.0;
+  x = '0;
+  y = A;
+  z = '0;
+  $display("PASSED");
+end
+
+endmodule

--- a/ivtest/ivltests/module_output_port_sv_var2.v
+++ b/ivtest/ivltests/module_output_port_sv_var2.v
@@ -1,0 +1,39 @@
+// Check that non-ANSI output ports that have a SystemVerilog data type are
+// elaborated as variables and be assigned a value.
+
+typedef struct packed { int x; } T1;
+typedef enum { A } T2;
+typedef T1 [1:0] T3;
+
+module test1;
+output reg a;
+output reg [1:0] b;
+output integer c;
+output time d;
+output bit e;
+output logic f;
+output shortint g;
+output int h;
+output longint i;
+output real r;
+output T1 x;
+output T2 y;
+output T3 z;
+
+initial begin
+  a = '0;
+  b = '0;
+  c = '0;
+  d = '0;
+  e = '0;
+  f = '0;
+  g = '0;
+  h = '0;
+  r = 0.0;
+  x = '0;
+  y = A;
+  z = '0;
+  $display("PASSED");
+end
+
+endmodule

--- a/ivtest/ivltests/module_output_port_var1.v
+++ b/ivtest/ivltests/module_output_port_var1.v
@@ -1,0 +1,21 @@
+// Check that ANSI output ports that have a Verilog data type are elaborated as
+// variables and be assigned a value.
+
+module test (
+  output reg a,
+  output reg [1:0] b,
+  output reg signed [1:0] c,
+  output integer d,
+  output time e
+);
+
+initial begin
+  a = 0;
+  b = 0;
+  c = 0;
+  d = 0;
+  e = 0;
+  $display("PASSED");
+end
+
+endmodule

--- a/ivtest/ivltests/module_output_port_var2.v
+++ b/ivtest/ivltests/module_output_port_var2.v
@@ -1,0 +1,20 @@
+// Check that non-ANSI output ports that have a Verilog data type are elaborated
+// as variables and be assigned a value.
+
+module test;
+output reg a;
+output reg [1:0] b;
+output reg signed [1:0] c;
+output integer d;
+output time e;
+
+initial begin
+  a = 0;
+  b = 0;
+  c = 0;
+  d = 0;
+  e = 0;
+  $display("PASSED");
+end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -312,6 +312,8 @@ localparam_type2	normal,-g2009		ivltests
 logical_short_circuit	normal,-g2012		ivltests
 logp2			normal,-g2005-sv	ivltests
 mod_inst_pkg		normal,-g2009		ivltests
+module_output_port_sv_var1 normal,-g2005-sv	ivltests
+module_output_port_sv_var2 normal,-g2005-sv	ivltests
 named_begin		normal,-g2009		ivltests
 named_begin_fail	CE,-g2009		ivltests
 named_fork		normal,-g2009		ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -644,6 +644,8 @@ mixed_width_case	normal			ivltests
 modparam		normal			ivltests top # Override parameter via passed down value
 module3.12A		normal			ivltests main
 module3.12B		normal			ivltests
+module_output_port_var1	normal			ivltests
+module_output_port_var2	normal			ivltests
 modulus			normal			ivltests # wire % and reg % operators
 modulus2		normal			ivltests # reg % operators
 monitor			normal			ivltests gold=monitor.gold

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -780,6 +780,10 @@ iuint1			normal,-g2009,-pallowsigned=1	ivltests
 logp2			normal,-g2009,-pallowsigned=1	ivltests
 mixed_width_case	normal,-pallowsigned=1	ivltests
 mod_inst_pkg		normal,-g2009,-pallowsigned=1	ivltests
+module_output_port_sv_var1 normal,-g2005-sv,-pallowsigned=1	ivltests
+module_output_port_sv_var2 normal,-g2005-sv,-pallowsigned=1	ivltests
+module_output_port_var1 normal,-pallowsigned=1			ivltests
+module_output_port_var2 normal,-pallowsigned=1			ivltests
 packeda			normal,-g2009,-pallowsigned=1	ivltests
 pr1033			normal,-pallowsigned=1	ivltests gold=pr1033.gold
 pr1380261		normal,-pallowsigned=1	ivltests

--- a/parse.y
+++ b/parse.y
@@ -4568,13 +4568,7 @@ port_declaration
 		      // output ports are implicitly (on the inside)
 		      // variables because "reg" is not valid syntax
 		      // here.
-	      } else if (dynamic_cast<atom2_type_t*> ($4)) {
-		    use_type = NetNet::IMPLICIT_REG;
-	      } else if (dynamic_cast<real_type_t*> ($4)) {
-		    use_type = NetNet::IMPLICIT_REG;
-	      } else if (dynamic_cast<struct_type_t*> ($4)) {
-		    use_type = NetNet::IMPLICIT_REG;
-	      } else if (dynamic_cast<enum_type_t*> ($4)) {
+	      } else if ($4) {
 		    use_type = NetNet::IMPLICIT_REG;
 	      }
 	}
@@ -5026,13 +5020,8 @@ module_item
 		// output ports are implicitly (on the inside)
 		// variables because "reg" is not valid syntax
 		// here.
-	} else if (dynamic_cast<atom2_type_t*> ($3)) {
+	} else if ($3) {
 	      use_type = NetNet::IMPLICIT_REG;
-	} else if (dynamic_cast<struct_type_t*> ($3)) {
-	      use_type = NetNet::IMPLICIT_REG;
-	} else if (enum_type_t*etype = dynamic_cast<enum_type_t*> ($3)) {
-	      if(etype->base_type == IVL_VT_LOGIC)
-		  use_type = NetNet::IMPLICIT_REG;
 	}
 	if (use_type == NetNet::NONE)
 	      pform_set_port_type(@2, $4, NetNet::POUTPUT, $3, $1);

--- a/pform.cc
+++ b/pform.cc
@@ -2620,8 +2620,7 @@ void pform_module_define_port(const struct vlltype&li,
 			      list<named_pexpr_t>*attr,
 			      bool keep_attr)
 {
-      struct_type_t*struct_type = 0;
-      enum_type_t*enum_type = 0;
+      data_type_t*packed_type = 0;
       ivl_variable_type_t data_type = IVL_VT_NO_TYPE;
       bool signed_flag = false;
 
@@ -2669,19 +2668,14 @@ void pform_module_define_port(const struct vlltype&li,
 			  __FILE__, __LINE__);
 	    }
 
-      } else if ((struct_type = dynamic_cast<struct_type_t*>(vtype))) {
-	    data_type = struct_type->figure_packed_base_type();
-	    signed_flag = false;
-	    prange = 0;
-
-      } else if ((enum_type = dynamic_cast<enum_type_t*>(vtype))) {
-	    data_type = enum_type->base_type;
-	    signed_flag = enum_type->signed_flag;
-	    prange = 0;
-
       } else if (vtype) {
-	    VLerror(li, "sorry: Given type %s not supported here (%s:%d).",
-		    typeid(*vtype).name(), __FILE__, __LINE__);
+	    if (vtype->figure_packed_base_type() != IVL_VT_NO_TYPE) {
+		  data_type = vtype->figure_packed_base_type();
+		  packed_type = vtype;
+	    } else {
+		  VLerror(li, "sorry: Given type %s not supported here (%s:%d).",
+			  typeid(*vtype).name(), __FILE__, __LINE__);
+	    }
       }
 
 
@@ -2694,11 +2688,8 @@ void pform_module_define_port(const struct vlltype&li,
 
       cur->set_signed(signed_flag);
 
-      if (struct_type) {
-	    cur->set_data_type(struct_type);
-
-      } else if (enum_type) {
-	    cur->set_data_type(enum_type);
+      if (packed_type) {
+	    cur->set_data_type(packed_type);
 
       } else if (prange == 0) {
 	    cur->set_range_scalar((type == NetNet::IMPLICIT) ? SR_PORT : SR_BOTH);


### PR DESCRIPTION
In SystemVerilog output ports are a variable if either:
 * They are explicitly declared a variable (with the `var` keyword)
 * There is no explicit net type, but a explicit data type

This is in detail described in section 23.2.2.3 ("Rules for determining port
kind, data type, and direction") of the LRM (1800-2017).

E.g.
```systemverilog
output x // Net
output [1:0] x // Net
output signed x // Net
output wire x // Net
output wire logic x // Net
output var x // Variable
output logic x // Variable
output var logic x // Variable
output int x // Variable
output real x // Variable
output string x // Variable
output some_typedef x // Variable
```

At the moment the code checks for certain data types and only makes the
output port a variable for those. And it is even different data types
depending on whether the port is declared ANSI or non-ANSI style.

Change this so that if a data type is specified and it is not a implicit
data type (i.e. only ranges or `signed`) then the output is of type
variable.

This ensures consistent and correct behavior.