### PR TITLE
Require explicit data type for package variable declarations

### DIFF
--- a/ivtest/ivltests/sv_package_implicit_var1.v
+++ b/ivtest/ivltests/sv_package_implicit_var1.v
@@ -1,0 +1,6 @@
+// Check that it is not possible to declare a variable in a package without an explicit data
+// type for the variable.
+
+pacakge P;
+  x; // This is a syntax error
+endpackage

--- a/ivtest/ivltests/sv_package_implicit_var2.v
+++ b/ivtest/ivltests/sv_package_implicit_var2.v
@@ -1,0 +1,6 @@
+// Check that it is not possible to declare a variable in a package without an explicit data
+// type for the variable.
+
+pacakge P;
+  [3:0] x; // This is a syntax error
+endpackage

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -529,6 +529,8 @@ sv_package2		normal,-g2009		ivltests
 sv_package3		normal,-g2009		ivltests
 sv_package4		normal,-g2009		ivltests
 sv_package5		normal,-g2009		ivltests
+sv_package_implicit_var1	CE,-g2009	ivltests
+sv_package_implicit_var2	CE,-g2009	ivltests
 sv_packed_port1		normal,-g2009		ivltests
 sv_packed_port2		normal,-g2009		ivltests
 sv_param_port_list	normal,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -1177,7 +1177,7 @@ constraint_set /* IEEE1800-2005 A.1.9 */
   ;
 
 data_declaration /* IEEE1800-2005: A.2.1.3 */
-  : attribute_list_opt data_type_or_implicit list_of_variable_decl_assignments ';'
+  : attribute_list_opt data_type list_of_variable_decl_assignments ';'
       { data_type_t*data_type = $2;
 	if (data_type == 0) {
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);


### PR DESCRIPTION
Variable declarations in packages need an explicit data type. Omitting the
data type or using just packed dimensions is not valid syntax. E.g. the
following should not work.

```SystemVerilog
package P;
  x;
  [1:0] y;
endpackage
```

The current implementation does accept this tough. To fix this update the
parser to only allow explicit data types for package variable declarations.