### PR TITLE
lgate: Inherit from LineInfo

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -4102,8 +4102,7 @@ gate_instance
       { lgate*tmp = new lgate;
 	tmp->name = $1;
 	tmp->parms = $3;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	delete[]$1;
 	$$ = tmp;
       }
@@ -4113,8 +4112,7 @@ gate_instance
 	tmp->name = $1;
 	tmp->parms = $4;
 	tmp->ranges = $2;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	delete[]$1;
 	$$ = tmp;
       }
@@ -4123,8 +4121,7 @@ gate_instance
       { lgate*tmp = new lgate;
 	tmp->name = "";
 	tmp->parms = $2;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	$$ = tmp;
       }
 
@@ -4136,8 +4133,7 @@ gate_instance
 	tmp->parms = 0;
 	tmp->parms_by_name = 0;
 	tmp->ranges = $2;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	delete[]$1;
 	$$ = tmp;
       }
@@ -4149,8 +4145,7 @@ gate_instance
 	tmp->name = $1;
 	tmp->parms = 0;
 	tmp->parms_by_name = $3;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	delete[]$1;
 	$$ = tmp;
       }
@@ -4161,8 +4156,7 @@ gate_instance
 	tmp->parms = 0;
 	tmp->parms_by_name = $4;
 	tmp->ranges = $2;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	delete[]$1;
 	$$ = tmp;
       }
@@ -4172,8 +4166,7 @@ gate_instance
 	tmp->name = $1;
 	tmp->parms = 0;
 	tmp->parms_by_name = 0;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	yyerror(@2, "error: Syntax error in instance port "
 	        "expression(s).");
 	delete[]$1;
@@ -4186,8 +4179,7 @@ gate_instance
 	tmp->parms = 0;
 	tmp->parms_by_name = 0;
 	tmp->ranges = $2;
-	tmp->file  = @1.text;
-	tmp->lineno = @1.first_line;
+	FILE_NAME(tmp, @1);
 	yyerror(@3, "error: Syntax error in instance port "
 	        "expression(s).");
 	delete[]$1;

--- a/pform.cc
+++ b/pform.cc
@@ -389,12 +389,6 @@ bool allow_timeprec_decl = true;
 // Track whether the current parameter declaration is in a parameter port list
 static bool pform_in_parameter_port_list = false;
 
