### PR TITLE
Elaborate base type of array types in the right scope

### DIFF
--- a/ivtest/ivltests/sv_typedef_array_base1.v
+++ b/ivtest/ivltests/sv_typedef_array_base1.v
@@ -1,0 +1,22 @@
+// Check that a vector base typeof an array type is evaluated in the scope where
+// the array type is declared.
+
+localparam A = 8;
+
+typedef logic [A-1:0] T[1:0];
+
+module test;
+  localparam A = 4;
+
+  T x;
+
+  initial begin
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_array_base2.v
+++ b/ivtest/ivltests/sv_typedef_array_base2.v
@@ -1,0 +1,24 @@
+// Check that a complex base type (like a struct) of an array type is evaluated
+// in the scope where the array type is declared.
+
+localparam A = 8;
+
+typedef struct packed {
+  logic [A-1:0] x;
+} T[1:0];
+
+module test;
+  localparam A = 4;
+
+  T x;
+
+  initial begin
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_array_base3.v
+++ b/ivtest/ivltests/sv_typedef_array_base3.v
@@ -1,0 +1,24 @@
+// Check that a vector base type of an array type gets evaluated in the right
+// scope if the base type is defined in a different scope than the array type.
+
+localparam A = 8;
+
+typedef logic [A-1:0] Base;
+
+module test;
+  localparam A = 4;
+
+  typedef Base T[1:0];
+
+  T x;
+
+  initial begin
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_array_base4.v
+++ b/ivtest/ivltests/sv_typedef_array_base4.v
@@ -1,0 +1,27 @@
+// Check that a complex base type (like a struct) of an array type gets
+// evaluated in the right scope if the base type is defined in a different scope
+// than the array type.
+
+localparam A = 8;
+
+typedef struct packed {
+  logic [A-1:0] x;
+} Base;
+
+module test;
+  localparam A = 4;
+
+  typedef Base T[1:0];
+
+  T x;
+
+  initial begin
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_darray_base1.v
+++ b/ivtest/ivltests/sv_typedef_darray_base1.v
@@ -1,0 +1,23 @@
+// Check that a vector base typeof a dynamic array type is evaluated in the
+// scope where the array type is declared.
+
+localparam A = 8;
+
+typedef logic [A-1:0] T[];
+
+module test;
+  localparam A = 4;
+
+  T x;
+
+  initial begin
+    x = new [1];
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_darray_base2.v
+++ b/ivtest/ivltests/sv_typedef_darray_base2.v
@@ -1,0 +1,25 @@
+// Check that a complex base type (like a packed array) of a dynamic array type
+// is evaluated in the scope where the array type is declared.
+
+localparam A = 8;
+
+// Use type identifier for the base to force packed array
+typedef logic l;
+typedef l [A-1:0] T[];
+
+module test;
+  localparam A = 4;
+
+  T x;
+
+  initial begin
+    x = new [1];
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_darray_base3.v
+++ b/ivtest/ivltests/sv_typedef_darray_base3.v
@@ -1,0 +1,26 @@
+// Check that a vector base type of a dynamic array type gets evaluated in the
+// right scope if the base type is defined in a different scope than the array
+// type.
+
+localparam A = 8;
+
+typedef logic [A-1:0] Base;
+
+module test;
+  localparam A = 4;
+
+  typedef Base T[];
+
+  T x;
+
+  initial begin
+    x = new [1];
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_darray_base4.v
+++ b/ivtest/ivltests/sv_typedef_darray_base4.v
@@ -1,0 +1,27 @@
+// Check that a complex base type (like a struct) of a dynamic array type gets
+// evaluated in the right scope if the base type is defined in a different scope
+// than the array type.
+
+localparam A = 8;
+
+// Use type identifier for the base to force packed array
+typedef logic l;
+typedef l [A-1:0] Base;
+
+module test;
+  localparam A = 4;
+
+  typedef Base T[];
+  T x;
+
+  initial begin
+    x = new [1];
+    x[0] = 8'hff;
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_queue_base1.v
+++ b/ivtest/ivltests/sv_typedef_queue_base1.v
@@ -1,0 +1,22 @@
+// Check that a vector base typeof a queue type is evaluated in the scope where
+// the array type is declared.
+
+localparam A = 8;
+
+typedef logic [A-1:0] T[$];
+
+module test;
+  localparam A = 4;
+
+  T x;
+
+  initial begin
+    x.push_back(8'hff);
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_queue_base2.v
+++ b/ivtest/ivltests/sv_typedef_queue_base2.v
@@ -1,0 +1,24 @@
+// Check that a complex base type (like a packed array) of a queue type is
+// evaluated in the scope where the array type is declared.
+
+localparam A = 8;
+
+// Use type identifier for the base to force packed array
+typedef logic l;
+typedef l [A-1:0] T[$];
+
+module test;
+  localparam A = 4;
+
+  T x;
+
+  initial begin
+    x.push_back(8'hff);
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_queue_base3.v
+++ b/ivtest/ivltests/sv_typedef_queue_base3.v
@@ -1,0 +1,24 @@
+// Check that a vector base type of a queue type gets evaluated in the right
+// scope if the base type is defined in a different scope than the array type.
+
+localparam A = 8;
+
+typedef logic [A-1:0] Base;
+
+module test;
+  localparam A = 4;
+
+  typedef Base T[$];
+
+  T x;
+
+  initial begin
+    x.push_back(8'hff);
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_typedef_queue_base4.v
+++ b/ivtest/ivltests/sv_typedef_queue_base4.v
@@ -1,0 +1,27 @@
+// Check that a complex base type (like a packed array) of a queue type gets
+// evaluated in the right scope if the base type is defined in a different scope
+// than the array type.
+
+localparam A = 8;
+
+// Use type identifier for the base to force packed array
+typedef logic l;
+typedef l [A-1:0] Base;
+
+module test;
+  localparam A = 4;
+
+  typedef Base T[$];
+
+  T x;
+
+  initial begin
+    x.push_back(8'hff);
+    if (x[0] === 8'hff) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -589,6 +589,18 @@ sv_timeunit_prec_fail2	CE,-g2009,-u,\
   ./ivltests/sv_timeunit_prec_fail2a.v,\
   ./ivltests/sv_timeunit_prec_fail2b.v,\
   ./ivltests/sv_timeunit_prec_fail2c.v,		ivltests gold=sv_timeunit_prec_fail2.gold
+sv_typedef_array_base1	normal,-g2009		ivltests
+sv_typedef_array_base2	normal,-g2009		ivltests
+sv_typedef_array_base3	normal,-g2009		ivltests
+sv_typedef_array_base4	normal,-g2009		ivltests
+sv_typedef_darray_base1	normal,-g2009		ivltests
+sv_typedef_darray_base2	normal,-g2009		ivltests
+sv_typedef_darray_base3	normal,-g2009		ivltests
+sv_typedef_darray_base4	normal,-g2009		ivltests
+sv_typedef_queue_base1	normal,-g2009		ivltests
+sv_typedef_queue_base2	normal,-g2009		ivltests
+sv_typedef_queue_base3	normal,-g2009		ivltests
+sv_typedef_queue_base4	normal,-g2009		ivltests
 sv_typedef_scope1	normal,-g2009		ivltests
 sv_typedef_scope2	normal,-g2009		ivltests
 sv_typedef_scope3	normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -439,6 +439,14 @@ pr3390385b		CE,-g2009		ivltests  # ++
 pr3390385c		CE,-g2009		ivltests  # ++
 pr3390385d		CE,-g2009		ivltests  # ++
 pr3462145		CE,-g2009		ivltests  # ++
+sv_typedef_darray_base1	CE,-g2009		ivltests  # Dyanmic array
+sv_typedef_darray_base2	CE,-g2009		ivltests  # Dyanmic array
+sv_typedef_darray_base3	CE,-g2009		ivltests  # Dyanmic array
+sv_typedef_darray_base4	CE,-g2009		ivltests  # Dyanmic array
+sv_typedef_queue_base1	CE,-g2009		ivltests  # queue
+sv_typedef_queue_base2	CE,-g2009		ivltests  # queue
+sv_typedef_queue_base3	CE,-g2009		ivltests  # queue
+sv_typedef_queue_base4	CE,-g2009		ivltests  # queue
 wait_fork		CE,-g2009		ivltests  # wait fork and join_*
 wild_cmp_err		CE,-g2009		ivltests  # ==?/!=?
 wild_cmp_err2		CE,-g2009		ivltests  # ==?/!=?


### PR DESCRIPTION
The base type of an array type needs to be elaborated in the scope where
the array type is declared. At the moment it is elaborated in the scope
where the signal is declared, which can cause incorrect results.

E.g. in the example below the width of the array base type would be 4
instead of 8.

```SystemVerilog
localparam A = 8;
typedef reg [A-1:0] T[1:0];

module test;
  localparam A = 4;
  T x;
endmodule
```

If an unpacked array type is specified use the scope of the array type as
the default scope for the base type. Note that the base type can still be a
typedef in a different scope than the array scope, but we need to start
searching for it in the array scope.