### PR TITLE
Allow shortreal module ports

### DIFF
--- a/ivtest/ivltests/module_port_shortreal.v
+++ b/ivtest/ivltests/module_port_shortreal.v
@@ -1,0 +1,30 @@
+// Check that shortreal module ports are supported
+
+module M (
+  input shortreal in,
+  output shortreal out
+);
+
+  assign out = in * 10.1;
+
+endmodule
+
+module test;
+
+  shortreal r;
+
+  M m (
+    .in (1.23),
+    .out (r)
+  );
+
+  initial begin
+    #1
+    if (r == 12.423) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-ivl1.list
+++ b/ivtest/regress-ivl1.list
@@ -225,6 +225,7 @@ ca_var_delay		normal			ivltests
 cast_real_signed	normal			ivltests
 cast_real_unsigned	normal			ivltests
 delayed_sfunc		normal,-gspecify	ivltests gold=delayed_sfunc.gold
+module_port_shortreal	normal,-g2005-sv	ivltests # shortreal
 pr1861212c		normal			ivltests gold=pr1861212.gold
 pr1864110a		normal			ivltests gold=pr1864110a.gold
 pr1864110b		normal			ivltests gold=pr1864110b.gold

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -134,6 +134,7 @@ implicit_cast5		CE,-g2009,-pallowsigned=1	ivltests
 implicit_cast6		CE,-g2009,-pallowsigned=1	ivltests
 implicit_cast12		CE,-g2009,-pallowsigned=1	ivltests
 implicit_cast13		CE,-g2009,-pallowsigned=1	ivltests
+module_port_shortreal	CE,-g2005-sv		ivltests
 pr1861212c		CE			ivltests
 pr1864110a		CE			ivltests
 pr1864110b		CE			ivltests

--- a/pform.cc
+++ b/pform.cc
@@ -2574,16 +2574,10 @@ void pform_module_define_port(const struct vlltype&li,
 	    signed_flag = vec_type->signed_flag;
 	    prange = vec_type->pdims.get();
 	    vtype = 0;
-      } else if (real_type_t*rtype = dynamic_cast<real_type_t*>(vtype)) {
+      } else if (dynamic_cast<real_type_t*>(vtype)) {
 	    data_type = IVL_VT_REAL;
 	    signed_flag = true;
 	    prange = 0;
-
-	    if (rtype->type_code() != real_type_t::REAL) {
-		  VLerror(li, "sorry: Only real (not shortreal) supported here (%s:%d).",
-			  __FILE__, __LINE__);
-	    }
-
       } else if (vtype) {
 	    if (vtype->figure_packed_base_type() != IVL_VT_NO_TYPE) {
 		  data_type = vtype->figure_packed_base_type();


### PR DESCRIPTION
Currently there is a restriction in the parser that rejects `shortreal`
typed module ports. And while at the moment `shortreal` signals are
implemented as `real` typed signals, which is not standard compliant, there
is nothing special about module ports in this regard.

Note that support for `shortreal` (and `real`) nets is an Icarus extension, but ports can
also be variables, in which case a shortreal port is allowed by the LRM.

`shortreal` variables and nets are allowed everywhere else. There is no
good reason to not allow them for module ports, so remove the restriction.