### PR TITLE
Fix verilog formatting in usage docs code-blocks

### DIFF
--- a/Documentation/usage/getting_started.rst
+++ b/Documentation/usage/getting_started.rst
@@ -18,7 +18,9 @@ So let us start. Given that you are going to use Icarus Verilog as part of
 your design process, the first thing to do as a designer is learn how to
 compile and execute even the most trivial design. For the purposes of
 simulation, we use as our example the most trivial simulation, a simple Hello,
-World program. ::
+World program.
+
+.. code-block:: verilog
 
   module hello;
     initial 
@@ -59,7 +61,9 @@ modules that are instantiated within others, and it becomes convenient to
 organize them into multiple files. A common convention is to write one
 moderate sized module per file (or group related tiny modules into a single
 file) then combine the files of the design together during compilation. For
-example, the counter model in counter.v::
+example, the counter model in counter.v
+
+.. code-block:: verilog
 
   module counter(output, clk, reset);
 
@@ -79,7 +83,9 @@ example, the counter model in counter.v::
 
   endmodule // counter
 
-and the test bench in counter_tb.v::
+and the test bench in counter_tb.v
+
+.. code-block:: verilog
 
   module test;
 

--- a/Documentation/usage/simulation.rst
+++ b/Documentation/usage/simulation.rst
@@ -258,7 +258,9 @@ world into the program at run time. Arguments can be entered on the command
 line, and larger amounts of data can be read from files. The simplest method
 is to take arguments from the command line.
 
-Consider this running example of a square root calculator::
+Consider this running example of a square root calculator
+
+.. code-block:: verilog
 
   module sqrt32(clk, rdy, reset, x, .y(acc));
     input  clk;
@@ -317,7 +319,9 @@ different input values on the run time command line without recompiling the
 simulation.
 
 This example demonstrates the use of the "$value$plusargs" to access command
-line arguments of a simulation::
+line arguments of a simulation
+
+.. code-block:: verilog
 
   module main;
 
@@ -362,7 +366,9 @@ run is "81". This gets assigned to "x" by the "$value$plusargs" function,
 which returns TRUE, and the simulation continues from there.
 
 If two arguments have to be passed to the testbench then the main module would
-be modified as follows::
+be modified as follows
+
+.. code-block:: verilog
 
   module main;
 
@@ -428,7 +434,9 @@ input values, then rerun the simulation without compiling it again. The
 advantage of this technique is that we can accumulate a large set of test
 input values, and run the lot as a batch.
 
-This example::
+This example
+
+.. code-block:: verilog
 
   module main;
 


### PR DESCRIPTION
Code-block defaults created some funny highlighting for verilog.

Used ".. code-block:: verilog" directive to fix (https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block)

systemverilog is also available (https://pygments.org/docs/lexers/#lexers-for-hardware-descriptor-languages)