### PR TITLE
 Handle class new assignment to non-class variables

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -6594,13 +6594,20 @@ NetExpr* PENewClass::elaborate_expr_constructor_(Design*des, NetScope*scope,
 NetExpr* PENewClass::elaborate_expr(Design*des, NetScope*scope,
 				    ivl_type_t ntype, unsigned flags) const
 {
-      NetExpr*obj = new NetENew(ntype);
-      obj->set_line(*this);
-
 	// Find the constructor for the class. If there is no
 	// constructor then the result of this expression is the
 	// allocation alone.
       const netclass_t*ctype = dynamic_cast<const netclass_t*> (ntype);
+
+      if (!ctype) {
+	    cerr << get_fileline() << ": error: class new not allowed here. "
+		 << "Left-hand side is not of class type." << endl;
+	    des->errors++;
+	    return 0;
+      }
+
+      NetExpr*obj = new NetENew(ntype);
+      obj->set_line(*this);
 
       obj = elaborate_expr_constructor_(des, scope, ctype, obj, flags);
       return obj;

--- a/ivtest/ivltests/sv_class_new_fail1.v
+++ b/ivtest/ivltests/sv_class_new_fail1.v
@@ -1,0 +1,13 @@
+// Check that using the class new operator on a non-class variable results in an
+// error.
+
+module test;
+
+  int i;
+
+  initial begin
+    i = new;
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_new_fail2.v
+++ b/ivtest/ivltests/sv_class_new_fail2.v
@@ -1,0 +1,13 @@
+// Check that using the class new operator on a dynamic array variable results
+// in an error.
+
+module test;
+
+  int i[];
+
+  initial begin
+    i = new;
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -499,6 +499,8 @@ sv_class_constructor_fail   CE,-g2009		ivltests
 sv_class_empty_item	normal,-g2009		ivltests
 sv_class_extends_scoped	normal,-g2009		ivltests
 sv_class_localparam	normal,-g2009		ivltests
+sv_class_new_fail1	CE,-g2009		ivltests
+sv_class_new_fail2	CE,-g2009		ivltests
 sv_class_new_init	normal,-g2009		ivltests
 sv_class_in_module_decl	normal,-g2009		ivltests
 sv_class_method_signed1	normal,-g2009		ivltests


### PR DESCRIPTION
Using a class new operator on a non-class variable should result in an
error. At the moment when using a class new operator on a dynamic array or
queue will result in an segmentation fault. This is because the
implementation assumes that the left hand side is of a class type.

Add a check in the class new operator implementation that the type of the
left hand side is a class. Report an error if it is not.