-static inline void FILE_NAME(LineInfo*obj, const char*file, unsigned lineno)
-{
-      obj->set_lineno(lineno);
-      obj->set_file(filename_strings.make(file));
-}
-
 /*
  * The lexical_scope keeps track of the current lexical scope that is
  * being parsed. The lexical scope may stack, so the current scope may
@@ -2205,8 +2199,8 @@ static void pform_makegate(PGBuiltin::Type type,
 			   list<named_pexpr_t>*attr)
 {
       if (info.parms_by_name) {
-	    cerr << info.file << ":" << info.lineno << ": Gates do not "
-		  "have port names." << endl;
+	    cerr << info.get_fileline() << ": Gates do not have port names."
+		 << endl;
 	    error_count += 1;
 	    return;
       }
@@ -2229,7 +2223,7 @@ static void pform_makegate(PGBuiltin::Type type,
 
       cur->strength0(str.str0);
       cur->strength1(str.str1);
-      FILE_NAME(cur, info.file, info.lineno);
+      cur->set_line(info);
 
       if (pform_cur_generate) {
 	    if (dev_name != "") add_local_symbol(pform_cur_generate, dev_name, cur);
@@ -2286,7 +2280,7 @@ static void pform_make_modgate(perm_string type,
 			       struct parmvalue_t*overrides,
 			       list<PExpr*>*wires,
 			       list<pform_range_t>*ranges,
-			       const char*fn, unsigned ln,
+			       const LineInfo&li,
 			       std::list<named_pexpr_t>*attr)
 {
       for (list<PExpr*>::iterator idx = wires->begin()
@@ -2295,7 +2289,7 @@ static void pform_make_modgate(perm_string type,
       }
 
       PGModule*cur = new PGModule(type, name, wires);
-      FILE_NAME(cur, fn, ln);
+      cur->set_line(li);
       cur->set_ranges(ranges);
 
       if (overrides && overrides->by_name) {
@@ -2329,7 +2323,7 @@ static void pform_make_modgate(perm_string type,
 			       struct parmvalue_t*overrides,
 			       list<named_pexpr_t>*bind,
 			       list<pform_range_t>*ranges,
-			       const char*fn, unsigned ln,
+			       const LineInfo&li,
 			       std::list<named_pexpr_t>*attr)
 {
       unsigned npins = bind->size();
@@ -2342,7 +2336,7 @@ static void pform_make_modgate(perm_string type,
       }
 
       PGModule*cur = new PGModule(type, name, pins, npins);
-      FILE_NAME(cur, fn, ln);
+      cur->set_line(li);
       cur->set_ranges(ranges);
 
       if (overrides && overrides->by_name) {
@@ -2412,7 +2406,7 @@ void pform_make_modgates(const struct vlltype&loc,
 	    if (cur.parms_by_name) {
 		  pform_make_modgate(type, cur_name, overrides,
 				     cur.parms_by_name, cur.ranges,
-				     cur.file, cur.lineno, attr);
+				     cur, attr);
 
 	    } else if (cur.parms) {
 
@@ -2425,13 +2419,13 @@ void pform_make_modgates(const struct vlltype&loc,
 		  }
 		  pform_make_modgate(type, cur_name, overrides,
 				     cur.parms, cur.ranges,
-				     cur.file, cur.lineno, attr);
+				     cur, attr);
 
 	    } else {
 		  list<PExpr*>*wires = new list<PExpr*>;
 		  pform_make_modgate(type, cur_name, overrides,
 				     wires, cur.ranges,
-				     cur.file, cur.lineno, attr);
+				     cur, attr);
 	    }
       }
 

--- a/pform.h
+++ b/pform.h
@@ -62,6 +62,7 @@ class PSpecPath;
 class PClass;
 class PPackage;
 struct vlltype;
+struct lgate;
 
 /*
  * The min:typ:max expression s selected at parse time using the
@@ -95,22 +96,6 @@ struct parmvalue_t {
 
 struct str_pair_t { ivl_drive_t str0, str1; };
 
-
-/* The lgate is gate instantiation information. */
-struct lgate {
-      explicit inline lgate(int =0)
-      : parms(0), parms_by_name(0), ranges(0), file(NULL), lineno(0)
-      { }
-
-      std::string name;
-      std::list<PExpr*>*parms;
-      std::list<named_pexpr_t>*parms_by_name;
-
-      std::list<pform_range_t>*ranges;
-
-      const char* file;
-      unsigned lineno;
-};
 
 extern std::list<pform_range_t>* make_range_from_width(uint64_t wid);
 extern std::list<pform_range_t>* copy_range(std::list<pform_range_t>* orig);

--- a/pform_types.h
+++ b/pform_types.h
@@ -75,6 +75,19 @@ typedef named<PExpr*> named_pexpr_t;
  */
 typedef std::pair<PExpr*,PExpr*> pform_range_t;
 
+/* The lgate is gate instantiation information. */
+struct lgate : public LineInfo {
+      explicit lgate(int = 0)
+      : parms(0), parms_by_name(0), ranges(0)
+      { }
+
+      std::string name;
+      std::list<PExpr*>*parms;
+      std::list<named_pexpr_t>*parms_by_name;
+
+      std::list<pform_range_t>*ranges;
+};
+
 /*
  * The pform_port_t holds the name and optional unpacked dimensions
  * and initialization expression for a single port in a list of port


### PR DESCRIPTION
The lgate struct has its own fields for tracking file and line number,
while everything else that has this information attached inherits from the
LineInfo class.

Make lgate also inherit from LineInfo for consistency.