### PR TITLE
Avoid signal look-up by name in the parser

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -603,9 +603,12 @@ static void current_function_set_statement(const YYLTYPE&loc, std::vector<Statem
 %type <statement> udp_initial udp_init_opt
 %type <expr>    udp_initial_expr_opt
 
-%type <text> net_variable event_variable label_opt class_declaration_endlabel_opt
+%type <wire> net_variable
+%type <wires> net_variable_list
+
+%type <text> event_variable label_opt class_declaration_endlabel_opt
 %type <text> block_identifier_opt
-%type <perm_strings> net_variable_list event_variable_list
+%type <perm_strings> event_variable_list
 %type <perm_strings> list_of_identifiers loop_variables
 %type <port_list> list_of_port_identifiers list_of_variable_port_identifiers
 
@@ -5833,23 +5836,20 @@ dimensions
 net_variable
   : IDENTIFIER dimensions_opt
       { perm_string name = lex_strings.make($1);
-	pform_makewire(@1, name, NetNet::IMPLICIT, IVL_VT_NO_TYPE, $2);
-	$$ = $1;
+	$$ = pform_makewire(@1, name, NetNet::IMPLICIT, IVL_VT_NO_TYPE, $2);
+	delete [] $1;
       }
   ;
 
 net_variable_list
 	: net_variable
-		{ std::list<perm_string>*tmp = new std::list<perm_string>;
-		  tmp->push_back(lex_strings.make($1));
+		{ std::vector<PWire*> *tmp = new std::vector<PWire*>;
+		  tmp->push_back($1);
 		  $$ = tmp;
-		  delete[]$1;
 		}
 	| net_variable_list ',' net_variable
-		{ std::list<perm_string>*tmp = $1;
-		  tmp->push_back(lex_strings.make($3));
-		  $$ = tmp;
-		  delete[]$3;
+		{ $1->push_back($3);
+		  $$ = $1;
 		}
 	;
 

--- a/pform.cc
+++ b/pform.cc
@@ -2536,13 +2536,6 @@ void pform_make_var_init(const struct vlltype&li,
 	    return;
       }
 
-      PWire*cur = pform_get_wire_in_scope(name);
-      if (cur == 0) {
-	    VLerror(li, "internal error: var_init to non-register?");
-	    delete expr;
-	    return;
-      }
-
       PEIdent*lval = new PEIdent(name);
       FILE_NAME(lval, li);
       PAssign*ass = new PAssign(lval, expr, !gn_system_verilog());

--- a/pform.h
+++ b/pform.h
@@ -347,10 +347,10 @@ extern PForeach* pform_make_foreach(const struct vlltype&loc,
  * The makewire functions announce to the pform code new wires. These
  * go into a module that is currently opened.
  */
-extern void pform_makewire(const struct vlltype&li, perm_string name,
-			   NetNet::Type type,
-			   ivl_variable_type_t dt,
-			   std::list<pform_range_t> *indices);
+extern PWire *pform_makewire(const struct vlltype&li, perm_string name,
+			     NetNet::Type type,
+			     ivl_variable_type_t dt,
+			     std::list<pform_range_t> *indices);
 
 /* This form handles assignment declarations. */
 
@@ -380,7 +380,11 @@ extern void pform_set_port_type(const struct vlltype&li,
 				data_type_t*dt,
 				std::list<named_pexpr_t>*attr);
 
-extern void pform_set_data_type(const struct vlltype&li, data_type_t*, std::list<perm_string>*names, NetNet::Type net_type, std::list<named_pexpr_t>*attr);
+extern void pform_set_data_type(const struct vlltype&li,
+				data_type_t *data_type,
+				std::vector<PWire*> *wires,
+				NetNet::Type net_type,
+				std::list<named_pexpr_t>*attr);
 
 extern void pform_set_string_type(const struct vlltype&li, const string_type_t*string_type, std::list<perm_string>*names, NetNet::Type net_type, std::list<named_pexpr_t>*attr);
 

--- a/pform_disciplines.cc
+++ b/pform_disciplines.cc
@@ -195,8 +195,7 @@ void pform_attach_discipline(const struct vlltype&loc,
 	    PWire* cur_net = pform_get_wire_in_scope(*cur);
 	    if (cur_net == 0) {
 		    /* Not declared yet, declare it now. */
-		  pform_makewire(loc, *cur, NetNet::WIRE, IVL_VT_REAL, 0);
-		  cur_net = pform_get_wire_in_scope(*cur);
+		  cur_net = pform_makewire(loc, *cur, NetNet::WIRE, IVL_VT_REAL, 0);
 		  assert(cur_net);
 	    }
 


### PR DESCRIPTION
There are a few places in the parser where a signal is created and then
immediately afterwards the signal is looked up by name to make some changes to
the signal.

Refactor the code so that the pointer to the signal is retained and the look-up
by name is no longer necessary.