### PR TITLE
Recover from port and signal vector range mismatch 

### DIFF
--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -1042,7 +1042,6 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 			           << "'' has a vectored net declaration "
 				   << nlist << "." << endl;
 			      des->errors += 1;
-			      return 0;
 			}
 		  }
 
@@ -1054,7 +1053,6 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 			     << " has a scalar net declaration at "
 			     << get_fileline() << "." << endl;
 			des->errors += 1;
-			return 0;
 		  }
 
 		  /* Both vectored, but they have different ranges. */
@@ -1066,7 +1064,6 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 			     << " at " << net_.front().first->get_fileline()
 			     << " that does not match." << endl;
 			des->errors += 1;
-			return 0;
 		  }
             }
 

--- a/ivtest/ivltests/module_port_range_mismatch.v
+++ b/ivtest/ivltests/module_port_range_mismatch.v
@@ -1,0 +1,16 @@
+// Check that range mismatches between port direction and data type are detected
+// for module ports. An error should be reported and no crash should occur.
+
+module test;
+  input [1:0] x;
+  wire [3:0] x;
+
+  wire [3:0] y;
+
+  assign y = x;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/task_port_range_mismatch.v
+++ b/ivtest/ivltests/task_port_range_mismatch.v
@@ -1,0 +1,18 @@
+// Check that range mismatches between port direction and data type are detected
+// for task ports. An error should be reported and no crash should occur.
+
+module test;
+
+  task t;
+    input [1:0] x;
+    reg [3:0] x;
+    reg [3:0] y;
+    y = x;
+    $display("FAILED");
+  endtask
+
+  initial begin
+    t(4'b1001);
+  end
+
+endmodule

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -1610,6 +1610,7 @@ task_noop		normal			ivltests # Task with no contents.
 task_noop2		CO			ivltests # Task *really* with no contents.
 task_omemw2		normal			ivltests
 task_omemw3		CO			ivltests # Pass bit selected from vector to task
+task_port_range_mismatch CE			ivltests
 task_port_size		normal			ivltests # truncate task port connections
 task_scope		normal			ivltests
 tern1			normal			ivltests # Finds problems with ?: using different sizes

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -648,6 +648,7 @@ module_inout_port_type	CE			ivltests
 module_input_port_type	CE			ivltests
 module_output_port_var1	normal			ivltests
 module_output_port_var2	normal			ivltests
+module_port_range_mismatch CE			ivltests
 modulus			normal			ivltests # wire % and reg % operators
 modulus2		normal			ivltests # reg % operators
 monitor			normal			ivltests gold=monitor.gold


### PR DESCRIPTION
When using non-ANSI style port declarations it is possible to have both a
port and net or variable declaration for the same signal. In this case the
range specification for the two declarations have to match.

In the current implementation if the range specifications do not match an
error is reported and no signal is created. This generates follow up errors
about the signal not being declared when it is used.

In some cases it even causes the application to crash. E.g. the task
elaboration expects the port signal to exist. If it does not it will crash.

To avoid this still create the signal, even when an error is detected. Use
the range specification of the net or variable in this case. Overall
elaboration will still fail due to the error, but the application will not
crash.