### PR TITLE
tgt-vvp: Allow multi-dimensional real arrays

### DIFF
--- a/ivtest/ivltests/real_array_multi_dim.v
+++ b/ivtest/ivltests/real_array_multi_dim.v
@@ -1,0 +1,35 @@
+// Check that multi-dimensional real arrays are supported
+
+module test;
+
+  reg failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr != val) begin \
+      $display("FAILED: `%s`, expected %f, got %f", `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+  real r[3:0][1:0];
+  integer i;
+
+  initial begin
+    for (i = 0; i < 8; i = i + 1) begin
+      r[i/2][i%2] = i / 8.0 - 0.5;
+    end
+
+    `check(r[0][0], -0.5);
+    `check(r[0][1], -0.375);
+    `check(r[1][0], -0.25);
+    `check(r[1][1], -0.125);
+    `check(r[2][0], 0.0);
+    `check(r[2][1], 0.125);
+    `check(r[3][0], 0.25);
+    `check(r[3][1], 0.375);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -1461,6 +1461,7 @@ real7			normal			ivltests
 real9			normal			ivltests
 real10			normal			ivltests
 real11			normal			ivltests
+real_array_multi_dim	normal			ivltests
 real_assign_deassign	normal			ivltests
 real_concat_invalid2	CE			ivltests
 real_delay		normal,-gspecify	ivltests gold=real_delay.gold

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -247,6 +247,7 @@ pr3054101h		CE			ivltests
 pr3592746		CE			ivltests
 real_array		CE			ivltests
 real_array_nb		CE,-pallowsigned=1	ivltests
+real_array_multi_dim	CE,-pallowsigned=1	ivltests
 scan-invalid		CE			ivltests
 sel_rval_bit_ob		CE			ivltests
 sel_rval_part_ob	CE			ivltests

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -756,9 +756,6 @@ static void store_real_to_lval(ivl_lval_t lval)
 	    return;
       }
 
-	// For now, only support 1-dimensional arrays.
-      assert(ivl_signal_dimensions(var) == 1);
-
       ivl_expr_t word_ex = ivl_lval_idx(lval);
       int word_ix = allocate_word();
 


### PR DESCRIPTION
There is currently a restriction in the vvp code generator backend that
throws an assertion when generating write access for a multi-dimensional
real array.

But there is nothing special about multi-dimensional arrays. In vvp arrays
are in canonical form. Meaning they only have a single dimension and the
conversion form multi to single dimension is done in the higher layers.

Remove the assert to allow multi-dimensional real arrays.