### PR TITLE
Fix part select on variables declared in packages

### DIFF
--- a/PWire.cc
+++ b/PWire.cc
@@ -160,11 +160,6 @@ bool PWire::get_isint() const
       return false;
 }
 
-bool PWire::get_scalar() const
-{
-      return is_scalar_;
-}
-
 void PWire::set_range_scalar(PWSRType type)
 {
       is_scalar_ = true;

--- a/PWire.h
+++ b/PWire.h
@@ -71,7 +71,6 @@ class PWire : public PNamedItem {
       void set_signed(bool flag);
       bool get_signed() const;
       bool get_isint() const;
-      bool get_scalar() const;
 
       bool set_data_type(ivl_variable_type_t dt);
       ivl_variable_type_t get_data_type() const;

--- a/ivtest/ivltests/package_vec_part_select.v
+++ b/ivtest/ivltests/package_vec_part_select.v
@@ -1,0 +1,20 @@
+// Check that it is possible to do a part select on a vector declared in
+// package
+
+package P;
+  reg [7:0] x = 8'h5a;
+  reg [1:0][7:0] y = 16'h5af0;
+endpackage
+
+module test;
+
+  initial begin
+    if (P::x[3:0] == 4'ha && P::x[7:4] == 4'h5 &&
+        P::y[0] == 8'hf0 && P::y[1] == 8'h5a) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -322,6 +322,7 @@ net_class_fail		CE,-g2005-sv		ivltests
 net_darray_fail		CE,-g2005-sv		ivltests
 net_queue_fail		CE,-g2005-sv		ivltests
 net_string_fail		CE,-g2005-sv		ivltests
+package_vec_part_select	normal,-g2005-sv	ivltests
 packeda			normal,-g2009		ivltests
 packeda2		normal,-g2009		ivltests
 parameter_in_generate2	CE,-g2005-sv		ivltests

--- a/netvector.cc
+++ b/netvector.cc
@@ -47,13 +47,13 @@ const netvector_t* netvector_t::integer_type()
 netvector_t netvector_t::scalar_logic (IVL_VT_LOGIC);
 
 netvector_t::netvector_t(ivl_variable_type_t type, long msb, long lsb, bool flag)
-: type_(type), signed_(flag), isint_(false), is_scalar_(false)
+: type_(type), signed_(flag), isint_(false)
 {
       packed_dims_.push_back(netrange_t(msb,lsb));
 }
 
 netvector_t::netvector_t(ivl_variable_type_t type)
-: type_(type), signed_(false), isint_(false), is_scalar_(false)
+: type_(type), signed_(false), isint_(false)
 {
 }
 

--- a/netvector.h
+++ b/netvector.h
@@ -54,8 +54,7 @@ class netvector_t : public ivl_type_s {
       inline void set_isint(bool flag) { isint_ = flag; }
       inline bool get_isint(void) const { return isint_; }
 
-      inline void set_scalar(bool flag) { is_scalar_ = flag; }
-      inline bool get_scalar(void) const { return is_scalar_; }
+      inline bool get_scalar(void) const { return packed_dims_.empty(); }
 
       ivl_variable_type_t base_type() const;
       const std::vector<netrange_t>&packed_dims() const;
@@ -88,13 +87,11 @@ class netvector_t : public ivl_type_s {
       ivl_variable_type_t type_;
       bool signed_    : 1;
       bool isint_     : 1;		// original type of integer
-      bool is_scalar_ : 1;
 };
 
 inline netvector_t::netvector_t(const std::vector<netrange_t>&pd,
 				ivl_variable_type_t type)
-: packed_dims_(pd), type_(type), signed_(false), isint_(false),
-  is_scalar_(false)
+: packed_dims_(pd), type_(type), signed_(false), isint_(false)
 {
 }
 

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -587,7 +587,7 @@ void PWire::dump(ostream&out, unsigned ind) const
       if (get_isint()) {
 	    out << " integer";
       }
-      if (get_scalar()) {
+      if (is_scalar_) {
 	    out << " scalar";
       }
       if (set_data_type_) {

--- a/tgt-vlog95/scope.c
+++ b/tgt-vlog95/scope.c
@@ -696,7 +696,8 @@ static int find_tfb_process(ivl_process_t proc, ivl_scope_t scope)
 	       * processes that are used to set local variables. */
 	    assert(ivl_process_type(proc) == IVL_PR_INITIAL);
 	      /* Find the module scope for this task/function. */
-	    while (ivl_scope_type(mod_scope) != IVL_SCT_MODULE) {
+	    while (ivl_scope_type(mod_scope) != IVL_SCT_MODULE &&
+		   ivl_scope_type(mod_scope) != IVL_SCT_PACKAGE) {
 		  mod_scope = ivl_scope_parent(mod_scope);
 		  assert(mod_scope);
 	    }
@@ -1154,7 +1155,9 @@ int emit_scope(ivl_scope_t scope, ivl_scope_t parent)
 	    for (idx = 0; idx < count; idx += 1) {
 		  emit_tran(scope, ivl_scope_switch(scope, idx));
 	    }
+      }
 
+      if (sc_type == IVL_SCT_MODULE || sc_type == IVL_SCT_PACKAGE) {
 	      /* Output any initial blocks for tasks or functions or named
 	       * blocks defined in this module. Used to initialize local
 	       * variables. */


### PR DESCRIPTION
The logic that decides whether a vector is scalar or not incorrectly flags
all variables that are declared in packages as scalar. As a result it is
not possible to do a part select on a vector declared in a package.

Rather than having an independent scalar flag consider a vector as scalar
if it does not have any packed dimensions.

Also in the PR is a small fix for the vlog95 backend to correctly generate
initializers for variables declared in packages. This is required for the new
regression test to pass with the vlog95 backend.