### PR TITLE
Handle signedness and width expansion for class properties and methods

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -430,6 +430,9 @@ class PEIdent : public PExpr {
 				       NetAssign_*) const;
 
     private:
+      NetExpr* elaborate_expr_(Design *des, NetScope *scope,
+			      unsigned expr_wid, unsigned flags) const;
+
       NetExpr*elaborate_expr_param_or_specparam_(Design*des,
 						 NetScope*scope,
 						 const NetExpr*par,

--- a/PExpr.h
+++ b/PExpr.h
@@ -926,22 +926,25 @@ class PECallFunction : public PExpr {
 
       NetExpr* cast_to_width_(NetExpr*expr, unsigned wid) const;
 
+      NetExpr* elaborate_expr_(Design *des, NetScope *scope,
+			       unsigned flags) const;
+
       NetExpr*elaborate_expr_pkg_(Design*des, NetScope*scope,
-				  unsigned expr_wid, unsigned flags)const;
+				  unsigned flags)const;
 
       NetExpr* elaborate_expr_method_(Design*des, NetScope*scope,
-				      symbol_search_results&search_results,
-				      unsigned expr_wid) const;
+				      symbol_search_results&search_results)
+				      const;
       NetExpr* elaborate_expr_method_par_(Design*des, NetScope*scope,
-					  symbol_search_results&search_results,
-					  unsigned expr_wid) const;
+					  symbol_search_results&search_results)
+					  const;
 
 
       NetExpr* elaborate_sfunc_(Design*des, NetScope*scope,
                                 unsigned expr_wid,
                                 unsigned flags) const;
-      NetExpr* elaborate_access_func_(Design*des, NetScope*scope, ivl_nature_t,
-                                      unsigned expr_wid) const;
+      NetExpr* elaborate_access_func_(Design*des, NetScope*scope, ivl_nature_t)
+                                      const;
       unsigned test_width_sfunc_(Design*des, NetScope*scope,
 			         width_mode_t&mode);
       unsigned test_width_method_(Design*des, NetScope*scope,
@@ -949,7 +952,7 @@ class PECallFunction : public PExpr {
 				  width_mode_t&mode);
 
       NetExpr*elaborate_base_(Design*des, NetScope*scope, NetScope*dscope,
-			      unsigned expr_wid, unsigned flags) const;
+			      unsigned flags) const;
 
       unsigned elaborate_arguments_(Design*des, NetScope*scope,
 				    NetFuncDef*def, bool need_const,

--- a/Statement.h
+++ b/Statement.h
@@ -249,9 +249,7 @@ class PCallTask  : public Statement {
 				      const char*sys_task_name) const;
       NetProc*elaborate_method_func_(NetScope*scope,
 				     NetNet*net,
-				     ivl_variable_type_t type,
-				     unsigned width,
-				     bool signed_flag,
+				     ivl_type_t type,
 				     perm_string method_name,
 				     const char*sys_task_name) const;
       bool test_task_calls_ok_(Design*des, NetScope*scope) const;

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3965,6 +3965,16 @@ unsigned PEIdent::test_width_method_(Design*des, NetScope*scope, width_mode_t&)
 	    }
       }
 
