### PR TITLE
Remove unused function `pform_set_param_from_type()`

### DIFF
--- a/pform.cc
+++ b/pform.cc
@@ -3210,29 +3210,6 @@ void pform_set_defparam(const pform_name_t&name, PExpr*expr)
             pform_cur_module.front()->defparms.push_back(make_pair(name,expr));
 }
 
-void pform_set_param_from_type(const struct vlltype&loc,
-                               const data_type_t *data_type,
-                               const char *name,
-                               list<pform_range_t> *&param_range,
-                               bool &param_signed,
-                               ivl_variable_type_t &param_type)
-{
-      if (const vector_type_t *vec = dynamic_cast<const vector_type_t*> (data_type)) {
-	    param_range = vec->pdims.get();
-	    param_signed = vec->signed_flag;
-	    param_type = vec->base_type;
-	    return;
-      }
-
-      param_range = 0;
-      param_signed = false;
-      param_type = IVL_VT_NO_TYPE;
-      cerr << loc.get_fileline() << ": sorry: cannot currently create a "
-              "parameter of type '" << name << "' which was defined at: "
-           << data_type->get_fileline() <<  "." << endl;
-      error_count += 1;
-}
-
 void pform_make_let(const struct vlltype&loc,
                     perm_string name,
                     list<PLet::let_port*>*ports,

--- a/pform.h
+++ b/pform.h
@@ -416,13 +416,6 @@ extern void pform_set_specparam(const struct vlltype&loc,
 				 PExpr*expr);
 extern void pform_set_defparam(const pform_name_t&name, PExpr*expr);
 
-extern void pform_set_param_from_type(const struct vlltype&loc,
-                                      const data_type_t *data_type,
-                                      const char *name,
-                                      std::list<pform_range_t> *&param_range,
-                                      bool &param_signed,
-                                      ivl_variable_type_t &param_type);
-
 extern void pform_make_let(const struct vlltype&loc,
                            perm_string name,
                            std::list<PLet::let_port_t*>*ports,


### PR DESCRIPTION
The `pform_set_param_from_type()` function is not used. The last user was
removed in commit 16646c547cbf ("Rework parsing of parameter types").

Remove the function itself.