### PR TITLE
Fix issue 699: segfault when rvalue to elaboration fails.

### DIFF
--- a/design_dump.cc
+++ b/design_dump.cc
@@ -1124,7 +1124,10 @@ void NetAssign::dump(ostream&o, unsigned ind) const
       if (const NetExpr*de = get_delay())
 	    o << "#(" << *de << ") ";
 
-      o << *rval() << ";" << endl;
+      if (rval())
+	    o << *rval() << ";" << endl;
+      else
+	    o << "<rval elaboration error>;" << endl;
 }
 
 void NetAssignNB::dump(ostream&o, unsigned ind) const
@@ -1142,7 +1145,10 @@ void NetAssignNB::dump(ostream&o, unsigned ind) const
 	    o << *event_;
       }
 
-      o << *rval() << ";" << endl;
+      if (rval())
+	    o << *rval() << ";" << endl;
+      else
+	    o << "rval elaboration error>;" << endl;
 
 }
 

--- a/ivtest/ivltests/br_gh699.v
+++ b/ivtest/ivltests/br_gh699.v
@@ -1,0 +1,9 @@
+
+// This should generate an error reporting the undef_func, but not segfault.
+module test1;
+   function [31:0] func1 (input [31:0] x);
+      return undef_func(x);
+   endfunction : func1
+
+   localparam X = func1(1);
+endmodule : test1

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -210,6 +210,7 @@ br_gh568		normal,-g2009		ivltests
 br_gh661a		normal,-g2009		ivltests
 br_gh661b		normal,-g2009		ivltests
 br_gh672		normal,-g2009		ivltests
+br_gh699		CE,-g2009		ivltests
 br_ml20171017		normal,-g2009		ivltests
 br_ml20180227		CE,-g2009		ivltests
 br_ml20180309a		normal,-g2009		ivltests

--- a/net_func_eval.cc
+++ b/net_func_eval.cc
@@ -441,8 +441,11 @@ bool NetAssign::eval_func_lval_(const LineInfo&loc,
 bool NetAssign::evaluate_function(const LineInfo&loc,
 				  map<perm_string,LocalVar>&context_map) const
 {
-	// Evaluate the r-value expression.
-      NetExpr*rval_result = rval()->evaluate_function(loc, context_map);
+      // Evaluate the r-value expression.
+      const NetExpr*use_rval = rval();
+      if (use_rval == 0)
+	    return false;
+      NetExpr*rval_result = use_rval->evaluate_function(loc, context_map);
       if (rval_result == 0)
 	    return false;
 


### PR DESCRIPTION
When the r-value to an assignment fails to elaborate, and that r-value is a function, the NetAssign::evaluate_function segfaults. Fix the segfault by properly returning an error flag. It is not necessary to count an error, since the elaboration failure in the first place counted the error.

Also add the test from Issue#699.

This fixes #699 .
