### PR TITLE
String special characters

### DIFF
--- a/ivtest/ivltests/sv_string7.v
+++ b/ivtest/ivltests/sv_string7.v
@@ -1,0 +1,45 @@
+
+module main;
+
+   string foo;
+   int 	  error_count;
+
+   task check_char(input int idx, input [7:0] val);
+      if (foo[idx] !== val) begin
+	 $display("FAILED: foo[%0d]==%02h, expecting %02h",
+		  idx, foo[idx], val);
+	 error_count = error_count+1;
+      end
+   endtask // check_char
+   
+   initial begin
+      // These are the special charasters in strings as defined by
+      // IEEE Std 1800-2017: 5.9.1 Special characters in strings.
+      // The string assignment is governed by:
+      // IEEE Std 1800-2017: 6.16 String data type
+      foo = "abc\n\t\\\"\v\f\a\001\002\x03\x04";
+      error_count = 0;
+
+      check_char(0, 8'h61); // 'a'
+      check_char(1, 8'h62); // 'b'
+      check_char(2, 8'h63); // 'c'
+      check_char(3, 8'h0a); // '\n'
+      check_char(4, 8'h09); // '\t'
+      check_char(5, 8'h5c); // '\\'
+      check_char(6, 8'h22); // '\"'
+      check_char(7, 8'h0b); // '\v'
+      check_char(8, 8'h0c); // '\f'
+      check_char(9, 8'h07); // '\a'
+      check_char(10, 8'h01); // '\001'
+      check_char(11, 8'h02); // '\002'
+      check_char(12, 8'h03); // '\x03'
+      check_char(13, 8'h04); // '\x04'
+
+      if (foo.len() !== 14) begin
+	 $display("FAILED: foo.len() == %0d, should be 14", foo.len());
+	 error_count = error_count+1;
+      end
+
+      if (error_count == 0) $display("PASSED");
+   end
+endmodule // main

--- a/ivtest/ivltests/sv_string7b.v
+++ b/ivtest/ivltests/sv_string7b.v
@@ -1,0 +1,46 @@
+
+module main;
+
+   string foo;
+   int 	  error_count;
+
+   task check_char(input int idx, input [7:0] val);
+      if (foo[idx] !== val) begin
+	 $display("FAILED: foo[%0d]==%02h, expecting %02h",
+		  idx, foo[idx], val);
+	 error_count = error_count+1;
+      end
+   endtask // check_char
+   
+   initial begin
+      // These are the special charasters in strings as defined by
+      // IEEE Std 1800-2017: 5.9.1 Special characters in strings.
+      // The string assignment is governed by:
+      // IEEE Std 1800-2017: 6.16 String data type
+      foo = "abc";
+      foo = {foo, "\n\t\\\"\v\f\a\001\002\x03\x04"};
+      error_count = 0;
+
+      check_char(0, 8'h61); // 'a'
+      check_char(1, 8'h62); // 'b'
+      check_char(2, 8'h63); // 'c'
+      check_char(3, 8'h0a); // '\n'
+      check_char(4, 8'h09); // '\t'
+      check_char(5, 8'h5c); // '\\'
+      check_char(6, 8'h22); // '\"'
+      check_char(7, 8'h0b); // '\v'
+      check_char(8, 8'h0c); // '\f'
+      check_char(9, 8'h07); // '\a'
+      check_char(10, 8'h01); // '\001'
+      check_char(11, 8'h02); // '\002'
+      check_char(12, 8'h03); // '\x03'
+      check_char(13, 8'h04); // '\x04'
+
+      if (foo.len() !== 14) begin
+	 $display("FAILED: foo.len() == %0d, should be 14", foo.len());
+	 error_count = error_count+1;
+      end
+
+      if (error_count == 0) $display("PASSED");
+   end
+endmodule // main

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -530,6 +530,8 @@ sv_string3		normal,-g2009		ivltests
 sv_string4		normal,-g2009		ivltests
 sv_string5		normal,-g2009		ivltests
 sv_string6		normal,-g2009		ivltests
+sv_string7		normal,-g2009		ivltests
+sv_string7b		normal,-g2009		ivltests
 sv_timeunit_prec1	normal,-g2005-sv	ivltests
 sv_timeunit_prec2	normal,-g2009		ivltests
 sv_timeunit_prec3a	normal,-g2005-sv	ivltests gold=sv_timeunit_prec3a.gold

--- a/verinum.cc
+++ b/verinum.cc
@@ -81,6 +81,18 @@ static string process_verilog_string_quotes(const string&str)
 			res = res + '\t';
 			idx += 1;
 			break;
+		      case 'v':
+			res = res + '\v';
+			idx += 1;
+			break;
+		      case 'f':
+			res = res + '\f';
+			idx += 1;
+			break;
+		      case 'a':
+			res = res + '\a';
+			idx += 1;
+			break;
 		      case '0':
 		      case '1':
 		      case '2':
@@ -96,6 +108,27 @@ static string process_verilog_string_quotes(const string&str)
 				   && str[idx+odx] <= '7') {
 				  byte_val = 8*byte_val + str[idx+odx]-'0';
 				  odx += 1;
+			    }
+			    idx += odx;
+			    res = res + byte_val;
+			    break;
+		      }
+		      case 'x': {
+			    char byte_val = 0;
+			    int odx = 1;
+			    while (odx < 3 && idx+odx < str_len) {
+				  if (str[idx+odx] >= '0' && str[idx+odx] <= '9') {
+					byte_val = 16*byte_val + str[idx+odx]-'0';
+					odx += 1;
+				  } else if  (str[idx+odx] >= 'a' && str[idx+odx] <= 'f') {
+					byte_val = 16*byte_val + str[idx+odx]-'a'+10;
+					odx += 1;
+				  } else if  (str[idx+odx] >= 'A' && str[idx+odx] <= 'F') {
+					byte_val = 16*byte_val + str[idx+odx]-'A'+10;
+					odx += 1;
+				  } else {
+					break;
+				  }
 			    }
 			    idx += odx;
 			    res = res + byte_val;


### PR DESCRIPTION
Fix handling of string literals as they find their way into the vvp string value stack. This bug caused string assignment to not work properly. The pertinent section of the standard is "_IEEE Std 1800-2017: 5.9.1 Special characters in strings_".

Include the sv_string7.v test to verify that this new behavior is correct.

This PR fixes issue#597