### PR TITLE
Allow to declare direction after data type for non-ANSI ports

### DIFF
--- a/PWire.cc
+++ b/PWire.cc
@@ -98,11 +98,9 @@ bool PWire::set_port_type(NetNet::PortType pt)
 
       switch (port_type_) {
 	  case NetNet::PIMPLICIT:
+	  case NetNet::NOT_A_PORT:
 	    port_type_ = pt;
 	    return true;
-
-	  case NetNet::NOT_A_PORT:
-	    return false;
 
 	  default:
 	    if (port_type_ != pt)

--- a/ivtest/ivltests/module_nonansi_enum1.v
+++ b/ivtest/ivltests/module_nonansi_enum1.v
@@ -1,0 +1,21 @@
+// Check that it is possible to declare the data type for a enum type module
+// port separately from the direction for non-ANSI style port declarations.
+// declarations.
+
+typedef enum integer {
+  A, B
+} T;
+
+module test(x);
+  output x;
+  T x;
+
+  initial begin
+    if ($bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_enum2.v
+++ b/ivtest/ivltests/module_nonansi_enum2.v
@@ -1,0 +1,20 @@
+// Check that it is possible to declare the data type for a enum type module
+// port before the direction for non-ANSI style port declarations.
+
+typedef enum integer {
+  A, B
+} T;
+
+module test(x);
+  T x;
+  output x;
+
+  initial begin
+    if ($bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_parray1.v
+++ b/ivtest/ivltests/module_nonansi_parray1.v
@@ -1,0 +1,20 @@
+// Check that it is possible to declare the data type for a packed array module
+// port separately from the direction for non-ANSI style port declarations.
+// declarations.
+
+typedef logic [3:0] T1;
+typedef T1 [7:0] T2;
+
+module test(x);
+  output x;
+  T2 x;
+
+  initial begin
+    if ($bits(x) == $bits(T2)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_parray2.v
+++ b/ivtest/ivltests/module_nonansi_parray2.v
@@ -1,0 +1,19 @@
+// Check that it is possible to declare the data type for a packed array module
+// port before the direction for non-ANSI style port declarations.
+
+typedef logic [3:0] T1;
+typedef T1 [7:0] T2;
+
+module test(x);
+  T2 x;
+  output x;
+
+  initial begin
+    if ($bits(x) == $bits(T2)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_real1.v
+++ b/ivtest/ivltests/module_nonansi_real1.v
@@ -1,0 +1,17 @@
+// Check that it is possible to declare the data type for a real type module
+// port separately from the direction for non-ANSI style port declarations.
+// declarations.
+
+module test(x);
+  output x;
+  real x;
+
+  initial begin
+    if (x == 0.0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_real2.v
+++ b/ivtest/ivltests/module_nonansi_real2.v
@@ -1,0 +1,16 @@
+// Check that it is possible to declare the data type for a real type module
+// port before the direction for non-ANSI style port declarations.
+
+module test(x);
+  real x;
+  output x;
+
+  initial begin
+    if (x == 0.0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_struct1.v
+++ b/ivtest/ivltests/module_nonansi_struct1.v
@@ -1,0 +1,22 @@
+// Check that it is possible to declare the data type for a struct type module
+// port separately from the direction for non-ANSI style port declarations.
+// declarations.
+
+typedef struct packed {
+  reg [31:0] x;
+  reg [7:0] y;
+} T;
+
+module test(x);
+  output x;
+  T x;
+
+  initial begin
+    if ($bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_struct2.v
+++ b/ivtest/ivltests/module_nonansi_struct2.v
@@ -1,0 +1,21 @@
+// Check that it is possible to declare the data type for a struct type module
+// port before the direction for non-ANSI style port declarations.
+
+typedef struct packed {
+  reg [31:0] x;
+  reg [7:0] y;
+} T;
+
+module test(x);
+  T x;
+  output x;
+
+  initial begin
+    if ($bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_vec1.v
+++ b/ivtest/ivltests/module_nonansi_vec1.v
@@ -1,0 +1,17 @@
+// Check that it is possible to declare the data type for a vector type module
+// port separately from the direction for non-ANSI style port declarations.
+// declarations.
+
+module test(x);
+  output [7:0] x;
+  reg [7:0] x;
+
+  initial begin
+    if ($bits(x) == 8) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_nonansi_vec2.v
+++ b/ivtest/ivltests/module_nonansi_vec2.v
@@ -1,0 +1,16 @@
+// Check that it is possible to declare the data type for a vector type module
+// port before the direction for non-ANSI style port declarations.
+
+module test(x);
+  reg [7:0] x;
+  output [7:0] x;
+
+  initial begin
+    if ($bits(x) == 8) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_enum1.v
+++ b/ivtest/ivltests/task_nonansi_enum1.v
@@ -1,0 +1,22 @@
+// Check that it is possible to declare the data type for an enum type task port
+// separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  typedef enum integer {
+    A, B
+  } T;
+
+  task t;
+    input x;
+    T x;
+    if (x == B && $bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(B);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_enum2.v
+++ b/ivtest/ivltests/task_nonansi_enum2.v
@@ -1,0 +1,22 @@
+// Check that it is possible to declare the data type for an enum type task port
+// before the direction for non-ANSI style port declarations.
+
+module test;
+
+  typedef enum integer {
+    A, B
+  } T;
+
+  task t;
+    T x;
+    input x;
+    if (x == B && $bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(B);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_int1.v
+++ b/ivtest/ivltests/task_nonansi_int1.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for an atom2 type task
+// port separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    input x;
+    int x;
+    if (x == 10 && $bits(x) == $bits(int)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_int2.v
+++ b/ivtest/ivltests/task_nonansi_int2.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for an atom2 type task
+// port before the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    int x;
+    input x;
+    if (x == 10 && $bits(x) == $bits(int)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_integer1.v
+++ b/ivtest/ivltests/task_nonansi_integer1.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for an integer type task
+// port separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    input x;
+    integer x;
+    if (x == 10 && $bits(x) == $bits(integer)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_integer2.v
+++ b/ivtest/ivltests/task_nonansi_integer2.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for an integer type task
+// port before the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    integer x;
+    input x;
+    if (x == 10 && $bits(x) == $bits(integer)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_parray1.v
+++ b/ivtest/ivltests/task_nonansi_parray1.v
@@ -1,0 +1,29 @@
+// Check that it is possible to declare the data type for a packed array type
+// task port separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  typedef logic [7:0] T1;
+  typedef T1 [3:0] T2;
+
+  task t;
+    input x;
+    T2 x;
+    if (x[0] == 1 && x[1] == 2 && x[2] == 3 && x[3] == 4 &&
+        $bits(x) == $bits(T2)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    static T2 val;
+    val[0] = 8'h1;
+    val[1] = 8'h2;
+    val[2] = 8'h3;
+    val[3] = 8'h4;
+    t(val);
+  end
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_parray2.v
+++ b/ivtest/ivltests/task_nonansi_parray2.v
@@ -1,0 +1,29 @@
+// Check that it is possible to declare the data type for a packed array type
+// task port before the direction for non-ANSI style port declarations.
+
+module test;
+
+  typedef logic [7:0] T1;
+  typedef T1 [3:0] T2;
+
+  task t;
+    T2 x;
+    input x;
+    if (x[0] == 1 && x[1] == 2 && x[2] == 3 && x[3] == 4 &&
+        $bits(x) == $bits(T2)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    static T2 val;
+    val[0] = 8'h1;
+    val[1] = 8'h2;
+    val[2] = 8'h3;
+    val[3] = 8'h4;
+    t(val);
+  end
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_real1.v
+++ b/ivtest/ivltests/task_nonansi_real1.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a real type task port
+// separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    input x;
+    real x;
+    if (x == 1.23) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(1.23);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_real2.v
+++ b/ivtest/ivltests/task_nonansi_real2.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a real type task port
+// before the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    real x;
+    input x;
+    if (x == 1.23) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(1.23);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_string1.v
+++ b/ivtest/ivltests/task_nonansi_string1.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a string type task
+// port separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    input x;
+    string x;
+    if (x == "TEST") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t("TEST");
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_string2.v
+++ b/ivtest/ivltests/task_nonansi_string2.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a string type task
+// port before the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    string x;
+    input x;
+    if (x == "TEST") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t("TEST");
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_struct1.v
+++ b/ivtest/ivltests/task_nonansi_struct1.v
@@ -1,0 +1,28 @@
+// Check that it is possible to declare the data type for a struct type task
+// port separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  typedef struct packed {
+    reg [31:0] x;
+    reg [7:0] y;
+  } T;
+
+  task t;
+    input x;
+    T x;
+    if (x.x == 10 && x.y == 20 && $bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    static T val;
+    val.x = 10;
+    val.y = 20;
+    t(val);
+  end
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_struct2.v
+++ b/ivtest/ivltests/task_nonansi_struct2.v
@@ -1,0 +1,28 @@
+// Check that it is possible to declare the data type for a struct type task
+// port before the direction for non-ANSI style port declarations.
+
+module test;
+
+  typedef struct packed {
+    reg [31:0] x;
+    reg [7:0] y;
+  } T;
+
+  task t;
+    input x;
+    T x;
+    if (x.x == 10 && x.y == 20 && $bits(x) == $bits(T)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    static T val;
+    val.x = 10;
+    val.y = 20;
+    t(val);
+  end
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_time1.v
+++ b/ivtest/ivltests/task_nonansi_time1.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a time type task port
+// separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    input x;
+    time x;
+    if (x == 10 && $bits(x) == $bits(time)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_time2.v
+++ b/ivtest/ivltests/task_nonansi_time2.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a time type task port
+// before the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    time x;
+    input x;
+    if (x == 10 && $bits(x) == $bits(time)) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_vec1.v
+++ b/ivtest/ivltests/task_nonansi_vec1.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a vector type task
+// port separately from the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    input [7:0] x;
+    reg [7:0] x;
+    if (x == 10 && $bits(x) == 8) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/ivltests/task_nonansi_vec2.v
+++ b/ivtest/ivltests/task_nonansi_vec2.v
@@ -1,0 +1,18 @@
+// Check that it is possible to declare the data type for a vector type task
+// port before the direction for non-ANSI style port declarations.
+
+module test;
+
+  task t;
+    reg [7:0] x;
+    input [7:0] x;
+    if (x == 10 && $bits(x) == 8) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial t(10);
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -312,6 +312,14 @@ localparam_type2	normal,-g2009		ivltests
 logical_short_circuit	normal,-g2012		ivltests
 logp2			normal,-g2005-sv	ivltests
 mod_inst_pkg		normal,-g2009		ivltests
+module_nonansi_enum1	normal,-g2005-sv	ivltests
+module_nonansi_enum2	normal,-g2005-sv	ivltests
+module_nonansi_parray1	normal,-g2005-sv	ivltests
+module_nonansi_parray2	normal,-g2005-sv	ivltests
+module_nonansi_real1	normal,-g2005-sv	ivltests
+module_nonansi_real2	normal,-g2005-sv	ivltests
+module_nonansi_struct1	normal,-g2005-sv	ivltests
+module_nonansi_struct2	normal,-g2005-sv	ivltests
 module_output_port_sv_var1 normal,-g2005-sv	ivltests
 module_output_port_sv_var2 normal,-g2005-sv	ivltests
 named_begin		normal,-g2009		ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -604,6 +604,14 @@ task_init_assign	normal,-g2009		ivltests
 task_init_var1		normal,-g2009		ivltests
 task_init_var2		normal,-g2009		ivltests
 task_init_var3		normal,-g2009		ivltests
+task_nonansi_enum1	normal,-g2005-sv	ivltests
+task_nonansi_enum2	normal,-g2005-sv	ivltests
+task_nonansi_int1	normal,-g2005-sv	ivltests
+task_nonansi_int2	normal,-g2005-sv	ivltests
+task_nonansi_parray1	normal,-g2005-sv	ivltests
+task_nonansi_parray2	normal,-g2005-sv	ivltests
+task_nonansi_struct1	normal,-g2005-sv	ivltests
+task_nonansi_struct2	normal,-g2005-sv	ivltests
 task_port_types1	normal,-g2009		ivltests
 task_port_types2	normal,-g2009		ivltests
 task_scope2		normal,-g2009		ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -1609,6 +1609,14 @@ task_inpad		normal			ivltests # Validates input of task should pad w/ 0
 task_iotypes		normal			ivltests # task ports with types.
 task_iotypes2		normal			ivltests # task ports with types.
 task_mem		normal			ivltests
+task_nonansi_integer1	normal			ivltests
+task_nonansi_integer2	normal			ivltests
+task_nonansi_real1	normal			ivltests
+task_nonansi_real2	normal			ivltests
+task_nonansi_time1	normal			ivltests
+task_nonansi_time2	normal			ivltests
+task_nonansi_vec1	normal			ivltests
+task_nonansi_vec2	normal			ivltests
 task_noop		normal			ivltests # Task with no contents.
 task_noop2		CO			ivltests # Task *really* with no contents.
 task_omemw2		normal			ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -647,6 +647,8 @@ module3.12A		normal			ivltests main
 module3.12B		normal			ivltests
 module_inout_port_type	CE			ivltests
 module_input_port_type	CE			ivltests
+module_nonansi_vec1	normal			ivltests
+module_nonansi_vec2	normal			ivltests
 module_output_port_var1	normal			ivltests
 module_output_port_var2	normal			ivltests
 module_port_range_mismatch CE			ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -95,6 +95,8 @@ recursive_task		CE			ivltests
 task_init_var1		CE,-pallowsigned=1	ivltests
 task_init_var2		CE,-pallowsigned=1	ivltests
 task_init_var3		CE,-pallowsigned=1	ivltests
+task_nonansi_int1	normal,-g2005-sv,-pallowsigned=1	ivltests
+task_nonansi_int2	normal,-g2005-sv,-pallowsigned=1	ivltests
 task_port_types1	CE,-pallowsigned=1	ivltests
 task_port_types2	CE,-pallowsigned=1	ivltests
 test_work14		CE			ivltests

--- a/pform.cc
+++ b/pform.cc
@@ -3413,16 +3413,10 @@ static void pform_set_port_type(const struct vlltype&li,
       }
 
       switch (cur->get_port_type()) {
+	  case NetNet::NOT_A_PORT:
 	  case NetNet::PIMPLICIT:
 	    if (! cur->set_port_type(pt))
 		  VLerror("error setting port direction.");
-	    break;
-
-	  case NetNet::NOT_A_PORT:
-	    cerr << li << ": error: "
-		 << "port " << name << " is not in the port list."
-		 << endl;
-	    error_count += 1;
 	    break;
 
 	  default:


### PR DESCRIPTION
When using non-ANSI ports (System)Verilog allows to have separate
declarations for the port direction and data type. E.g.

```
input x;
reg x;
```

It is also allowed to first declare the data type and then the port type.
E.g.

```
reg x;
input x;
```

Currently this fails with an error message. Add support for handling this
by allowing to change the port type of a signal from `NOT_A_PORT` to port
direction.