### PR TITLE
parser: Consistently pass line information as `vlltype`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1187,7 +1187,7 @@ data_declaration /* IEEE1800-2005: A.2.1.3 */
 	pform_makewire(@2, 0, str_strength, $3, NetNet::IMPLICIT_REG, data_type, $1);
       }
   | attribute_list_opt K_event event_variable_list ';'
-      { if ($3) pform_make_events($3, @2.text, @2.first_line);
+      { if ($3) pform_make_events(@2, $3);
       }
   | attribute_list_opt package_import_declaration
   ;
@@ -2624,7 +2624,7 @@ block_item_decl
       }
 
   | K_event event_variable_list ';'
-      { if ($2) pform_make_events($2, @1.text, @1.first_line);
+      { if ($2) pform_make_events(@1, $2);
       }
 
   | parameter_declaration
@@ -4421,8 +4421,7 @@ list_of_port_declarations
 	| list_of_port_declarations ',' IDENTIFIER
 		{ Module::port_t*ptmp;
 		  perm_string name = lex_strings.make($3);
-		  ptmp = pform_module_port_reference(name, @3.text,
-						     @3.first_line);
+		  ptmp = pform_module_port_reference(@3, name);
 		  std::vector<Module::port_t*>*tmp = $1;
 		  tmp->push_back(ptmp);
 
@@ -4453,7 +4452,7 @@ port_declaration
 	perm_string name = lex_strings.make($5);
 	data_type_t*use_type = $4;
 	if ($6) use_type = new uarray_type_t(use_type, $6);
-	ptmp = pform_module_port_reference(name, @2.text, @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	pform_module_define_port(@2, name, NetNet::PINPUT, $3, use_type, $1);
 	port_declaration_context.port_type = NetNet::PINPUT;
 	port_declaration_context.port_net_type = $3;
@@ -4465,8 +4464,7 @@ port_declaration
     K_input K_wreal IDENTIFIER
       { Module::port_t*ptmp;
 	perm_string name = lex_strings.make($4);
-	ptmp = pform_module_port_reference(name, @2.text,
-					   @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	real_type_t*real_type = new real_type_t(real_type_t::REAL);
 	FILE_NAME(real_type, @3);
 	pform_module_define_port(@2, name, NetNet::PINPUT,
@@ -4482,7 +4480,7 @@ port_declaration
 	Module::port_t*ptmp;
 	perm_string name = lex_strings.make($5);
 	data_type_t*use_type = $4;
-	ptmp = pform_module_port_reference(name, @2.text, @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	ptmp->default_value = $7;
 	pform_module_define_port(@2, name, NetNet::PINPUT, $3, use_type, $1);
 	port_declaration_context.port_type = NetNet::PINPUT;
@@ -4494,7 +4492,7 @@ port_declaration
   | attribute_list_opt K_inout net_type_opt data_type_or_implicit IDENTIFIER dimensions_opt
       { Module::port_t*ptmp;
 	perm_string name = lex_strings.make($5);
-	ptmp = pform_module_port_reference(name, @2.text, @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	pform_module_define_port(@2, name, NetNet::PINOUT, $3, $4, $1);
 	port_declaration_context.port_type = NetNet::PINOUT;
 	port_declaration_context.port_net_type = $3;
@@ -4510,8 +4508,7 @@ port_declaration
     K_inout K_wreal IDENTIFIER
       { Module::port_t*ptmp;
 	perm_string name = lex_strings.make($4);
-	ptmp = pform_module_port_reference(name, @2.text,
-					   @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	real_type_t*real_type = new real_type_t(real_type_t::REAL);
 	FILE_NAME(real_type, @3);
 	pform_module_define_port(@2, name, NetNet::PINOUT,
@@ -4543,7 +4540,7 @@ port_declaration
 		    use_type = NetNet::IMPLICIT_REG;
 	      }
 	}
-	ptmp = pform_module_port_reference(name, @2.text, @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	pform_module_define_port(@2, name, NetNet::POUTPUT, use_type, use_dtype, $1);
 	port_declaration_context.port_type = NetNet::POUTPUT;
 	port_declaration_context.port_net_type = use_type;
@@ -4555,8 +4552,7 @@ port_declaration
     K_output K_wreal IDENTIFIER
       { Module::port_t*ptmp;
 	perm_string name = lex_strings.make($4);
-	ptmp = pform_module_port_reference(name, @2.text,
-					   @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	real_type_t*real_type = new real_type_t(real_type_t::REAL);
 	FILE_NAME(real_type, @3);
 	pform_module_define_port(@2, name, NetNet::POUTPUT,
@@ -4574,7 +4570,7 @@ port_declaration
 	if (use_type == NetNet::IMPLICIT) {
 	      use_type = NetNet::IMPLICIT_REG;
 	}
-	ptmp = pform_module_port_reference(name, @2.text, @2.first_line);
+	ptmp = pform_module_port_reference(@2, name);
 	pform_module_define_port(@2, name, NetNet::POUTPUT, use_type, $4, $1);
 	port_declaration_context.port_type = NetNet::PINOUT;
 	port_declaration_context.port_net_type = use_type;
@@ -5122,7 +5118,7 @@ module_item
      cont_assign_list. */
 
 	| K_assign drive_strength_opt delay3_opt cont_assign_list ';'
-		{ pform_make_pgassign_list($4, $3, $2, @1.text, @1.first_line); }
+		{ pform_make_pgassign_list(@1, $4, $3, $2); }
 
   /* Always and initial items are behavioral processes. */
 
@@ -5786,7 +5782,7 @@ port_reference
     : IDENTIFIER
         { Module::port_t*ptmp;
 	  perm_string name = lex_strings.make($1);
-	  ptmp = pform_module_port_reference(name, @1.text, @1.first_line);
+	  ptmp = pform_module_port_reference(@1, name);
 	  delete[]$1;
 	  $$ = ptmp;
 	}
@@ -6608,7 +6604,6 @@ statement_item /* This is roughly statement_item in the LRM */
   | lpvalue '=' K_repeat '(' expression ')' event_control expression ';'
       { PAssign*tmp = new PAssign($1,$5,$7,$8);
 	FILE_NAME(tmp,@1);
-	tmp->set_lineno(@1.first_line);
 	$$ = tmp;
       }
   | lpvalue K_LE event_control expression ';'
@@ -7082,9 +7077,7 @@ udp_primitive
 	  K_endprimitive label_opt
 
 		{ perm_string tmp2 = lex_strings.make($2);
-		  pform_make_udp(tmp2, $4, $7, $9, $8,
-				 @2.text, @2.first_line);
-
+		  pform_make_udp(@2, tmp2, $4, $7, $9, $8);
 		  check_end_label(@11, "primitive", $2, $11);
 		  delete[]$2;
 		}
@@ -7100,9 +7093,7 @@ udp_primitive
 
 		{ perm_string tmp2 = lex_strings.make($2);
 		  perm_string tmp6 = lex_strings.make($6);
-		  pform_make_udp(tmp2, $5, tmp6, $7, $9, $12,
-				 @2.text, @2.first_line);
-
+		  pform_make_udp(@2, tmp2, $5, tmp6, $7, $9, $12);
 		  check_end_label(@14, "primitive", $2, $14);
 		  delete[]$2;
 		  delete[]$6;

--- a/pform.h
+++ b/pform.h
@@ -183,9 +183,8 @@ extern void pform_module_define_port(const struct vlltype&li,
 				     data_type_t*vtype,
 				     std::list<named_pexpr_t>*attr);
 
-extern Module::port_t* pform_module_port_reference(perm_string name,
-						   const char*file,
-						   unsigned lineno);
+extern Module::port_t* pform_module_port_reference(const struct vlltype&loc,
+						   perm_string name);
 extern void pform_endmodule(const char*, bool inside_celldefine,
                             Module::UCDriveType uc_drive_def);
 
@@ -204,17 +203,16 @@ extern void pform_set_constructor_return(PFunction*net);
 extern void pform_end_class_declaration(const struct vlltype&loc);
 extern bool pform_in_class();
 
-extern void pform_make_udp(perm_string name, std::list<perm_string>*parms,
+extern void pform_make_udp(const struct vlltype&loc, perm_string name,
+			   std::list<perm_string>*parms,
 			   std::vector<PWire*>*decl, std::list<std::string>*table,
-			   Statement*init,
-			   const char*file, unsigned lineno);
+			   Statement*init);
 
-extern void pform_make_udp(perm_string name,
+extern void pform_make_udp(const struct vlltype&loc, perm_string name,
 			   bool sync_flag, perm_string out_name,
 			   PExpr*sync_init,
 			   std::list<perm_string>*parms,
-			   std::list<std::string>*table,
-			   const char*file, unsigned lineno);
+			   std::list<std::string>*table);
 /*
  * Package related functions.
  */
@@ -462,8 +460,8 @@ extern void pform_mc_translate_on(bool flag);
 
 extern std::vector<PWire*>* pform_make_udp_input_ports(std::list<perm_string>*);
 
-extern void pform_make_events(std::list<perm_string>*names,
-			      const char*file, unsigned lineno);
+extern void pform_make_events(const struct vlltype&loc,
+			      std::list<perm_string>*names);
 /*
  * The makegate function creates a new gate (which need not have a
  * name) and connects it to the specified wires.
@@ -482,10 +480,10 @@ extern void pform_make_modgates(const struct vlltype&loc,
 				std::list<named_pexpr_t>*attr);
 
 /* Make a continuous assignment node, with optional bit- or part- select. */
-extern void pform_make_pgassign_list(std::list<PExpr*>*alist,
+extern void pform_make_pgassign_list(const struct vlltype&loc,
+				     std::list<PExpr*>*alist,
 				     std::list<PExpr*>*del,
-				     struct str_pair_t str,
-				     const char* fn, unsigned lineno);
+				     struct str_pair_t str);
 
 extern std::vector<pform_tf_port_t>*pform_make_task_ports(const struct vlltype&loc,
 					     NetNet::PortType pt,

--- a/pform.h
+++ b/pform.h
@@ -465,12 +465,6 @@ extern std::vector<PWire*>* pform_make_udp_input_ports(std::list<perm_string>*);
 extern void pform_make_events(std::list<perm_string>*names,
 			      const char*file, unsigned lineno);
 /*
- * Make real datum objects.
- */
-extern void pform_make_reals(std::list<perm_string>*names,
-			     const char*file, unsigned lineno);
-
-/*
  * The makegate function creates a new gate (which need not have a
  * name) and connects it to the specified wires.
  */


### PR DESCRIPTION
Currently there is a mix of passing line information either as `struct vlltype`
or as a separate `const char *file` and `unsigned lineno`.

For consistency always use the struct vlltype variant.