### PR TITLE
Correctly handle data types on nets

### DIFF
--- a/ivtest/gold/pr2976242c.gold
+++ b/ivtest/gold/pr2976242c.gold
@@ -1,4 +1,4 @@
-./ivltests/pr2976242c.v:43: error: Port out of module io_real_to_vec is declared as a real inout port.
+./ivltests/pr2976242c.v:43: error: Port `out` of module `io_real_to_vec` is declared as a real inout port.
 ./ivltests/pr2976242c.v:11: error: Cannot connect an arrayed instance of module vec_to_real to real signal r_vec.
 ./ivltests/pr2976242c.v:14: error: When automatically converting a real port of an arrayed instance to a bit signal
 ./ivltests/pr2976242c.v:14:      : the signal width (5) must be an integer multiple of the instance count (2).

--- a/ivtest/ivltests/module_inout_port_type.v
+++ b/ivtest/ivltests/module_inout_port_type.v
@@ -1,0 +1,14 @@
+// Check Verilog types on a module inout port. In Verilog this is an error, but
+// in SystemVerilog it is supported
+
+module test (
+  inout reg a,
+  inout time b,
+  inout integer c
+);
+
+  initial begin
+    $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/module_input_port_type.v
+++ b/ivtest/ivltests/module_input_port_type.v
@@ -1,0 +1,14 @@
+// Check Verilog types on a module input port. In Verilog this is an error, but
+// in SystemVerilog it is supported
+
+module test (
+  input reg a,
+  input time b,
+  input integer c
+);
+
+  initial begin
+    $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/net_class_fail.v
+++ b/ivtest/ivltests/net_class_fail.v
@@ -1,0 +1,12 @@
+// Check that declaring a net of a class type results in an error
+
+module test;
+  class C;
+  endclass
+
+  wire C x;
+
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/net_darray_fail.v
+++ b/ivtest/ivltests/net_darray_fail.v
@@ -1,0 +1,10 @@
+// Check that declaring a net of a dynamic array type results in an error
+
+module test;
+
+  wire x[];
+
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/net_queue_fail.v
+++ b/ivtest/ivltests/net_queue_fail.v
@@ -1,0 +1,10 @@
+// Check that declaring a net of a queue type results in an error
+
+module test;
+
+  wire x[$];
+
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/net_string_fail.v
+++ b/ivtest/ivltests/net_string_fail.v
@@ -1,0 +1,10 @@
+// Check that declaring a net of string type results in an error
+
+module test;
+
+  wire string x;
+
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -77,6 +77,8 @@ br_gh25b		normal			ivltests
 br_gh567		normal			ivltests
 check_constant_3	normal			ivltests
 function4		normal			ivltests
+module_inout_port_type	normal			ivltests
+module_input_port_type	normal			ivltests
 parameter_in_generate1	normal			ivltests
 parameter_no_default	normal			ivltests
 parameter_omit1		normal			ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -318,6 +318,10 @@ named_begin		normal,-g2009		ivltests
 named_begin_fail	CE,-g2009		ivltests
 named_fork		normal,-g2009		ivltests
 named_fork_fail		CE,-g2009		ivltests
+net_class_fail		CE,-g2005-sv		ivltests
+net_darray_fail		CE,-g2005-sv		ivltests
+net_queue_fail		CE,-g2005-sv		ivltests
+net_string_fail		CE,-g2005-sv		ivltests
 packeda			normal,-g2009		ivltests
 packeda2		normal,-g2009		ivltests
 parameter_in_generate2	CE,-g2005-sv		ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -644,6 +644,8 @@ mixed_width_case	normal			ivltests
 modparam		normal			ivltests top # Override parameter via passed down value
 module3.12A		normal			ivltests main
 module3.12B		normal			ivltests
+module_inout_port_type	CE			ivltests
+module_input_port_type	CE			ivltests
 module_output_port_var1	normal			ivltests
 module_output_port_var2	normal			ivltests
 modulus			normal			ivltests # wire % and reg % operators

