### PR TITLE
 Handle signed return types for built-in methods of SV types

### DIFF
--- a/Statement.h
+++ b/Statement.h
@@ -249,9 +249,7 @@ class PCallTask  : public Statement {
 				      const char*sys_task_name) const;
       NetProc*elaborate_method_func_(NetScope*scope,
 				     NetNet*net,
-				     ivl_variable_type_t type,
-				     unsigned width,
-				     bool signed_flag,
+				     ivl_type_t type,
 				     perm_string method_name,
 				     const char*sys_task_name) const;
       bool test_task_calls_ok_(Design*des, NetScope*scope) const;

--- a/ivtest/ivltests/sv_queue_signed1.v
+++ b/ivtest/ivltests/sv_queue_signed1.v
@@ -1,0 +1,31 @@
+// Check that the return value of a queue pop method is sign extended correctly.
+
+module test;
+
+  shortint qs[$];
+  int x, y;
+
+  bit [15:0] qu[$];
+  int w, z;
+
+  initial begin
+    qs.push_back(-1);
+    qs.push_back(-2);
+    qu.push_back(-1);
+    qu.push_back(-2);
+
+    // The returned value is signed and should be sign extended
+    x = qs.pop_front();
+    y = qs.pop_back();
+    // The returned value is unsigned and should not be sign extended
+    w = qu.pop_front();
+    z = qu.pop_back();
+
+    if (x === -1 && y === -2 && w == 65535 && z == 65534) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED x=%0d, y=%0d, z=%0d, w=%0d", x, y, z, w);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_queue_signed2.v
+++ b/ivtest/ivltests/sv_queue_signed2.v
@@ -1,0 +1,29 @@
+// Check that the signedness of the element type of a queue is correctly handled
+// when passing the result of one of the pop methods as an argument to a system
+// function.
+
+module test;
+
+  shortint qs[$];
+  bit [15:0] qu[$];
+
+  string s;
+
+  initial begin
+    qs.push_back(-1);
+    qs.push_back(-2);
+    qu.push_back(-1);
+    qu.push_back(-2);
+
+    // Values popped from qs should be treated as signed, values popped from qu
+    // should be treated as unsigned
+    s = $sformatf("%0d %0d %0d %0d", qs.pop_front(), qs.pop_back(),
+                                     qu.pop_front(), qu.pop_back());
+    if (s == "-1 -2 65535 65534") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -554,6 +554,8 @@ sv_queue_parray_fail	CE,-g2009		ivltests gold=sv_queue_parray_fail.gold
 sv_queue_real		normal,-g2009,-pfileline=1	ivltests gold=sv_queue_real.gold
 sv_queue_real_bounded	normal,-g2009,-pfileline=1	ivltests gold=sv_queue_real_bounded.gold
 sv_queue_real_fail	CE,-g2009		ivltests gold=sv_queue_real_fail.gold
+sv_queue_signed1	normal,-g2009		ivltests
+sv_queue_signed2	normal,-g2009		ivltests
 sv_queue_string		normal,-g2009,-pfileline=1	ivltests gold=sv_queue_string.gold
 sv_queue_string_bounded	normal,-g2009,-pfileline=1	ivltests gold=sv_queue_string_bounded.gold
 sv_queue_string_fail	CE,-g2009		ivltests gold=sv_queue_string_fail.gold

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -592,6 +592,8 @@ sv_queue3		CE,-g2009		ivltests
 sv_queue_real		CE,-g2009		ivltests
 sv_queue_real_bounded	CE,-g2009		ivltests
 sv_queue_real_fail	CE,-g2009		ivltests
+sv_queue_signed1	CE,-g2009,-pallowsigned=1	ivltests
+sv_queue_signed2	CE,-g2009,-pallowsigned=1	ivltests
 sv_queue_string		CE,-g2009		ivltests
 sv_queue_string_bounded	CE,-g2009		ivltests
 sv_queue_string_fail	CE,-g2009		ivltests

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -487,28 +487,13 @@ NetESFunc::NetESFunc(const char*n, ivl_variable_type_t t,
 }
 
 NetESFunc::NetESFunc(const char*n, ivl_type_t rtype, unsigned np)
-: NetExpr(rtype), name_(0), type_(IVL_VT_NO_TYPE), enum_type_(0), parms_(np), is_overridden_(false)
+: NetExpr(rtype), name_(0), type_(rtype->base_type()),
+  enum_type_(dynamic_cast<const netenum_t*>(rtype)), parms_(np),
+  is_overridden_(false)
 {
       name_ = lex_strings.add(n);
       expr_width(rtype->packed_width());
-	// FIXME: For now, assume that all uses of this constructor
-	// are for the IVL_VT_DARRAY type. Eventually, the type_
-	// member will go away.
-      if (dynamic_cast<const netdarray_t*>(rtype))
-	    type_ = IVL_VT_DARRAY;
-      else if (dynamic_cast<const netclass_t*>(rtype))
-	    type_ = IVL_VT_CLASS;
-      else if (dynamic_cast<const netstring_t*>(rtype))
-	    type_ = IVL_VT_STRING;
-      else
-	    ivl_assert(*this, 0);
-}
-
-NetESFunc::NetESFunc(const char*n, const netenum_t*enum_type, unsigned np)
-: name_(0), type_(enum_type->base_type()), enum_type_(enum_type), parms_(np), is_overridden_(false)
-{
-      name_ = lex_strings.add(n);
-      expr_width(enum_type->packed_width());
+      cast_signed_base_(rtype->get_signed());
 }
 
 NetESFunc::~NetESFunc()

