### PR TITLE
 parser: Fix UDP registered output syntax 

### DIFF
--- a/ivtest/ivltests/udp_output_reg.v
+++ b/ivtest/ivltests/udp_output_reg.v
@@ -1,0 +1,37 @@
+// Check that it is possible to have a `output reg` in a UDP defintion
+
+module test;
+
+  reg clk = 1'b0;
+  reg d = 1'b0;
+  wire q;
+
+  dff ff(q, clk, d);
+
+  initial begin
+    #1
+    clk = 1'b1;
+    #1
+    clk = 1'b0;
+    d = 1'b1;
+
+    if (q === 1'b0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule
+
+primitive dff(q, c, d);
+  output reg q;
+  input c, d;
+  table
+  //c d : q : q+
+    p 0 : ? : 0 ;
+    p 1 : ? : 1 ;
+    n ? : ? : - ;
+    ? * : ? : - ;
+  endtable
+endprimitive

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -1667,6 +1667,7 @@ udp_dff			normal			ivltests
 udp_dff_std		normal			ivltests
 udp_eval_arg		normal			ivltests
 udp_jkff		normal			ivltests
+udp_output_reg		normal			ivltests
 udp_real_delay		normal			ivltests
 udp_sched		normal			ivltests
 udp_x			normal			ivltests

--- a/parse.y
+++ b/parse.y
@@ -7007,7 +7007,7 @@ udp_port_decl
 	$$ = tmp;
 	delete[]$2;
       }
-  | K_reg K_output IDENTIFIER ';'
+  | K_output K_reg IDENTIFIER ';'
       { perm_string pname = lex_strings.make($3);
 	PWire*pp = new PWire(pname, NetNet::REG, NetNet::POUTPUT, IVL_VT_LOGIC);
 	vector<PWire*>*tmp = new std::vector<PWire*>(1);


### PR DESCRIPTION
The parser currently expects `reg output` for UDP registered output. But
the correct syntax is `output reg`. Fix this to accept the correct syntax.