### PR TITLE
Always comb vs void func

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -692,7 +692,8 @@ static void elaborate_scope_func(Design*des, NetScope*scope, PFunction*task)
 
       if (debug_scopes) {
 	    cerr << task->get_fileline() << ": elaborate_scope_func: "
-		 << "Elaborate task scope " << scope_path(task_scope) << endl;
+		 << "Elaborate function scope " << scope_path(task_scope)
+		 << endl;
       }
 
       task->elaborate_scope(des, task_scope);
@@ -1589,7 +1590,7 @@ void PEvent::elaborate_scope(Design*, NetScope*scope) const
 
 void PFunction::elaborate_scope(Design*des, NetScope*scope) const
 {
-      assert(scope->type() == NetScope::FUNC);
+      ivl_assert(*this, scope->type() == NetScope::FUNC);
 
         // Save a reference to the pform representation of the function
         // in case we need to perform early elaboration.

--- a/ivtest/ivltests/issue576.v
+++ b/ivtest/ivltests/issue576.v
@@ -1,0 +1,15 @@
+
+// This example is rediculous, but legal. However, Icarus Verilog will print
+// various warnings about this. The warnings are OK, but Issue#576 saw this
+// program assert, which is worse.
+module test;
+   function void fun;
+      begin
+	 $display("PASSED");
+	 $finish;
+      end
+   endfunction // fun
+
+   always_comb fun;
+   
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -622,3 +622,4 @@ br_gh436		normal,-g2012		ivltests gold=br_gh436.gold
 br_gh451		normal,-g2012,-Ptest.foo=4	ivltests gold=br_gh451.gold
 br_gh453		normal,-g2012		ivltests
 br_gh460		normal,-g2012		ivltests
+issue576		normal,-g2012		ivltests

--- a/netlist.cc
+++ b/netlist.cc
@@ -3502,7 +3502,14 @@ bool NetSTask::check_synth(ivl_process_type_t pr_type,
       return false;
 }
 
-bool NetTaskDef::check_synth(ivl_process_type_t pr_type,
+/*
+ * This function is called to make sure the task/function can be used
+ * in a context where it must be synthesizable, such as in an always_comb
+ * or always_ff.
+ *
+ * If this is a function, then the function must be void.
+ */
+bool NetBaseDef::check_synth(ivl_process_type_t pr_type,
                              const NetScope* /* scope */) const
 {
       bool result = false;
@@ -3522,7 +3529,13 @@ bool NetTaskDef::check_synth(ivl_process_type_t pr_type,
 bool NetUTask::check_synth(ivl_process_type_t pr_type,
                            const NetScope* scope) const
 {
-      return task()->task_def()->check_synth(pr_type, scope);
+      const NetScope* task_scope = task();
+      if (task_scope->type() == NetScope::FUNC) {
+	    // This can happen if this a void function.
+	    return task_scope->func_def()->check_synth(pr_type, scope);
+      } else {
+	    return task_scope->task_def()->check_synth(pr_type, scope);
+      }
 }
 
 bool NetWhile::check_synth(ivl_process_type_t pr_type,

--- a/netlist.h
+++ b/netlist.h
@@ -867,6 +867,8 @@ class NetBaseDef {
 	//const string& name() const;
       const NetProc*proc() const;
 
+      virtual bool check_synth(ivl_process_type_t pr_type, const NetScope*scope) const;
+
     private:
       NetScope*scope_;
       std::vector<NetNet*>ports_;
@@ -3867,7 +3869,6 @@ class NetTaskDef : public NetBaseDef {
 
       void dump(std::ostream&, unsigned) const;
       DelayType delay_type(bool print_delay=false) const;
-      virtual bool check_synth(ivl_process_type_t pr_type, const NetScope*scope) const;
 
     private: // not implemented
       NetTaskDef(const NetTaskDef&);


### PR DESCRIPTION
This fixes the assertion failure that happens when void functions are used in always_comp functions. This fixes #576, but does not address the problem of the contents of a void function not being scanned for sensitivity lists.