### PR TITLE
Restrict enum compatibility to the same scope

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -186,8 +186,7 @@ static void elaborate_scope_enumeration(Design*des, NetScope*scope,
       netenum_t*use_enum = new netenum_t(enum_type->base_type,
 					 enum_type->signed_flag,
 					 enum_type->integer_flag, range,
-					 enum_type->names->size(),
-					 enum_type);
+					 enum_type->names->size());
 
       use_enum->set_line(*enum_type);
       scope->add_enumeration_set(enum_type, use_enum);

--- a/ivtest/ivltests/enum_compatibility1.v
+++ b/ivtest/ivltests/enum_compatibility1.v
@@ -1,0 +1,25 @@
+// Check that enum types declared in a higher level scope are compatible between
+// different instances of a module.
+
+typedef enum integer {
+  A
+} T;
+
+module M;
+  T e;
+endmodule
+
+module test;
+  M m1();
+  M m2();
+
+  initial begin
+    m1.e = A;
+    m2.e = m1.e;
+    if (m2.e === A) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/enum_compatibility2.v
+++ b/ivtest/ivltests/enum_compatibility2.v
@@ -1,0 +1,30 @@
+// Check that enum types explicitly imported from a package are compatible
+// between different instances of a module.
+
+package P;
+  typedef enum integer {
+    A
+  } T;
+endpackage
+
+module M;
+  import P::T;
+  T e;
+endmodule
+
+module test;
+  import P::A;
+
+  M m1();
+  M m2();
+
+  initial begin
+    m1.e = A;
+    m2.e = m1.e;
+    if (m2.e === A) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/enum_compatibility3.v
+++ b/ivtest/ivltests/enum_compatibility3.v
@@ -1,0 +1,30 @@
+// Check that enum types implicitly imported from a package are compatible
+// between different instances of a module.
+
+package P;
+  typedef enum integer {
+    A
+  } T;
+endpackage
+
+module M;
+  import P::*;
+  T e;
+endmodule
+
+module test;
+  import P::*;
+
+  M m1();
+  M m2();
+
+  initial begin
+    m1.e = A;
+    m2.e = m1.e;
+    if (m2.e === A) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/enum_compatibility_fail.v
+++ b/ivtest/ivltests/enum_compatibility_fail.v
@@ -1,0 +1,21 @@
+// Check that enums declared within a module are not compatible between
+// different instances of a module
+
+module M;
+
+  enum integer {
+    A
+  } e;
+
+endmodule
+
+module test;
+  M m1();
+  M m2();
+
+  initial begin
+    // These are different types and not compatible
+    m1.e = m2.e;
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -232,6 +232,10 @@ disable_fork_cmd	normal,-g2009		ivltests
 display_bug		normal,-g2009		ivltests gold=display_bug.gold
 edge			normal,-g2009		ivltests
 enum_base_range		normal,-g2005-sv	ivltests
+enum_compatibility1	normal,-g2005-sv	ivltests
+enum_compatibility2	normal,-g2005-sv	ivltests
+enum_compatibility3	normal,-g2005-sv	ivltests
+enum_compatibility_fail	CE,-g2005-sv	ivltests
 enum_elem_ranges	normal,-g2005-sv	ivltests
 enum_dims_invalid	CE,-g2005-sv		ivltests
 enum_in_struct		normal,-g2005-sv	ivltests

--- a/netenum.cc
+++ b/netenum.cc
@@ -24,11 +24,9 @@
 using namespace std;
 
 netenum_t::netenum_t(ivl_variable_type_t btype, bool signed_flag,
-		     bool integer_flag, const netrange_t &range, size_t name_count,
-		     enum_type_t*enum_type)
-: base_type_(btype), enum_type_(enum_type), signed_flag_(signed_flag),
-  integer_flag_(integer_flag), range_(range),
-  names_(name_count), bits_(name_count)
+		     bool integer_flag, const netrange_t &range, size_t name_count)
+: base_type_(btype), signed_flag_(signed_flag), integer_flag_(integer_flag),
+  range_(range), names_(name_count), bits_(name_count)
 {
 }
 
@@ -159,5 +157,5 @@ perm_string netenum_t::bits_at(size_t idx) const
 
 bool netenum_t::matches(const netenum_t*other) const
 {
-      return enum_type_ == other->enum_type_;
+      return this == other;
 }

--- a/netenum.h
+++ b/netenum.h
@@ -29,14 +29,12 @@
 
 class NetScope;
 
-struct enum_type_t;
-
 class netenum_t : public LineInfo, public ivl_type_s {
 
     public:
       explicit netenum_t(ivl_variable_type_t base_type, bool signed_flag,
 			 bool isint_flag, const netrange_t &range,
-			 size_t name_count, enum_type_t*enum_type);
+			 size_t name_count);
       ~netenum_t();
 
       virtual ivl_variable_type_t base_type() const;
@@ -74,7 +72,6 @@ class netenum_t : public LineInfo, public ivl_type_s {
 
     private:
       ivl_variable_type_t base_type_;
-      enum_type_t*enum_type_;
       bool signed_flag_;
       bool integer_flag_;
       netrange_t range_;


### PR DESCRIPTION
An enum data type declared in a module is not compatible between different
instances of the module. The type is unique in each hierarchical instance
scope. The type can for example depend on module parameters which would
result in conflicting definitions. This is defined in section 6.22 ("Type
compatibility") of the LRM (1800-2017).

At the moment enum compatibility is checked by comparing the enum_type_t.
But the enum_type_t is shared among the netenum_t that are created for each
module instance and gives the wrong result.

Since there is exactly one netenum_t created for each enum and each
instantiated scope use this to check if the data type of two enum type
signals is compatible.