--- a/parse.y
+++ b/parse.y
@@ -4891,6 +4891,7 @@ module_item
   | attribute_list_opt net_type data_type_or_implicit delay3_opt net_variable_list ';'
 
       { data_type_t*data_type = $3;
+        pform_check_net_data_type(@2, $2, $3);
 	if (data_type == 0) {
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
 	      FILE_NAME(data_type, @2);
@@ -4925,6 +4926,7 @@ module_item
 
   | attribute_list_opt net_type data_type_or_implicit delay3_opt net_decl_assigns ';'
       { data_type_t*data_type = $3;
+        pform_check_net_data_type(@2, $2, $3);
 	if (data_type == 0) {
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
 	      FILE_NAME(data_type, @2);
@@ -4938,6 +4940,7 @@ module_item
 
   | attribute_list_opt net_type data_type_or_implicit drive_strength net_decl_assigns ';'
       { data_type_t*data_type = $3;
+        pform_check_net_data_type(@2, $2, $3);
 	if (data_type == 0) {
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
 	      FILE_NAME(data_type, @2);

--- a/pform.cc
+++ b/pform.cc
@@ -2652,9 +2652,6 @@ void pform_module_define_port(const struct vlltype&li,
 	    data_type = vec_type->base_type;
 	    signed_flag = vec_type->signed_flag;
 	    prange = vec_type->pdims.get();
-	    if (vec_type->reg_flag)
-		  type = NetNet::REG;
-
       } else if (atom2_type_t*atype = dynamic_cast<atom2_type_t*>(vtype)) {
 	    data_type = IVL_VT_BOOL;
 	    signed_flag = atype->signed_flag;

--- a/pform.h
+++ b/pform.h
@@ -587,4 +587,7 @@ bool pform_requires_sv(const struct vlltype&loc, const char *feature);
 void pform_start_parameter_port_list();
 void pform_end_parameter_port_list();
 
+void pform_check_net_data_type(const struct vlltype&loc, NetNet::Type net_type,
+			       const data_type_t *data_type);
+
 #endif /* IVL_pform_H */

--- a/pform_types.h
+++ b/pform_types.h
@@ -233,12 +233,7 @@ extern atom2_type_t size_type;
  *   bit unsigned foo
  *   reg foo
  *
- * There are a few special cases:
- *
- * For the most part, Verilog treats "logic" and "reg" as synonyms,
- * but there are a few cases where the parser needs to know the
- * difference. So "reg_flag" is set to true if the IVL_VT_LOGIC type
- * is due to the "reg" keyword.
+ * There is one special case:
  *
  * If there are no reg/logic/bit/bool keywords, then Verilog will
  * assume the type is logic, but the context may need to know about
@@ -247,7 +242,7 @@ extern atom2_type_t size_type;
 struct vector_type_t : public data_type_t {
       inline explicit vector_type_t(ivl_variable_type_t bt, bool sf,
 				    std::list<pform_range_t>*pd)
-      : base_type(bt), signed_flag(sf), reg_flag(false), integer_flag(false), implicit_flag(false), pdims(pd) { }
+      : base_type(bt), signed_flag(sf), integer_flag(false), implicit_flag(false), pdims(pd) { }
       virtual ivl_variable_type_t figure_packed_base_type(void)const;
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
       virtual std::ostream& debug_dump(std::ostream&out) const;
@@ -255,7 +250,6 @@ struct vector_type_t : public data_type_t {
 
       ivl_variable_type_t base_type;
       bool signed_flag;
-      bool reg_flag; // True if "reg" was used
       bool integer_flag; // True if "integer" was used
       bool implicit_flag; // True if this type is implicitly logic/reg
       std::unique_ptr< std::list<pform_range_t> > pdims;


### PR DESCRIPTION
While a variable can have any data type the data type for nets is quite
restricted.

The SystemVerilog LRM section 6.7.1 ("Net declarations with built-in net
types") requires that the data type of a wire is either a 4-state packed or
a unpacked struct or unpacked array of 4-state packed types.

As an extension to this iverilog allows real data type for wires as well as
2-state packed types.

Add a check that reports an error if a net with any other type is declared.

In addition in Verilog a net can not have an explicit data type at all. It
can only have a packed dimension and a signed flag. As an extension to this
Icarus also allows wires to be of `real` data type.

Note that in Verilog mode the data type is checked in the parser since only
the parser knows whether the data type is an implicit type (`input reg [7:0]`
and `input [7:0] x` elaborate the same). But for SystemVerilog the
type is checked during elaboration since due to forward typedefs and type
parameters the type is not necessarily known in the parser.

Related to this in Verilog a module input port can only be a net and can not
have a data type. But in SystemVerilog it can be a net and have a data type.
E.g. `input integer x`. Currently input ports that have the data type `reg` or
`integer` get converted to a variable, in both Verilog and SystemVerilog mode.
This is not the correct behavior, in Verilog this type of input port is an error,
but in SystemVerilog it is allowed. In the latter case it should get elaborated
as a net input port with the specified data type. Fix this by removing the code
that converts the net to a variable.