### PR TITLE
Add option to skip writing date to output file

### DIFF
--- a/vpi/sys_fst.c
+++ b/vpi/sys_fst.c
@@ -33,6 +33,7 @@
 # include  "ivl_alloc.h"
 
 static char *dump_path = NULL;
+static int dump_no_date = 0;
 static struct fstContext *dump_file = NULL;
 
 static struct t_vpi_time zero_delay = { vpiSimTime, 0, 0, 0.0 };
@@ -399,7 +400,10 @@ static void open_dumpfile(vpiHandle callh)
 		  prec -= 1;
 	    }
 
-	    fstWriterSetDate(dump_file, asctime(localtime(&walltime)));
+		if (!dump_no_date)
+			fstWriterSetDate(dump_file, asctime(localtime(&walltime)));
+		else
+			fstWriterSetDate(dump_file, "");
 	    fstWriterSetVersion(dump_file, "Icarus Verilog");
 	    sprintf(scale_buf, "\t%u%s\n", scale, units_names[udx]);
 	    fstWriterSetTimescaleFromString(dump_file, scale_buf);
@@ -918,7 +922,9 @@ void sys_fst_register(void)
 		  lxm_optimum_mode = LXM_BOTH;
 	    } else if (strcmp(vlog_info.argv[idx],"-fst-speed-space") == 0) {
 		  lxm_optimum_mode = LXM_BOTH;
-	    }
+		} else if (strcmp(vlog_info.argv[idx],"-no-date") == 0) {
+		  dump_no_date = 1;
+		}
       }
 
       /* All the compiletf routines are located in vcd_priv.c. */

--- a/vpi/sys_vcd.c
+++ b/vpi/sys_vcd.c
@@ -33,6 +33,7 @@
 
 static char *dump_path = NULL;
 static FILE *dump_file = NULL;
+static int   dump_no_date = 0;
 
 static struct t_vpi_time zero_delay = { vpiSimTime, 0, 0, 0.0 };
 
@@ -436,9 +437,11 @@ static void open_dumpfile(vpiHandle callh)
 		  prec -= 1;
 	    }
 
-	    fprintf(dump_file, "$date\n");
-	    fprintf(dump_file, "\t%s",asctime(localtime(&walltime)));
-	    fprintf(dump_file, "$end\n");
+		if (!dump_no_date) {
+			fprintf(dump_file, "$date\n");
+			fprintf(dump_file, "\t%s",asctime(localtime(&walltime)));
+			fprintf(dump_file, "$end\n");
+		}
 	    fprintf(dump_file, "$version\n");
 	    fprintf(dump_file, "\tIcarus Verilog\n");
 	    fprintf(dump_file, "$end\n");
@@ -880,6 +883,17 @@ void sys_vcd_register(void)
 {
       s_vpi_systf_data tf_data;
       vpiHandle res;
+      int idx;
+      struct t_vpi_vlog_info vlog_info;
+
+      /* Scan the extended arguments */
+      vpi_get_vlog_info(&vlog_info);
+
+      for (idx = 0 ;  idx < vlog_info.argc ;  idx += 1) {
+        if (strcmp(vlog_info.argv[idx],"-no-date") == 0) {
+          dump_no_date = 1;
+        }
+      }
 
       /* All the compiletf routines are located in vcd_priv.c. */
 


### PR DESCRIPTION
Added "-no-date" option toVPI  vcd and fst dumper to make them reproducible.