### PR TITLE
data_type_t::elaborate_type(): Make return type const

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -543,7 +543,7 @@ static void elaborate_scope_class(Design*des, NetScope*scope, PClass*pclass)
       for (map<perm_string, class_type_t::prop_info_t>::iterator cur = use_type->properties.begin()
 		 ; cur != use_type->properties.end() ; ++ cur) {
 
-	    ivl_type_s*tmp = cur->second.type->elaborate_type(des, class_scope);
+	    ivl_type_t tmp = cur->second.type->elaborate_type(des, class_scope);
 	    ivl_assert(*pclass, tmp);
 	    if (debug_scopes) {
 		  cerr << pclass->get_fileline() << ": elaborate_scope_class: "

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -38,7 +38,7 @@ using namespace std;
  * Elaborations of types may vary depending on the scope that it is
  * done in, so keep a per-scope cache of the results.
  */
-ivl_type_s* data_type_t::elaborate_type(Design*des, NetScope*scope)
+ivl_type_t data_type_t::elaborate_type(Design*des, NetScope*scope)
 {
 	// User-defined types must be elaborated in the context
 	// where they were defined.
@@ -48,16 +48,16 @@ ivl_type_s* data_type_t::elaborate_type(Design*des, NetScope*scope)
       ivl_assert(*this, scope);
       Definitions*use_definitions = scope;
 
-      map<Definitions*,ivl_type_s*>::iterator pos = cache_type_elaborate_.lower_bound(use_definitions);
+      map<Definitions*,ivl_type_t>::iterator pos = cache_type_elaborate_.lower_bound(use_definitions);
 	  if (pos != cache_type_elaborate_.end() && pos->first == use_definitions)
 	     return pos->second;
 
-      ivl_type_s*tmp = elaborate_type_raw(des, scope);
-      cache_type_elaborate_.insert(pos, pair<NetScope*,ivl_type_s*>(scope, tmp));
+      ivl_type_t tmp = elaborate_type_raw(des, scope);
+      cache_type_elaborate_.insert(pos, pair<NetScope*,ivl_type_t>(scope, tmp));
       return tmp;
 }
 
-ivl_type_s* data_type_t::elaborate_type_raw(Design*des, NetScope*) const
+ivl_type_t data_type_t::elaborate_type_raw(Design*des, NetScope*) const
 {
       cerr << get_fileline() << ": internal error: "
 	   << "Elaborate method not implemented for " << typeid(*this).name()
@@ -66,7 +66,7 @@ ivl_type_s* data_type_t::elaborate_type_raw(Design*des, NetScope*) const
       return 0;
 }
 
-ivl_type_s* atom2_type_t::elaborate_type_raw(Design*des, NetScope*) const
+ivl_type_t atom2_type_t::elaborate_type_raw(Design*des, NetScope*) const
 {
       switch (type_code) {
 	  case 64:
@@ -101,7 +101,7 @@ ivl_type_s* atom2_type_t::elaborate_type_raw(Design*des, NetScope*) const
       }
 }
 
-ivl_type_s* class_type_t::elaborate_type_raw(Design*, NetScope*) const
+ivl_type_t class_type_t::elaborate_type_raw(Design*, NetScope*) const
 {
       ivl_assert(*this, save_elaborated_type);
       return save_elaborated_type;
@@ -113,17 +113,16 @@ ivl_type_s* class_type_t::elaborate_type_raw(Design*, NetScope*) const
  * available at the right time. At that time, the netenum_t* object is
  * stashed in the scope so that I can retrieve it here.
  */
-ivl_type_s* enum_type_t::elaborate_type_raw(Design*, NetScope*scope) const
+ivl_type_t enum_type_t::elaborate_type_raw(Design*, NetScope*scope) const
 {
       ivl_assert(*this, scope);
-      ivl_type_s*tmp = scope->enumeration_for_key(this);
-      if (tmp == 0 && scope->unit()) {
+      ivl_type_t tmp = scope->enumeration_for_key(this);
+      if (tmp == 0 && scope->unit())
 	    tmp = scope->unit()->enumeration_for_key(this);
-}
       return tmp;
 }
 
-ivl_type_s* vector_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
+ivl_type_t vector_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
       vector<netrange_t> packed;
       if (pdims.get())
@@ -136,7 +135,7 @@ ivl_type_s* vector_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
       return tmp;
 }
 
-ivl_type_s* real_type_t::elaborate_type_raw(Design*, NetScope*) const
+ivl_type_t real_type_t::elaborate_type_raw(Design*, NetScope*) const
 {
       switch (type_code_) {
 	  case REAL:
@@ -147,12 +146,12 @@ ivl_type_s* real_type_t::elaborate_type_raw(Design*, NetScope*) const
       return 0;
 }
 
-ivl_type_s* string_type_t::elaborate_type_raw(Design*, NetScope*) const
+ivl_type_t string_type_t::elaborate_type_raw(Design*, NetScope*) const
 {
       return &netstring_t::type_string;
 }
 
-ivl_type_s* parray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
+ivl_type_t parray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
       vector<netrange_t>packed;
       if (dims.get())
@@ -175,7 +174,7 @@ ivl_type_s* parray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
       return new netparray_t(packed, etype);
 }
 
-netstruct_t* struct_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
+ivl_type_t struct_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
       netstruct_t*res = new netstruct_t;
 
@@ -213,7 +212,7 @@ netstruct_t* struct_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
       return res;
 }
 
-ivl_type_s* uarray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
+ivl_type_t uarray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
 
       ivl_type_t btype = base_type->elaborate_type(des, scope);

--- a/netclass.cc
+++ b/netclass.cc
@@ -32,7 +32,8 @@ netclass_t::~netclass_t()
 {
 }
 
-bool netclass_t::set_property(perm_string pname, property_qualifier_t qual, ivl_type_s*ptype)
+bool netclass_t::set_property(perm_string pname, property_qualifier_t qual,
+			      ivl_type_t ptype)
 {
       map<perm_string,size_t>::const_iterator cur;
       cur = properties_.find(pname);

--- a/netclass.h
+++ b/netclass.h
@@ -41,7 +41,7 @@ class netclass_t : public ivl_type_s {
 	// Set the property of the class during elaboration. Set the
 	// name and type, and return true. If the name is already
 	// present, then return false.
-      bool set_property(perm_string pname, property_qualifier_t qual, ivl_type_s*ptype);
+      bool set_property(perm_string pname, property_qualifier_t qual, ivl_type_t ptype);
 
 	// Set the scope for the class. The scope has no parents and
 	// is used for the elaboration of methods
@@ -127,7 +127,7 @@ class netclass_t : public ivl_type_s {
       struct prop_t {
 	    perm_string name;
 	    property_qualifier_t qual;
-	    ivl_type_s* type;
+	    ivl_type_t type;
 	    mutable bool initialized_flag;
       };
       std::vector<prop_t> property_table_;

--- a/pform_types.h
+++ b/pform_types.h
@@ -47,7 +47,6 @@ class Definitions;
 class PExpr;
 class PWire;
 class Statement;
-class ivl_type_s;
 class netclass_t;
 class netenum_t;
 typedef named<verinum> named_number_t;
@@ -154,7 +153,7 @@ class data_type_t : public PNamedItem {
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
       virtual std::ostream& debug_dump(std::ostream&out) const;
 
-      ivl_type_s* elaborate_type(Design*des, NetScope*scope);
+      ivl_type_t elaborate_type(Design*des, NetScope*scope);
 
       virtual SymbolType symbol_type() const;
 
@@ -162,10 +161,10 @@ class data_type_t : public PNamedItem {
 
     private:
 	// Elaborate the type to an ivl_type_s type.
-      virtual ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      virtual ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 
 	// Keep per-scope elaboration results cached.
-      std::map<Definitions*,ivl_type_s*> cache_type_elaborate_;
+      std::map<Definitions*,ivl_type_t> cache_type_elaborate_;
 };
 
 struct void_type_t : public data_type_t {
@@ -180,7 +179,7 @@ struct void_type_t : public data_type_t {
  */
 struct enum_type_t : public data_type_t {
 	// Return the elaborated version of the type.
-      virtual ivl_type_s*elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 
       ivl_variable_type_t figure_packed_base_type() const;
 
@@ -202,7 +201,7 @@ struct struct_member_t : public LineInfo {
 struct struct_type_t : public data_type_t {
       virtual ivl_variable_type_t figure_packed_base_type(void)const;
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
-      virtual netstruct_t* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 
       bool packed_flag;
       bool union_flag;
@@ -218,7 +217,7 @@ struct atom2_type_t : public data_type_t {
 
       virtual std::ostream& debug_dump(std::ostream&out) const;
 
-      ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 
       ivl_variable_type_t figure_packed_base_type() const;
 };
@@ -246,7 +245,7 @@ struct vector_type_t : public data_type_t {
       virtual ivl_variable_type_t figure_packed_base_type(void)const;
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
       virtual std::ostream& debug_dump(std::ostream&out) const;
-      ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 
       ivl_variable_type_t base_type;
       bool signed_flag;
@@ -276,7 +275,7 @@ struct parray_type_t : public array_base_t {
 
       virtual ivl_variable_type_t figure_packed_base_type(void)const;
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
-      virtual ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 };
 
 /*
@@ -288,7 +287,7 @@ struct uarray_type_t : public array_base_t {
 
     public:
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
-      virtual ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 };
 
 struct real_type_t : public data_type_t {
@@ -297,7 +296,7 @@ struct real_type_t : public data_type_t {
       inline explicit real_type_t(type_t tc) : type_code_(tc) { }
       virtual std::ostream& debug_dump(std::ostream&out) const;
 
-      ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 
       inline type_t type_code() const { return type_code_; }
 
@@ -309,7 +308,7 @@ struct string_type_t : public data_type_t {
       inline explicit string_type_t() { }
       ~string_type_t();
 
-      ivl_type_s* elaborate_type_raw(Design*des, NetScope*scope) const;
+      ivl_type_t elaborate_type_raw(Design*des, NetScope*scope) const;
 };
 
 struct class_type_t : public data_type_t {
@@ -346,7 +345,7 @@ struct class_type_t : public data_type_t {
 	// without waiting for any constructor.
       std::vector<Statement*> initialize_static;
 
-      ivl_type_s* elaborate_type_raw(Design*, NetScope*) const;
+      ivl_type_t elaborate_type_raw(Design*, NetScope*) const;
 	// The save_elaborated_type member must be set to the pointer
 	// to the netclass_t object that is created to represent this
 	// type. The elaborate_type_raw() method uses this pointer,


### PR DESCRIPTION
For some data types the value returned by the `elaborate_type()` method is
shared among different signals of that type. E.g. all string or real types
get elaborated to the same ivl_type_s. This means the returned value must
not be modified, otherwise the data type for unrelated signals might get
changed.

To enforce this and protect against accidental breakage make the return type
type of the `elaborate_type()` and the related `elaborate_type_raw()`
methods const.

Note that `ivl_type_t` is used for the new return type which is a typedef
for `const ivl_type_s*`.