+      if (const struct netqueue_t *queue = net->queue_type()) {
+	    if (member_name == "pop_back" || member_name == "pop_front") {
+		  expr_type_ = queue->element_base_type();
+		  expr_width_ = queue->element_width();
+		  min_width_ = expr_width_;
+		  signed_flag_ = queue->get_signed();
+		  return expr_width_;
+	    }
+      }
+
 	// Look for the enumeration attributes.
       if (const netenum_t*netenum = net->enumeration()) {
 	    if (member_name == "num") {

--- a/ivtest/ivltests/enum_method_signed1.v
+++ b/ivtest/ivltests/enum_method_signed1.v
@@ -1,0 +1,156 @@
+// Check that the signedness of methods on the built-in enum type is handled
+// correctly when calling the method with parenthesis.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED(%0d): ", `__LINE__, `"x`"); \
+      failed = 1'b1; \
+    end
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+
+  enum shortint {
+    A = -1,
+    B = -2,
+    C = -3
+  } es;
+
+  enum bit [15:0] {
+    X = 65535,
+    Y = 65534,
+    Z = 65533
+  } eu;
+
+  initial begin
+    es = B;
+    eu = Y;
+
+    // These all evaluate as signed
+    `check($signed(eu.first()) < 0)
+    `check(es.first() < 0)
+
+    `check($signed(eu.last()) < 0)
+    `check(es.last() < 0)
+
+    `check($signed(eu.prev()) < 0)
+    `check(es.prev() < 0)
+
+    `check($signed(eu.next()) < 0)
+    `check(es.next() < 0)
+
+    // These all evaluate as unsigned
+    `check(eu.first() > 0)
+    `check({es.first()} > 0)
+    `check($unsigned(es.first()) > 0)
+    `check(es.first() > 16'h0)
+
+    `check(eu.last() > 0)
+    `check({es.last()} > 0)
+    `check($unsigned(es.last()) > 0)
+    `check(es.last() > 16'h0)
+
+    `check(eu.prev() > 0)
+    `check({es.prev()} > 0)
+    `check($unsigned(es.prev()) > 0)
+    `check(es.prev() > 16'h0)
+
+    `check(eu.next() > 0)
+    `check({es.next()} > 0)
+    `check($unsigned(es.next()) > 0)
+    `check(es.next() > 16'h0)
+
+    // In arithmetic expressions if one operand is unsigned all operands are
+    // considered unsigned
+    z = eu.first() + x;
+    `check(z === 65545)
+    z = eu.first() + y;
+    `check(z === 65545)
+
+    z = eu.last() + x;
+    `check(z === 65543)
+    z = eu.last() + y;
+    `check(z === 65543)
+
+    z = eu.prev() + x;
+    `check(z === 65545)
+    z = eu.prev() + y;
+    `check(z === 65545)
+
+    z = eu.next() + x;
+    `check(z === 65543)
+    z = eu.next() + y;
+    `check(z === 65543)
+
+    z = es.first() + x;
+    `check(z === 65545)
+    z = es.first() + y;
+    `check(z === 9)
+
+    z = es.last() + x;
+    `check(z === 65543)
+    z = es.last() + y;
+    `check(z === 7)
+
+    z = es.prev() + x;
+    `check(z === 65545)
+    z = es.prev() + y;
+    `check(z === 9)
+
+    z = es.next() + x;
+    `check(z === 65543)
+    z = es.next() + y;
+    `check(z === 7)
+
+    // For ternary operators if one operand is unsigned the result is unsigend
+    z = x ? eu.first() : x;
+    `check(z === 65535)
+    z = x ? eu.first() : y;
+    `check(z === 65535)
+
+    z = x ? eu.last() : x;
+    `check(z === 65533)
+    z = x ? eu.last() : y;
+    `check(z === 65533)
+
+    z = x ? eu.prev() : x;
+    `check(z === 65535)
+    z = x ? eu.prev() : y;
+    `check(z === 65535)
+
+    z = x ? eu.next() : x;
+    `check(z === 65533)
+    z = x ? eu.next() : y;
+    `check(z === 65533)
+
+    z = x ? es.first() : x;
+    `check(z === 65535)
+    z = x ? es.first() : y;
+    `check(z === -1)
+
+    z = x ? es.last() : x;
+    `check(z === 65533)
+    z = x ? es.last() : y;
+    `check(z === -3)
+
+    z = x ? es.prev() : x;
+    `check(z === 65535)
+    z = x ? es.prev() : y;
+    `check(z === -1)
+
+    z = x ? es.next() : x;
+    `check(z === 65533)
+    z = x ? es.next() : y;
+    `check(z === -3)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/enum_method_signed2.v
+++ b/ivtest/ivltests/enum_method_signed2.v
@@ -1,0 +1,35 @@
+// Check that the signedness of methods on the built-in enum type is handled
+// correctly when calling the function with parenthesis and passing the result
+// to a system function.
+
+module test;
+
+  enum shortint {
+    A = -1,
+    B = -2,
+    C = -3
+  } es;
+
+  enum bit [15:0] {
+    X = 65535,
+    Y = 65534,
+    Z = 65533
+  } eu;
+
+  string s;
+
+  initial begin
+    es = B;
+    eu = Y;
+
+    s = $sformatf("%0d %0d %0d %0d %0d %0d %0d %0d",
+                  es.first(), es.last(), es.prev(), es.next(),
+                  eu.first(), eu.last(), eu.prev(), eu.next());
+    if (s == "-1 -3 -1 -3 65535 65533 65535 65533") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/enum_method_signed3.v
+++ b/ivtest/ivltests/enum_method_signed3.v
@@ -1,0 +1,156 @@
+// Check that the signedness of methods on the built-in enum type is handled
+// correctly when calling the method without parenthesis.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED(%0d): ", `__LINE__, `"x`"); \
+      failed = 1'b1; \
+    end
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+
+  enum shortint {
+    A = -1,
+    B = -2,
+    C = -3
+  } es;
+
+  enum bit [15:0] {
+    X = 65535,
+    Y = 65534,
+    Z = 65533
+  } eu;
+
+  initial begin
+    es = B;
+    eu = Y;
+
+    // These all evaluate as signed
+    `check($signed(eu.first) < 0)
+    `check(es.first < 0)
+
+    `check($signed(eu.last) < 0)
+    `check(es.last < 0)
+
+    `check($signed(eu.prev) < 0)
+    `check(es.prev < 0)
+
+    `check($signed(eu.next) < 0)
+    `check(es.next < 0)
+
+    // These all evaluate as unsigned
+    `check(eu.first > 0)
+    `check({es.first} > 0)
+    `check($unsigned(es.first) > 0)
+    `check(es.first > 16'h0)
+
+    `check(eu.last > 0)
+    `check({es.last} > 0)
+    `check($unsigned(es.last) > 0)
+    `check(es.last > 16'h0)
+
+    `check(eu.prev > 0)
+    `check({es.prev} > 0)
+    `check($unsigned(es.prev) > 0)
+    `check(es.prev > 16'h0)
+
+    `check(eu.next > 0)
+    `check({es.next} > 0)
+    `check($unsigned(es.next) > 0)
+    `check(es.next > 16'h0)
+
+    // In arithmetic expressions if one operand is unsigned all operands are
+    // considered unsigned
+    z = eu.first + x;
+    `check(z === 65545)
+    z = eu.first + y;
+    `check(z === 65545)
+
+    z = eu.last + x;
+    `check(z === 65543)
+    z = eu.last + y;
+    `check(z === 65543)
+
+    z = eu.prev + x;
+    `check(z === 65545)
+    z = eu.prev + y;
+    `check(z === 65545)
+
+    z = eu.next + x;
+    `check(z === 65543)
+    z = eu.next + y;
+    `check(z === 65543)
+
+    z = es.first + x;
+    `check(z === 65545)
+    z = es.first + y;
+    `check(z === 9)
+
+    z = es.last + x;
+    `check(z === 65543)
+    z = es.last + y;
+    `check(z === 7)
+
+    z = es.prev + x;
+    `check(z === 65545)
+    z = es.prev + y;
+    `check(z === 9)
+
+    z = es.next + x;
+    `check(z === 65543)
+    z = es.next + y;
+    `check(z === 7)
+
+    // For ternary operators if one operand is unsigned the result is unsigend
+    z = x ? eu.first : x;
+    `check(z === 65535)
+    z = x ? eu.first : y;
+    `check(z === 65535)
+
+    z = x ? eu.last : x;
+    `check(z === 65533)
+    z = x ? eu.last : y;
+    `check(z === 65533)
+
+    z = x ? eu.prev : x;
+    `check(z === 65535)
+    z = x ? eu.prev : y;
+    `check(z === 65535)
+
+    z = x ? eu.next : x;
+    `check(z === 65533)
+    z = x ? eu.next : y;
+    `check(z === 65533)
+
+    z = x ? es.first : x;
+    `check(z === 65535)
+    z = x ? es.first : y;
+    `check(z === -1)
+
+    z = x ? es.last : x;
+    `check(z === 65533)
+    z = x ? es.last : y;
+    `check(z === -3)
+
+    z = x ? es.prev : x;
+    `check(z === 65535)
+    z = x ? es.prev : y;
+    `check(z === -1)
+
+    z = x ? es.next : x;
+    `check(z === 65533)
+    z = x ? es.next : y;
+    `check(z === -3)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/enum_method_signed4.v
+++ b/ivtest/ivltests/enum_method_signed4.v
@@ -1,0 +1,35 @@
+// Check that the signedness of methods on the built-in enum type is handled
+// correctly when calling the function without parenthesis and passing the
+// result to a system function.
+
+module test;
+
+  enum shortint {
+    A = -1,
+    B = -2,
+    C = -3
+  } es;
+
+  enum bit [15:0] {
+    X = 65535,
+    Y = 65534,
+    Z = 65533
+  } eu;
+
+  string s;
+
+  initial begin
+    es = B;
+    eu = Y;
+
+    s = $sformatf("%0d %0d %0d %0d %0d %0d %0d %0d",
+                  es.first, es.last, es.prev, es.next,
+                  eu.first, eu.last, eu.prev, eu.next);
+    if (s == "-1 -3 -1 -3 65535 65533 65535 65533") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_method_signed1.v
+++ b/ivtest/ivltests/sv_class_method_signed1.v
@@ -1,0 +1,71 @@
+// Check that the signedness of methods on user defined classes is handled
+// correctly.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED(%0d): ", `__LINE__, `"x`"); \
+      failed = 1'b1; \
+    end
+
+  class C;
+    function shortint s;
+      return -1;
+    endfunction
+
+    function bit [15:0] u;
+      return -1;
+    endfunction
+  endclass
+
+  C c;
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+
+  initial begin
+    c = new;
+
+    // These all evaluate as signed
+    `check($signed(c.u()) < 0)
+    `check(c.s() < 0)
+
+    // These all evaluate as unsigned
+    `check(c.u() > 0)
+    `check({c.s()} > 0)
+    `check($unsigned(c.s()) > 0)
+    `check(c.s() > 16'h0)
+
+    // In arithmetic expressions if one operand is unsigned all operands are
+    // considered unsigned
+    z = c.u() + x;
+    `check(z === 65545)
+    z = c.u() + y;
+    `check(z === 65545)
+
+    z = c.s() + x;
+    `check(z === 65545)
+    z = c.s() + y;
+    `check(z === 9)
+
+    // For ternary operators if one operand is unsigned the result is unsigend
+    z = x ? c.u() : x;
+    `check(z === 65535)
+    z = x ? c.u() : y;
+    `check(z === 65535)
+
+    z = x ? c.s() : x;
+    `check(z === 65535)
+    z = x ? c.s() : y;
+    `check(z === -1)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_method_signed2.v
+++ b/ivtest/ivltests/sv_class_method_signed2.v
@@ -1,0 +1,30 @@
+// Check that the signedness of methods on user defined classes is handled
+// correctly when passing the result to a system function.
+
+module test;
+
+  class C;
+    function shortint s;
+      return -1;
+    endfunction
+
+    function bit [15:0] u;
+      return -1;
+    endfunction
+  endclass
+
+  C c;
+  string s;
+
+  initial begin
+    c = new;
+
+    s = $sformatf("%0d %0d", c.s(), c.u());
+    if (s == "-1 65535") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_property_signed1.v
+++ b/ivtest/ivltests/sv_class_property_signed1.v
@@ -1,0 +1,66 @@
+// Check that the signedness of class properties are handled correctly when
+// accessing the property on a class object.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED(%0d): ", `__LINE__, `"x`"); \
+      failed = 1'b1; \
+    end
+
+  class C;
+    shortint s = -1;
+    bit [15:0] u = -1;
+  endclass
+
+  C c;
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+
+  initial begin
+    c = new;
+
+    // These all evaluate as signed
+    `check(c.s < 0)
+    `check($signed(c.u) < 0)
+
+    // These all evaluate as unsigned
+    `check(c.u > 0)
+    `check({c.s} > 0)
+    `check($unsigned(c.s) > 0)
+    `check(c.s > 16'h0)
+
+    // In arithmetic expressions if one operand is unsigned all operands are
+    // considered unsigned
+    z = c.u + x;
+    `check(z === 65545)
+    z = c.u + y;
+    `check(z === 65545)
+
+    z = c.s + x;
+    `check(z === 65545)
+    z = c.s + y;
+    `check(z === 9)
+
+    // For ternary operators if one operand is unsigned the result is unsigend
+    z = x ? c.u : x;
+    `check(z === 65535)
+    z = x ? c.u : y;
+    `check(z === 65535)
+
+    z = x ? c.s : x;
+    `check(z === 65535)
+    z = x ? c.s : y;
+    `check(z === -1)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_property_signed2.v
+++ b/ivtest/ivltests/sv_class_property_signed2.v
@@ -1,0 +1,25 @@
+// Check that the signedness of class properties are handled correctly when
+// accessing the property on a class object and passing it to a system function.
+
+module test;
+
+  class C;
+    shortint s = -1;
+    bit [15:0] u = -1;
+  endclass
+
+  C c;
+  string s;
+
+  initial begin
+    c = new;
+
+    s = $sformatf("%0d %0d", c.s, c.u);
+    if (s == "-1 65535") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_property_signed3.v
+++ b/ivtest/ivltests/sv_class_property_signed3.v
@@ -1,0 +1,71 @@
+// Check that the signedness of class properties are handled correctly when
+// accessing the property in a class method.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED: ", `"x`", `__LINE__); \
+      failed = 1'b1; \
+    end
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+
+  class C;
+    shortint s = -1;
+    bit [15:0] u = -1;
+
+    task test;
+
+      // These all evaluate as signed
+      `check(s < 0)
+      `check($signed(u) < 0)
+
+      // These all evaluate as unsigned
+      `check(u > 0)
+      `check({s} > 0)
+      `check($unsigned(s) > 0)
+      `check(s > 16'h0)
+
+      // In arithmetic expressions if one operand is unsigned all operands are
+      // considered unsigned
+      z = u + x;
+      `check(z === 65545)
+      z = u + y;
+      `check(z === 65545)
+
+      z = s + x;
+      `check(z === 65545)
+      z = s + y;
+      `check(z === 9)
+
+      // For ternary operators if one operand is unsigned the result is unsigend
+      z = x ? u : x;
+      `check(z === 65535)
+      z = x ? u : y;
+      `check(z === 65535)
+
+      z = x ? s : x;
+      `check(z === 65535)
+      z = x ? s : y;
+      `check(z === -1)
+
+      if (!failed) begin
+        $display("PASSED");
+      end
+    endtask
+
+  endclass
+
+  C c;
+
+  initial begin
+    c = new;
+    c.test();
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_property_signed4.v
+++ b/ivtest/ivltests/sv_class_property_signed4.v
@@ -1,0 +1,30 @@
+// Check that the signedness of class properties are handled correctly when
+// accessing the property in a class method and passing it to a system function.
+
+module test;
+
+  class C;
+    shortint s = -1;
+    bit [15:0] u = -1;
+
+    task test;
+      string str;
+
+      str = $sformatf("%0d %0d", s, u);
+      if (str == "-1 65535") begin
+        $display("PASSED");
+      end else begin
+        $display("FAILED s=%s", s);
+      end
+    endtask
+
+  endclass
+
+  C c;
+
+  initial begin
+    c = new;
+    c.test();
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_queue_method_signed1.v
+++ b/ivtest/ivltests/sv_queue_method_signed1.v
@@ -1,0 +1,99 @@
+// Check that the signedness of the element type of a queue is correctly handled
+// whenn calling one of the pop methods with parenthesis.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED(%0d): ", `__LINE__, `"x`"); \
+      failed = 1'b1; \
+    end
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+  longint w;
+
+  shortint qs[$];
+  bit [15:0] qu[$];
+
+  initial begin
+    for (int i = 0; i < 16; i++) begin
+      qu.push_back(-1);
+      qs.push_back(-1);
+    end
+
+    // These all evaluate as signed
+    `check($signed(qu.pop_back()) < 0)
+    `check(qs.pop_back() < 0)
+
+    `check($signed(qu.pop_front()) < 0)
+    `check(qs.pop_front() < 0)
+
+    // These all evaluate as unsigned
+    `check(qu.pop_back() > 0)
+    `check({qs.pop_back()} > 0)
+    `check($unsigned(qs.pop_back()) > 0)
+    `check(qs.pop_back() > 16'h0)
+
+    `check(qu.pop_front() > 0)
+    `check({qs.pop_front()} > 0)
+    `check($unsigned(qs.pop_front()) > 0)
+    `check(qs.pop_front() > 16'h0)
+
+    // In arithmetic expressions if one operand is unsigned all operands are
+    // considered unsigned
+    z = qu.pop_back() + x;
+    `check(z === 65545)
+    z = qu.pop_back() + y;
+    `check(z === 65545)
+
+    z = qu.pop_front() + x;
+    `check(z === 65545)
+    z = qu.pop_front() + y;
+    `check(z === 65545)
+
+    z = qs.pop_back() + x;
+    `check(z === 65545)
+    z = qs.pop_back() + y;
+    `check(z === 9)
+
+    z = qs.pop_front() + x;
+    `check(z === 65545)
+    z = qs.pop_front() + y;
+    `check(z === 9)
+
+    // For ternary operators if one operand is unsigned the result is unsigend
+    z = x ? qu.pop_back() : x;
+    `check(z === 65535)
+    z = x ? qu.pop_back() : y;
+    `check(z === 65535)
+
+    z = x ? qu.pop_front() : x;
+    `check(z === 65535)
+    z = x ? qu.pop_front() : y;
+    `check(z === 65535)
+
+    z = x ? qs.pop_back() : x;
+    `check(z === 65535)
+    z = x ? qs.pop_back() : y;
+    `check(z === -1)
+
+    z = x ? qs.pop_front() : x;
+    `check(z === 65535)
+    z = x ? qs.pop_front() : y;
+    `check(z === -1)
+
+    // Size return value is always positive, but check that it gets padded
+    // properly
+    w = x ? qu.size() : 64'h123;
+    `check(w === 64'h4)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_queue_method_signed2.v
+++ b/ivtest/ivltests/sv_queue_method_signed2.v
@@ -1,0 +1,29 @@
+// Check that the signedness of the element type of a queue is correctly handled
+// when passing the result of one of the pop methods as an argument to a system
+// function.
+
+module test;
+
+  shortint qs[$];
+  bit [15:0] qu[$];
+
+  string s;
+
+  initial begin
+    qs.push_back(-1);
+    qs.push_back(-2);
+    qu.push_back(-1);
+    qu.push_back(-2);
+
+    // Values popped from qs should be treated as signed, values popped from qu
+    // should be treated as unsigned
+    s = $sformatf("%0d %0d %0d %0d", qs.pop_front(), qs.pop_back(),
+                                     qu.pop_front(), qu.pop_back());
+    if (s == "-1 -2 65535 65534") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_queue_method_signed3.v
+++ b/ivtest/ivltests/sv_queue_method_signed3.v
@@ -1,0 +1,99 @@
+// Check that the signedness of the element type of a queue is correctly handled
+// whenn calling one of the pop methods with parenthesis.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(x) \
+    if (!(x)) begin \
+      $display("FAILED(%0d): ", `__LINE__, `"x`"); \
+      failed = 1'b1; \
+    end
+
+  int unsigned x = 10;
+  int y = 10;
+  int z;
+  longint w;
+
+  shortint qs[$];
+  bit [15:0] qu[$];
+
+  initial begin
+    for (int i = 0; i < 16; i++) begin
+      qu.push_back(-1);
+      qs.push_back(-1);
+    end
+
+    // These all evaluate as signed
+    `check($signed(qu.pop_back) < 0)
+    `check(qs.pop_back < 0)
+
+    `check($signed(qu.pop_front) < 0)
+    `check(qs.pop_front < 0)
+
+    // These all evaluate as unsigned
+    `check(qu.pop_back > 0)
+    `check({qs.pop_back} > 0)
+    `check($unsigned(qs.pop_back) > 0)
+    `check(qs.pop_back > 16'h0)
+
+    `check(qu.pop_front > 0)
+    `check({qs.pop_front} > 0)
+    `check($unsigned(qs.pop_front) > 0)
+    `check(qs.pop_front > 16'h0)
+
+    // In arithmetic expressions if one operand is unsigned all operands are
+    // considered unsigned
+    z = qu.pop_back + x;
+    `check(z === 65545)
+    z = qu.pop_back + y;
+    `check(z === 65545)
+
+    z = qu.pop_front + x;
+    `check(z === 65545)
+    z = qu.pop_front + y;
+    `check(z === 65545)
+
+    z = qs.pop_back + x;
+    `check(z === 65545)
+    z = qs.pop_back + y;
+    `check(z === 9)
+
+    z = qs.pop_front + x;
+    `check(z === 65545)
+    z = qs.pop_front + y;
+    `check(z === 9)
+
+    // For ternary operators if one operand is unsigned the result is unsigend
+    z = x ? qu.pop_back : x;
+    `check(z === 65535)
+    z = x ? qu.pop_back : y;
+    `check(z === 65535)
+
+    z = x ? qu.pop_front : x;
+    `check(z === 65535)
+    z = x ? qu.pop_front : y;
+    `check(z === 65535)
+
+    z = x ? qs.pop_back : x;
+    `check(z === 65535)
+    z = x ? qs.pop_back : y;
+    `check(z === -1)
+
+    z = x ? qs.pop_front : x;
+    `check(z === 65535)
+    z = x ? qs.pop_front : y;
+    `check(z === -1)
+
+    // Size return value is always positive, but check that it gets padded
+    // properly
+    w = x ? qu.size : 64'h123;
+    `check(w === 64'h4)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_queue_method_signed4.v
+++ b/ivtest/ivltests/sv_queue_method_signed4.v
@@ -1,0 +1,29 @@
+// Check that the signedness of the element type of a queue is correctly handled
+// when passing the result of one of the pop methods as an argument to a system
+// function.
+
+module test;
+
+  shortint qs[$];
+  bit [15:0] qu[$];
+
+  string s;
+
+  initial begin
+    qs.push_back(-1);
+    qs.push_back(-2);
+    qu.push_back(-1);
+    qu.push_back(-2);
+
+    // Values popped from qs should be treated as signed, values popped from qu
+    // should be treated as unsigned
+    s = $sformatf("%0d %0d %0d %0d", qs.pop_front, qs.pop_back,
+                                     qu.pop_front, qu.pop_back);
+    if (s == "-1 -2 65535 65534") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED s=%s", s);
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -494,6 +494,10 @@ sv_class_new_init	normal,-g2009		ivltests
 sv_class_in_module_decl	normal,-g2009		ivltests
 sv_class_method_signed1	normal,-g2009		ivltests
 sv_class_method_signed2	normal,-g2009		ivltests
+sv_class_property_signed1	normal,-g2009	ivltests
+sv_class_property_signed2	normal,-g2009	ivltests
+sv_class_property_signed3	normal,-g2009	ivltests
+sv_class_property_signed4	normal,-g2009	ivltests
 sv_class_static_prop1	normal,-g2009		ivltests
 sv_class_static_prop2	normal,-g2009		ivltests
 sv_class_static_prop3	normal,-g2009		ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -265,6 +265,10 @@ enum_in_struct		normal,-g2005-sv	ivltests
 enum_in_class		normal,-g2005-sv	ivltests
 enum_in_class_name_coll	CE,-g2005-sv		ivltests
 enum_line_info		CE,-g2005-sv		ivltests gold=enum_line_info.gold
+enum_method_signed1	normal,-g2005-sv	ivltests
+enum_method_signed2	normal,-g2005-sv	ivltests
+enum_method_signed3	normal,-g2005-sv	ivltests
+enum_method_signed4	normal,-g2005-sv	ivltests
 enum_next		normal,-g2005-sv	ivltests
 enum_order		normal,-g2005-sv	ivltests
 enum_ports		normal,-g2005-sv	ivltests
@@ -488,6 +492,8 @@ sv_class_extends_scoped	normal,-g2009		ivltests
 sv_class_localparam	normal,-g2009		ivltests
 sv_class_new_init	normal,-g2009		ivltests
 sv_class_in_module_decl	normal,-g2009		ivltests
+sv_class_method_signed1	normal,-g2009		ivltests
+sv_class_method_signed2	normal,-g2009		ivltests
 sv_class_static_prop1	normal,-g2009		ivltests
 sv_class_static_prop2	normal,-g2009		ivltests
 sv_class_static_prop3	normal,-g2009		ivltests
@@ -571,6 +577,10 @@ sv_queue_parray_fail	CE,-g2009		ivltests gold=sv_queue_parray_fail.gold
 sv_queue_real		normal,-g2009,-pfileline=1	ivltests gold=sv_queue_real.gold
 sv_queue_real_bounded	normal,-g2009,-pfileline=1	ivltests gold=sv_queue_real_bounded.gold
 sv_queue_real_fail	CE,-g2009		ivltests gold=sv_queue_real_fail.gold
+sv_queue_method_signed1	normal,-g2009		ivltests
+sv_queue_method_signed2	normal,-g2009		ivltests
+sv_queue_method_signed3	normal,-g2009		ivltests
+sv_queue_method_signed4	normal,-g2009		ivltests
 sv_queue_string		normal,-g2009,-pfileline=1	ivltests gold=sv_queue_string.gold
 sv_queue_string_bounded	normal,-g2009,-pfileline=1	ivltests gold=sv_queue_string_bounded.gold
 sv_queue_string_fail	CE,-g2009		ivltests gold=sv_queue_string_fail.gold

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -386,6 +386,10 @@ sv_class_new_init	CE,-g2009		ivltests
 sv_class_in_module_decl	CE,-g2009		ivltests
 sv_class_method_signed1	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_method_signed2	CE,-g2009,-pallowsigned=1	ivltests
+sv_class_property_signed1	CE,-g2009,-pallowsigned=1	ivltests
+sv_class_property_signed2	CE,-g2009,-pallowsigned=1	ivltests
+sv_class_property_signed3	CE,-g2009,-pallowsigned=1	ivltests
+sv_class_property_signed4	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_static_prop1	CE,-g2009		ivltests
 sv_class_static_prop2	CE,-g2009		ivltests
 sv_class_static_prop3	CE,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -384,6 +384,8 @@ sv_class_extends_scoped	CE,-g2009		ivltests
 sv_class_localparam	CE,-g2009		ivltests
 sv_class_new_init	CE,-g2009		ivltests
 sv_class_in_module_decl	CE,-g2009		ivltests
+sv_class_method_signed1	CE,-g2009,-pallowsigned=1	ivltests
+sv_class_method_signed2	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_static_prop1	CE,-g2009		ivltests
 sv_class_static_prop2	CE,-g2009		ivltests
 sv_class_static_prop3	CE,-g2009		ivltests
@@ -438,6 +440,10 @@ br_gh436		CE,-g2012,-pallowsigned=1	ivltests  # queues/strings
 br_gh672		CE,-g2009		ivltests  # join_none
 br_mw20200501		CE,-g2009		ivltests  # queues
 disable_fork_cmd	CE,-g2009		ivltests  # disable fork and join_*
+enum_method_signed1	CE,-g2009,-pallowsigned=1	ivltests
+enum_method_signed2	CE,-g2009,-pallowsigned=1	ivltests
+enum_method_signed3	CE,-g2009,-pallowsigned=1	ivltests
+enum_method_signed4	CE,-g2009,-pallowsigned=1	ivltests
 enum_next		CE,-g2009,-pallowsigned=1	ivltests  # enum
 enum_test1		CE,-g2009		ivltests  # enum
 fork_join_any		CE,-g2009,-pallowsigned=1	ivltests  # join_any
@@ -611,6 +617,10 @@ br_gh433		CE,-g2009,-pallowsigned=1	ivltests
 sv_queue1		CE,-g2009,-pallowsigned=1	ivltests
 sv_queue2		CE,-g2009,-pallowsigned=1	ivltests
 sv_queue3		CE,-g2009		ivltests
+sv_queue_method_signed1	CE,-g2009,-pallowsigned=1	ivltests
+sv_queue_method_signed2	CE,-g2009,-pallowsigned=1	ivltests
+sv_queue_method_signed3	CE,-g2009,-pallowsigned=1	ivltests
+sv_queue_method_signed4	CE,-g2009,-pallowsigned=1	ivltests
 sv_queue_real		CE,-g2009		ivltests
 sv_queue_real_bounded	CE,-g2009		ivltests
 sv_queue_real_fail	CE,-g2009		ivltests

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -487,28 +487,13 @@ NetESFunc::NetESFunc(const char*n, ivl_variable_type_t t,
 }
 
 NetESFunc::NetESFunc(const char*n, ivl_type_t rtype, unsigned np)
-: NetExpr(rtype), name_(0), type_(IVL_VT_NO_TYPE), enum_type_(0), parms_(np), is_overridden_(false)
+: NetExpr(rtype), name_(0), type_(rtype->base_type()),
+  enum_type_(dynamic_cast<const netenum_t*>(rtype)), parms_(np),
+  is_overridden_(false)
 {
       name_ = lex_strings.add(n);
       expr_width(rtype->packed_width());
-	// FIXME: For now, assume that all uses of this constructor
-	// are for the IVL_VT_DARRAY type. Eventually, the type_
-	// member will go away.
-      if (dynamic_cast<const netdarray_t*>(rtype))
-	    type_ = IVL_VT_DARRAY;
-      else if (dynamic_cast<const netclass_t*>(rtype))
-	    type_ = IVL_VT_CLASS;
-      else if (dynamic_cast<const netstring_t*>(rtype))
-	    type_ = IVL_VT_STRING;
-      else
-	    ivl_assert(*this, 0);
-}
-
-NetESFunc::NetESFunc(const char*n, const netenum_t*enum_type, unsigned np)
-: name_(0), type_(enum_type->base_type()), enum_type_(enum_type), parms_(np), is_overridden_(false)
-{
-      name_ = lex_strings.add(n);
-      expr_width(enum_type->packed_width());
+      cast_signed_base_(rtype->get_signed());
 }
 
 NetESFunc::~NetESFunc()

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -561,6 +561,7 @@ ivl_variable_type_t NetEShallowCopy::expr_type() const
 NetEAccess::NetEAccess(NetBranch*br, ivl_nature_t nat)
 : branch_(br), nature_(nat)
 {
+      cast_signed_base_(true);
 }
 
 NetEAccess::~NetEAccess()

--- a/netlist.cc
+++ b/netlist.cc
@@ -2159,6 +2159,7 @@ NetEUFunc::NetEUFunc(NetScope*scope, NetScope*def, NetESignal*res,
 : scope_(scope), func_(def), result_sig_(res), parms_(p), need_const_(nc)
 {
       expr_width(result_sig_->expr_width());
+      cast_signed_base_(result_sig_->has_sign());
 }
 
 NetEUFunc::~NetEUFunc()

--- a/netlist.cc
+++ b/netlist.cc
@@ -549,6 +549,9 @@ template <class T> static unsigned calculate_count(T*type)
 void NetNet::calculate_slice_widths_from_packed_dims_(void)
 {
       ivl_assert(*this, net_type_);
+      if (!net_type_->packed())
+	    return;
+
       slice_dims_ = net_type_->slice_dimensions();
 
 	// Special case: There are no actual packed dimensions, so
@@ -598,42 +601,10 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
       s->add_signal(this);
 }
 
-/*
- * When we create a netnet for a packed struct, create a single
- * vector with the msb_/lsb_ chosen to name enough bits for the entire
- * packed structure.
- */
-NetNet::NetNet(NetScope*s, perm_string n, Type t, netstruct_t*ty)
+NetNet::NetNet(NetScope*s, perm_string n, Type t, ivl_type_t type)
 : NetObj(s, n, 1),
     type_(t), port_type_(NOT_A_PORT),
-    local_flag_(false), net_type_(ty),
-    discipline_(0),
-    eref_count_(0), lref_count_(0)
-{
-	//XXXX packed_dims_.push_back(netrange_t(calculate_count(ty)-1, 0));
-      calculate_slice_widths_from_packed_dims_();
-
-      initialize_dir_();
-
-      s->add_signal(this);
-}
-
-NetNet::NetNet(NetScope*s, perm_string n, Type t, netdarray_t*ty)
-: NetObj(s, n, 1),
-    type_(t), port_type_(NOT_A_PORT),
-    local_flag_(false), net_type_(ty),
-    discipline_(0),
-    eref_count_(0), lref_count_(0)
-{
-      initialize_dir_();
-
-      s->add_signal(this);
-}
-
-NetNet::NetNet(NetScope*s, perm_string n, Type t, netvector_t*ty)
-: NetObj(s, n, 1),
-    type_(t), port_type_(NOT_A_PORT),
-    local_flag_(false), net_type_(ty),
+    local_flag_(false), net_type_(type),
     discipline_(0),
     eref_count_(0), lref_count_(0)
 {

--- a/netlist.h
+++ b/netlist.h
@@ -679,12 +679,7 @@ class NetNet  : public NetObj, public PortType {
 		      const std::list<netrange_t>&unpacked,
 		      ivl_type_t type);
 
-	// This form builds a NetNet from its record/enum/darray
-	// definition. They should probably be replaced with a single
-	// version that takes an ivl_type_s* base.
-      explicit NetNet(NetScope*s, perm_string n, Type t, netstruct_t*type);
-      explicit NetNet(NetScope*s, perm_string n, Type t, netdarray_t*type);
-      explicit NetNet(NetScope*s, perm_string n, Type t, netvector_t*type);
+      explicit NetNet(NetScope*s, perm_string n, Type t, ivl_type_t type);
 
       virtual ~NetNet();
 

--- a/netlist.h
+++ b/netlist.h
@@ -4641,7 +4641,6 @@ class NetESFunc  : public NetExpr {
       NetESFunc(const char*name, ivl_variable_type_t t,
 		unsigned width, unsigned nprms, bool is_overridden =false);
       NetESFunc(const char*name, ivl_type_t rtype, unsigned nprms);
-      NetESFunc(const char*name, const netenum_t*enum_type, unsigned nprms);
       ~NetESFunc();
 
       const char* name() const;


### PR DESCRIPTION
The result for the built-in methods for the SystemVerilog types is
currently always unsigned. This can lead to incorrect behavior if the value
is sign extended or passed as an argument to a system function (e.g.
`$display`).

E.g. the following will print `4294967295` rather than `-1`.
```SystemVerilog
 int q[$];
 q.push_back(-1);
 $display(q.pop_front());
 ```
    
To correctly support this consistently assign the actual data type of the
built-in method's return value to the `NetESFunc`, rather than just the width
and base type. The width, base type and also the signedness can be derived
from the data type.

The signedness of an expression can also change depending on its context.
E.g. for an arithmetic operation with one unsigned operand all operands are
treated as unsigned.

In addition to methods this is currently also not considered for class properties
This can lead to incorrect behavior if the value is sign extended.

E.g. the following will print 4294967295 rather than 65535.

```SystemVerilog
class C;
  shortint x = -1;
endclass
...
C c = new;
$display(c.x + 32'h0);
```

Furthermore the return value is not expanded to the width of its context.
This can cause vvp to crash with an exception when it expects a vector on
the stack to have a certain width.

E.g.
```SystemVerilog
class C;
  shortint x = -1;
endclass
...
C c = new;
int x;
bit a = 1'b1;
x = a ? c.x : 64'h0;
```

Solve both of this by using `pad_to_width()` on a methods return value and
on class properties if it is a vectorable type. Since this needs to be done for
any expression not just method calls or class properties move this call to
`pad_to_width()` into a common path of the `elaborate_expr()` method of
both `PEIdent` and `PECallFunction`.