--- a/netlist.cc
+++ b/netlist.cc
@@ -551,6 +551,9 @@ template <class T> static unsigned calculate_count(T*type)
 void NetNet::calculate_slice_widths_from_packed_dims_(void)
 {
       ivl_assert(*this, net_type_);
+      if (!net_type_->packed())
+	    return;
+
       slice_dims_ = net_type_->slice_dimensions();
 
 	// Special case: There are no actual packed dimensions, so
@@ -600,42 +603,10 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
       s->add_signal(this);
 }
 
-/*
- * When we create a netnet for a packed struct, create a single
- * vector with the msb_/lsb_ chosen to name enough bits for the entire
- * packed structure.
- */
-NetNet::NetNet(NetScope*s, perm_string n, Type t, netstruct_t*ty)
+NetNet::NetNet(NetScope*s, perm_string n, Type t, ivl_type_t type)
 : NetObj(s, n, 1),
     type_(t), port_type_(NOT_A_PORT),
-    local_flag_(false), net_type_(ty),
-    discipline_(0),
-    eref_count_(0), lref_count_(0)
-{
-	//XXXX packed_dims_.push_back(netrange_t(calculate_count(ty)-1, 0));
-      calculate_slice_widths_from_packed_dims_();
-
-      initialize_dir_();
-
-      s->add_signal(this);
-}
-
-NetNet::NetNet(NetScope*s, perm_string n, Type t, netdarray_t*ty)
-: NetObj(s, n, 1),
-    type_(t), port_type_(NOT_A_PORT),
-    local_flag_(false), net_type_(ty),
-    discipline_(0),
-    eref_count_(0), lref_count_(0)
-{
-      initialize_dir_();
-
-      s->add_signal(this);
-}
-
-NetNet::NetNet(NetScope*s, perm_string n, Type t, netvector_t*ty)
-: NetObj(s, n, 1),
-    type_(t), port_type_(NOT_A_PORT),
-    local_flag_(false), net_type_(ty),
+    local_flag_(false), net_type_(type),
     discipline_(0),
     eref_count_(0), lref_count_(0)
 {

--- a/netlist.h
+++ b/netlist.h
@@ -4635,7 +4635,6 @@ class NetESFunc  : public NetExpr {
       NetESFunc(const char*name, ivl_variable_type_t t,
 		unsigned width, unsigned nprms, bool is_overridden =false);
       NetESFunc(const char*name, ivl_type_t rtype, unsigned nprms);
-      NetESFunc(const char*name, const netenum_t*enum_type, unsigned nprms);
       ~NetESFunc();
 
       const char* name() const;

--- a/netlist.h
+++ b/netlist.h
@@ -679,12 +679,7 @@ class NetNet  : public NetObj, public PortType {
 		      const std::list<netrange_t>&unpacked,
 		      ivl_type_t type);
 
-	// This form builds a NetNet from its record/enum/darray
-	// definition. They should probably be replaced with a single
-	// version that takes an ivl_type_s* base.
-      explicit NetNet(NetScope*s, perm_string n, Type t, netstruct_t*type);
-      explicit NetNet(NetScope*s, perm_string n, Type t, netdarray_t*type);
-      explicit NetNet(NetScope*s, perm_string n, Type t, netvector_t*type);
+      explicit NetNet(NetScope*s, perm_string n, Type t, ivl_type_t type);
 
       virtual ~NetNet();
 


### PR DESCRIPTION
The result for the built-in methods for the SystemVerilog types is
currently always unsigned. This can lead to incorrect behavior if the value
is sign extended or passed as an argument to a system function (e.g.
$display).

For most built-in methods this does not matter, since even though they have
a signed return type, they will not return a negative value. E.g. the
string `len()` or queue `size()` functions.

It does make a difference though for the queue `pop_front()` and
`pop_back()` methods. Their return type is the element type of the queue.
If the element type is signed and the value in queue is negative is will be
handled incorrectly.

E.g. the following will print `4294967295` rather than `-1`.
```SystemVerilog
int q[$];
q.push_back(-1);
$display(q.pop_front());
```

To correctly support this consistently assign the actual data type of the
built-in method's return value to the `NetESFunc`, rather than just the width
and base type. The width, base type and also the signedness can be derived
from the data type.

Note that assigning the actual data type is also required to support type
checking on the return value, e.g. as needed for enum types.