### PR TITLE
Small class syntax improvements

### DIFF
--- a/ivtest/ivltests/sv_class_constructor1.v
+++ b/ivtest/ivltests/sv_class_constructor1.v
@@ -1,0 +1,14 @@
+// Check that a class constructor declaration without parenthesis after the
+// `new` is supported.
+
+module test;
+
+  class C;
+    function new;
+      $display("PASSED");
+    endfunction
+  endclass
+
+  C c = new;
+
+endmodule

--- a/ivtest/ivltests/sv_class_constructor_fail.v
+++ b/ivtest/ivltests/sv_class_constructor_fail.v
@@ -1,0 +1,14 @@
+// Check that a class constructor with non-ANSI port results in an error.
+
+module test;
+
+  class C;
+    function new;
+      input x; // This is a syntax error
+      $display("FAILED");
+    endfunction
+  endclass
+
+  C c = new;
+
+endmodule

--- a/ivtest/ivltests/sv_class_super1.v
+++ b/ivtest/ivltests/sv_class_super1.v
@@ -1,0 +1,21 @@
+// Check that it is possible to explicitly call the base class constructor, even
+// if it does not take any parameters. Check that it is possible to call it with
+// parenthesis after the `new`.
+
+module test;
+
+  class B;
+    function new();
+      $display("PASSED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new();
+      super.new();
+    endfunction
+  endclass
+
+  C c = new;
+
+endmodule

--- a/ivtest/ivltests/sv_class_super2.v
+++ b/ivtest/ivltests/sv_class_super2.v
@@ -1,0 +1,21 @@
+// Check that it is possible to explicitly call the base class constructor, even
+// if it does not take any parameters. Check that it is possible to call it
+// without parenthesis after the `new`.
+
+module test;
+
+  class B;
+    function new();
+      $display("PASSED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new();
+      super.new;
+    endfunction
+  endclass
+
+  C c = new;
+
+endmodule

--- a/ivtest/ivltests/sv_class_task1.v
+++ b/ivtest/ivltests/sv_class_task1.v
@@ -1,0 +1,22 @@
+// Check that it is possible to call a class task without parenthesis after the
+// task name when using the implicit `this` class handle.
+
+module test;
+
+  class C;
+    task a;
+      $display("PASSED");
+    endtask
+
+    task b;
+      this.a;
+    endtask
+  endclass
+
+  C c = new;
+
+  initial begin
+    c.b;
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -474,11 +474,16 @@ sv_class21		normal,-g2009		ivltests
 sv_class22		normal,-g2009		ivltests
 sv_class23		normal,-g2009		ivltests
 sv_class24		normal,-g2009		ivltests
+sv_class_constructor1	normal,-g2009		ivltests
+sv_class_constructor_fail   CE,-g2009		ivltests
 sv_class_empty_item	normal,-g2009		ivltests
 sv_class_extends_scoped	normal,-g2009		ivltests
 sv_class_localparam	normal,-g2009		ivltests
 sv_class_new_init	normal,-g2009		ivltests
 sv_class_in_module_decl	normal,-g2009		ivltests
+sv_class_super1		normal,-g2009		ivltests
+sv_class_super2		normal,-g2009		ivltests
+sv_class_task1		normal,-g2009		ivltests
 sv_darray1		normal,-g2009		ivltests
 sv_darray2		normal,-g2009		ivltests
 sv_darray3		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -372,11 +372,15 @@ sv_class21		CE,-g2009		ivltests
 sv_class22		CE,-g2009		ivltests
 sv_class23		CE,-g2009		ivltests
 sv_class24		CE,-g2009		ivltests
+sv_class_constructor1	CE,-g2009		ivltests
 sv_class_empty_item	CE,-g2009		ivltests
 sv_class_extends_scoped	CE,-g2009		ivltests
 sv_class_localparam	CE,-g2009		ivltests
 sv_class_new_init	CE,-g2009		ivltests
 sv_class_in_module_decl	CE,-g2009		ivltests
+sv_class_super1		CE,-g2009		ivltests
+sv_class_super2		CE,-g2009		ivltests
+sv_class_task1		CE,-g2009		ivltests
 sv_end_label		CE,-g2009		ivltests  # Also generate
 sv_foreach2		CE,-g2009,-pallowsigned=1	ivltests
 sv_foreach3		CE,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -892,7 +892,7 @@ class_item /* IEEE1800-2005: A.1.8 */
 	current_function = pform_push_constructor_scope(@3);
       }
     '(' tf_port_list_opt ')' ';'
-    tf_item_list_opt
+    block_item_decls_opt
     statement_or_null_list_opt
     K_endfunction endnew_opt
       { current_function->set_ports($6);

--- a/parse.y
+++ b/parse.y
@@ -6641,11 +6641,11 @@ statement_item /* This is roughly statement_item in the LRM */
 	$$ = tmp;
       }
 
-  | class_hierarchy_identifier '(' expression_list_with_nuls ')' ';'
-      { PCallTask*tmp = new PCallTask(*$1, *$3);
+  | class_hierarchy_identifier argument_list_parens_opt ';'
+      { PCallTask*tmp = new PCallTask(*$1, *$2);
 	FILE_NAME(tmp, @1);
 	delete $1;
-	delete $3;
+	delete $2;
 	$$ = tmp;
       }
 

--- a/parse.y
+++ b/parse.y
@@ -891,14 +891,14 @@ class_item /* IEEE1800-2005: A.1.8 */
       { assert(current_function==0);
 	current_function = pform_push_constructor_scope(@3);
       }
-    '(' tf_port_list_opt ')' ';'
+    tf_port_list_parens_opt ';'
     block_item_decls_opt
     statement_or_null_list_opt
     K_endfunction endnew_opt
-      { current_function->set_ports($6);
+      { current_function->set_ports($5);
 	pform_set_constructor_return(current_function);
 	pform_set_this_class(@3, current_function);
-	current_function_set_statement(@3, $10);
+	current_function_set_statement(@3, $8);
 	pform_pop_scope();
 	current_function = 0;
       }
@@ -6656,8 +6656,8 @@ statement_item /* This is roughly statement_item in the LRM */
        beginning of a constructor, but let the elaborator figure that
        out. */
 
-  | implicit_class_handle '.' K_new '(' expression_list_with_nuls ')' ';'
-      { PChainConstructor*tmp = new PChainConstructor(*$5);
+  | implicit_class_handle '.' K_new argument_list_parens_opt ';'
+      { PChainConstructor*tmp = new PChainConstructor(*$4);
 	FILE_NAME(tmp, @3);
 	if (peek_head_name(*$1) == THIS_TOKEN) {
 	  yyerror(@1, "error: this.new is invalid syntax. Did you mean super.new?");


### PR DESCRIPTION
A few small improvements to the parser to handle class syntax related to constructors and implicit class handles (`this`, `super`).

- Don't allow non-ANSI ports on class constructors
- Allow class constructor declaration without parenthesis after the `new`
- Allow `super` class constructor invocation without parenthesis after the `new`
- Allow to invoke class task without parenthesis after the task name when using `super` or `this` as part of the identifier path

To support this add a few parser helper rules to handle common syntax.