### PR TITLE
Small cleanups for `pform_makewire()`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5833,8 +5833,7 @@ dimensions
 net_variable
   : IDENTIFIER dimensions_opt
       { perm_string name = lex_strings.make($1);
-	pform_makewire(@1, name, NetNet::IMPLICIT,
-		       NetNet::NOT_A_PORT, IVL_VT_NO_TYPE, 0);
+	pform_makewire(@1, name, NetNet::IMPLICIT, IVL_VT_NO_TYPE);
 	pform_set_reg_idx(name, $2);
 	$$ = $1;
       }

--- a/parse.y
+++ b/parse.y
@@ -5833,8 +5833,7 @@ dimensions
 net_variable
   : IDENTIFIER dimensions_opt
       { perm_string name = lex_strings.make($1);
-	pform_makewire(@1, name, NetNet::IMPLICIT, IVL_VT_NO_TYPE);
-	pform_set_reg_idx(name, $2);
+	pform_makewire(@1, name, NetNet::IMPLICIT, IVL_VT_NO_TYPE, $2);
 	$$ = $1;
       }
   ;

--- a/pform.cc
+++ b/pform.cc
@@ -2742,7 +2742,7 @@ static PWire* pform_get_or_make_wire(const vlltype&li, perm_string name,
  * this one to create the wire and stash it.
  */
 void pform_makewire(const vlltype&li, perm_string name, NetNet::Type type,
-		    ivl_variable_type_t dt)
+		    ivl_variable_type_t dt, std::list<pform_range_t> *indices)
 {
       PWire*cur = pform_get_or_make_wire(li, name, type, NetNet::NOT_A_PORT,
 					 dt);
@@ -2765,6 +2765,9 @@ void pform_makewire(const vlltype&li, perm_string name, NetNet::Type type,
 	  default:
 	    break;
       }
+
+      if (indices && !indices->empty())
+	    cur->set_unpacked_idx(*indices);
 }
 
 void pform_makewire(const struct vlltype&li,
@@ -2785,8 +2788,7 @@ void pform_makewire(const struct vlltype&li,
       for (list<decl_assignment_t*>::iterator cur = assign_list->begin()
 		 ; cur != assign_list->end() ; ++ cur) {
 	    decl_assignment_t* curp = *cur;
-	    pform_makewire(li, curp->name, type, IVL_VT_NO_TYPE);
-	    pform_set_reg_idx(curp->name, &curp->index);
+	    pform_makewire(li, curp->name, type, IVL_VT_NO_TYPE, &curp->index);
 	    names->push_back(curp->name);
       }
 
@@ -3066,22 +3068,6 @@ void pform_set_type_attrib(perm_string name, const string&key,
       }
 
       (*udp).second ->attributes[key] = new PEString(value);
-}
-
-/*
- * This function attaches a memory index range to an existing
- * register. (The named wire must be a register.
- */
-void pform_set_reg_idx(perm_string name, list<pform_range_t>*indices)
-{
-      PWire*cur = lexical_scope->wires_find(name);
-      if (cur == 0) {
-	    VLerror("internal error: name is not a valid memory for index.");
-	    return;
-      }
-
-      if (indices && !indices->empty())
-	    cur->set_unpacked_idx(*indices);
 }
 
 LexicalScope::range_t* pform_parameter_value_range(bool exclude_flag,

--- a/pform.cc
+++ b/pform.cc
@@ -2741,12 +2741,11 @@ static PWire* pform_get_or_make_wire(const vlltype&li, perm_string name,
  * the variable/net. Other forms of pform_makewire ultimately call
  * this one to create the wire and stash it.
  */
-void pform_makewire(const vlltype&li, perm_string name,
-		    NetNet::Type type, NetNet::PortType pt,
-		    ivl_variable_type_t dt,
-		    list<named_pexpr_t>*attr)
+void pform_makewire(const vlltype&li, perm_string name, NetNet::Type type,
+		    ivl_variable_type_t dt)
 {
-      PWire*cur = pform_get_or_make_wire(li, name, type, pt, dt);
+      PWire*cur = pform_get_or_make_wire(li, name, type, NetNet::NOT_A_PORT,
+					 dt);
       assert(cur);
 
       bool flag;
@@ -2765,13 +2764,6 @@ void pform_makewire(const vlltype&li, perm_string name,
 	    break;
 	  default:
 	    break;
-      }
-
-      if (attr) {
-	    for (list<named_pexpr_t>::iterator attr_cur = attr->begin()
-		       ; attr_cur != attr->end() ;  ++attr_cur) {
-		  cur->attributes[attr_cur->name] = attr_cur->parm;
-	    }
       }
 }
 
@@ -2793,7 +2785,7 @@ void pform_makewire(const struct vlltype&li,
       for (list<decl_assignment_t*>::iterator cur = assign_list->begin()
 		 ; cur != assign_list->end() ; ++ cur) {
 	    decl_assignment_t* curp = *cur;
-	    pform_makewire(li, curp->name, type, NetNet::NOT_A_PORT, IVL_VT_NO_TYPE, 0);
+	    pform_makewire(li, curp->name, type, IVL_VT_NO_TYPE);
 	    pform_set_reg_idx(curp->name, &curp->index);
 	    names->push_back(curp->name);
       }

--- a/pform.h
+++ b/pform.h
@@ -349,7 +349,8 @@ extern PForeach* pform_make_foreach(const struct vlltype&loc,
  */
 extern void pform_makewire(const struct vlltype&li, perm_string name,
 			   NetNet::Type type,
-			   ivl_variable_type_t dt);
+			   ivl_variable_type_t dt,
+			   std::list<pform_range_t> *indices);
 
 /* This form handles assignment declarations. */
 
@@ -378,9 +379,6 @@ extern void pform_set_port_type(const struct vlltype&li,
 				NetNet::PortType,
 				data_type_t*dt,
 				std::list<named_pexpr_t>*attr);
-
-extern void pform_set_reg_idx(perm_string name,
-			      std::list<pform_range_t>*indices);
 
 extern void pform_set_data_type(const struct vlltype&li, data_type_t*, std::list<perm_string>*names, NetNet::Type net_type, std::list<named_pexpr_t>*attr);
 

--- a/pform.h
+++ b/pform.h
@@ -144,7 +144,6 @@ extern PWire* pform_get_wire_in_scope(perm_string name);
 extern PWire* pform_get_make_wire_in_scope(const struct vlltype&li,
                                            perm_string name,
                                            NetNet::Type net_type,
-                                           NetNet::PortType port_type,
                                            ivl_variable_type_t vt_type);
 
 /*
@@ -350,9 +349,7 @@ extern PForeach* pform_make_foreach(const struct vlltype&loc,
  */
 extern void pform_makewire(const struct vlltype&li, perm_string name,
 			   NetNet::Type type,
-			   NetNet::PortType pt,
-			   ivl_variable_type_t,
-			   std::list<named_pexpr_t>*attr);
+			   ivl_variable_type_t dt);
 
 /* This form handles assignment declarations. */
 

--- a/pform_disciplines.cc
+++ b/pform_disciplines.cc
@@ -195,7 +195,7 @@ void pform_attach_discipline(const struct vlltype&loc,
 	    PWire* cur_net = pform_get_wire_in_scope(*cur);
 	    if (cur_net == 0) {
 		    /* Not declared yet, declare it now. */
-		  pform_makewire(loc, *cur, NetNet::WIRE, IVL_VT_REAL);
+		  pform_makewire(loc, *cur, NetNet::WIRE, IVL_VT_REAL, 0);
 		  cur_net = pform_get_wire_in_scope(*cur);
 		  assert(cur_net);
 	    }

--- a/pform_disciplines.cc
+++ b/pform_disciplines.cc
@@ -195,8 +195,7 @@ void pform_attach_discipline(const struct vlltype&loc,
 	    PWire* cur_net = pform_get_wire_in_scope(*cur);
 	    if (cur_net == 0) {
 		    /* Not declared yet, declare it now. */
-		  pform_makewire(loc, *cur, NetNet::WIRE,
-				 NetNet::NOT_A_PORT, IVL_VT_REAL, 0);
+		  pform_makewire(loc, *cur, NetNet::WIRE, IVL_VT_REAL);
 		  cur_net = pform_get_wire_in_scope(*cur);
 		  assert(cur_net);
 	    }


### PR DESCRIPTION
A small set of cleanups for the `pform_makewire()` function

- Remove unused parameters
- `pform_set_reg_idx()` is always called in combination with `pform_makewire()`. Move it into it.