### PR TITLE
Handle empty class item declarations in parser

### DIFF
--- a/ivtest/ivltests/sv_class_empty_item.v
+++ b/ivtest/ivltests/sv_class_empty_item.v
@@ -1,0 +1,22 @@
+// Check that empty item declarations are supported for classes
+
+module test;
+
+class C;
+  ;
+  int x;;
+
+  task test;
+    $display("PASSED");
+  endtask;
+  ;
+endclass
+
+  C c;
+
+  initial begin
+    c = new;
+    c.test;
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -442,6 +442,7 @@ sv_class21		normal,-g2009		ivltests
 sv_class22		normal,-g2009		ivltests
 sv_class23		normal,-g2009		ivltests
 sv_class24		normal,-g2009		ivltests
+sv_class_empty_item	normal,-g2009		ivltests
 sv_class_extends_scoped	normal,-g2009		ivltests
 sv_class_localparam	normal,-g2009		ivltests
 sv_class_new_init	normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -365,6 +365,7 @@ sv_class21		CE,-g2009		ivltests
 sv_class22		CE,-g2009		ivltests
 sv_class23		CE,-g2009		ivltests
 sv_class24		CE,-g2009		ivltests
+sv_class_empty_item	CE,-g2009		ivltests
 sv_class_extends_scoped	CE,-g2009		ivltests
 sv_class_localparam	CE,-g2009		ivltests
 sv_class_new_init	CE,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -979,6 +979,9 @@ class_item /* IEEE1800-2005: A.1.8 */
 
   | parameter_declaration
 
+    /* Empty class item */
+  | ';'
+
   | error ';'
       { yyerror(@2, "error: invalid class item.");
 	yyerrok;


### PR DESCRIPTION
The SystemVerilog grammar explicitly allows an empty class item
declaration. The empty class item declaration is just a semicolon and has
no effect.

E.g. the following is legal
```SystemVerilog
class C
  int x;;;
endclass
```

Add support to the parser to accept empty class item declarations.