### PR TITLE
Use `real_type_t` as the data type for `real` type signals

### DIFF
--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -937,12 +937,7 @@ bool test_ranges_eeq(const vector<netrange_t>&lef, const vector<netrange_t>&rig)
 ivl_type_t PWire::elaborate_type(Design*des, NetScope*scope,
 			         const std::vector<netrange_t>&packed_dimensions) const
 {
-      if (dynamic_cast<struct_type_t*>(set_data_type_) ||
-	  dynamic_cast<enum_type_t*>(set_data_type_) ||
-	  dynamic_cast<string_type_t*>(set_data_type_) ||
-	  dynamic_cast<class_type_t*>(set_data_type_) ||
-	  dynamic_cast<parray_type_t*>(set_data_type_) ||
-	  dynamic_cast<atom_type_t*>(set_data_type_)) {
+      if (set_data_type_ && !dynamic_cast<vector_type_t*>(set_data_type_)) {
 	    ivl_type_t use_type = set_data_type_->elaborate_type(des, scope);
 	    ivl_assert(*this, packed_dimensions.empty());
 	    return use_type;
@@ -962,8 +957,7 @@ ivl_type_t PWire::elaborate_type(Design*des, NetScope*scope,
       }
 
       ivl_assert(*this, use_data_type == IVL_VT_LOGIC ||
-			use_data_type == IVL_VT_BOOL ||
-			use_data_type == IVL_VT_REAL);
+			use_data_type == IVL_VT_BOOL);
 
       netvector_t*vec = new netvector_t(packed_dimensions, use_data_type);
       vec->set_signed(get_signed());

--- a/ivtest/ivltests/vams_abs3.v
+++ b/ivtest/ivltests/vams_abs3.v
@@ -1,0 +1,59 @@
+// Check that VAMS `abs()` functions works if its argument is a function call
+
+module main;
+
+   function reg signed [7:0] fv(input reg signed [7:0] x);
+      fv = x;
+   endfunction
+
+   function real fr(input real x);
+      fr = x;
+   endfunction
+
+   reg signed [7:0]  a;
+   wire signed [7:0] vala = abs(fv(a));
+
+   reg	      real  b;
+   wire       real  valb = abs(fr(b));
+
+   initial begin
+      a = 0;
+      b = 0;
+      #1 if (vala !== 0) begin
+	 $display("FAILED -- a=%b, vala=%b", a, vala);
+	 $finish;
+      end
+
+      #1 if (valb != 0) begin
+	 $display("FAILED -- b=%g valb=%g", b, valb);
+	 $finish;
+      end
+
+      a = 1;
+      b = 1;
+      #1 if (vala !== 1) begin
+	 $display("FAILED -- a=%b, vala=%b", a, vala);
+	 $finish;
+      end
+
+      #1 if (valb != 1) begin
+	 $display("FAILED -- b=%g valb=%g", b, valb);
+	 $finish;
+      end
+
+      a = -1;
+      b = -1;
+      #1 if (vala !== 1) begin
+	 $display("FAILED -- a=%b, vala=%b", a, vala);
+	 $finish;
+      end
+
+      #1 if (valb != 1) begin
+	 $display("FAILED -- b=%g valb=%g", b, valb);
+	 $finish;
+      end
+
+      $display("PASSED");
+   end
+
+endmodule // main

--- a/ivtest/regress-vams.list
+++ b/ivtest/regress-vams.list
@@ -81,6 +81,7 @@ value_range2		normal,-gverilog-ams	ivltests
 value_range3		CE,-gverilog-ams	ivltests
 vams_abs1		normal,-gverilog-ams	ivltests
 vams_abs2		normal,-gverilog-ams	ivltests
+vams_abs3		normal,-gverilog-ams	ivltests
 wreal			normal,-gverilog-ams	ivltests
 # Verilog functions added in a VAMS simulator
 constfunc6_ams		normal			ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -158,6 +158,7 @@ real_wire_force_rel	CE			ivltests
 tern8			CE			ivltests
 v2005_math		CE			ivltests
 vams_abs2		CE,-gverilog-ams,-pallowsigned=1	ivltests
+vams_abs3		CE,-gverilog-ams,-pallowsigned=1	ivltests
 vhdl_real		CE,-g2009,ivltests/vhdl_real.vhd	ivltests
 vhdl_unbounded		CE,-g2009,ivltests/vhdl_unbounded.vhd	ivltests
 wreal			CE			ivltests

--- a/netlist.cc
+++ b/netlist.cc
@@ -715,10 +715,8 @@ bool NetNet::get_signed() const
 
 bool NetNet::get_scalar() const
 {
-      if (const netvector_t*vec = dynamic_cast<const netvector_t*> (net_type_))
-	    return vec->get_scalar();
-      else
-	    return false;
+      ivl_assert(*this, net_type_);
+      return net_type_->get_scalar();
 }
 
 const netenum_t*NetNet::enumeration(void) const

--- a/netlist.cc
+++ b/netlist.cc
@@ -32,6 +32,7 @@
 # include  "netdarray.h"
 # include  "netenum.h"
 # include  "netparray.h"
+# include  "netscalar.h"
 # include  "netqueue.h"
 # include  "netstruct.h"
 # include  "netvector.h"

--- a/netscalar.h
+++ b/netscalar.h
@@ -28,6 +28,8 @@ class netreal_t : public ivl_type_s {
       ~netreal_t();
 
       ivl_variable_type_t base_type() const;
+      bool get_signed() const { return true; }
+      bool get_scalar() const { return true; }
 
       std::ostream& debug_dump(std::ostream&) const;
 

--- a/nettypes.cc
+++ b/nettypes.cc
@@ -56,6 +56,11 @@ bool ivl_type_s::get_signed() const
       return false;
 }
 
+bool ivl_type_s::get_scalar() const
+{
+      return false;
+}
+
 bool ivl_type_s::type_compatible(ivl_type_t that) const
 {
       if (this == that)

--- a/nettypes.h
+++ b/nettypes.h
@@ -45,6 +45,7 @@ class ivl_type_s {
 	// those specific types.
       virtual ivl_variable_type_t base_type() const;
       virtual bool get_signed() const;
+      virtual bool get_scalar() const;
 
 	// Return true if "that" type is compatible with this
 	// type. Compatible means the types are essentially the same.

--- a/pform.cc
+++ b/pform.cc
@@ -2569,7 +2569,6 @@ void pform_module_define_port(const struct vlltype&li,
 			      list<named_pexpr_t>*attr,
 			      bool keep_attr)
 {
-      data_type_t*packed_type = 0;
       ivl_variable_type_t data_type = IVL_VT_NO_TYPE;
       bool signed_flag = false;
 
@@ -2601,6 +2600,7 @@ void pform_module_define_port(const struct vlltype&li,
 	    data_type = vec_type->base_type;
 	    signed_flag = vec_type->signed_flag;
 	    prange = vec_type->pdims.get();
+	    vtype = 0;
       } else if (real_type_t*rtype = dynamic_cast<real_type_t*>(vtype)) {
 	    data_type = IVL_VT_REAL;
 	    signed_flag = true;
@@ -2614,7 +2614,6 @@ void pform_module_define_port(const struct vlltype&li,
       } else if (vtype) {
 	    if (vtype->figure_packed_base_type() != IVL_VT_NO_TYPE) {
 		  data_type = vtype->figure_packed_base_type();
-		  packed_type = vtype;
 	    } else {
 		  VLerror(li, "sorry: Given type %s not supported here (%s:%d).",
 			  typeid(*vtype).name(), __FILE__, __LINE__);
@@ -2631,10 +2630,10 @@ void pform_module_define_port(const struct vlltype&li,
 
       cur->set_signed(signed_flag);
 
-      if (packed_type) {
-	    cur->set_data_type(packed_type);
+      if (vtype)
+	    cur->set_data_type(vtype);
 
-      } else if (prange == 0) {
+      if (prange == 0) {
 	    cur->set_range_scalar((type == NetNet::IMPLICIT) ? SR_PORT : SR_BOTH);
 
       } else {
@@ -2966,8 +2965,7 @@ vector<pform_tf_port_t>*pform_make_task_ports(const struct vlltype&loc,
       }
 
       if (/*real_type_t*real_type = */ dynamic_cast<real_type_t*> (vtype)) {
-	    ret = pform_make_task_ports(loc, pt, IVL_VT_REAL,
-					 true, 0, ports);
+	    ret = do_make_task_ports(loc, pt, IVL_VT_REAL, vtype, ports);
       }
 
       if (dynamic_cast<string_type_t*> (vtype)) {
@@ -3442,7 +3440,6 @@ void pform_set_data_type(const struct vlltype&li, data_type_t*data_type, list<pe
       }
 
       else if (/*real_type_t*real_type =*/ dynamic_cast<real_type_t*> (data_type)) {
-	    pform_set_net_range(names, 0, true, 0);
 	    vt = IVL_VT_REAL;
       }
 

--- a/pform_disciplines.cc
+++ b/pform_disciplines.cc
@@ -209,7 +209,9 @@ void pform_attach_discipline(const struct vlltype&loc,
 		  error_count += 1;
 
 	    } else {
-		  cur_net->set_data_type(IVL_VT_REAL);
+		  data_type_t *type = new real_type_t(real_type_t::REAL);
+		  FILE_NAME(type, loc);
+		  cur_net->set_data_type(type);
 		  cur_net->set_discipline(discipline);
 	    }
       }


### PR DESCRIPTION
Currently a `vector_type_t` with the base type set to `IVL_VT_REAL` is used as
the data type for real type signals. But there is also the `real_type_t` data
type, which is used as the data type for function return types and class
properties.

Move signals also over to using `real_type_t`. This ensures consistent
behavior between all sorts of constructs with a data type, makes sure that
`vector_type_t` is only used for vector types.

It also allows to eventually differentiate between `real` and `shortreal`
at the elaboration stage. Currently this information is discarded by the
parser.

As a side effect this PR also fixes the rather obscure case of passing a call
to a function with a real return type as the argument to the Verilog AMS
`abs()` function.