### PR TITLE
Add parameters to vcd dumps

### DIFF
--- a/ivtest/gold/array_dump.vcd.gold
+++ b/ivtest/gold/array_dump.vcd.gold
@@ -1,5 +1,5 @@
 $date
-	Tue Apr 21 18:40:22 2009
+	Sun May 15 18:09:10 2022
 $end
 $version
 	Icarus Verilog
@@ -17,6 +17,9 @@ $scope module top $end
 $var reg 8 # \array[2] [7:0] $end
 $upscope $end
 $enddefinitions $end
+$comment Show the parameter values. $end
+$dumpall
+$end
 #0
 $dumpvars
 bx #

--- a/ivtest/gold/br_gh156.vcd.gold
+++ b/ivtest/gold/br_gh156.vcd.gold
@@ -1,5 +1,5 @@
 $date
-	Sun May 15 18:09:25 2022
+	Sun May 15 09:20:23 2022
 $end
 $version
 	Icarus Verilog
@@ -7,16 +7,19 @@ $end
 $timescale
 	1s
 $end
-$scope module top $end
-$var reg 8 ! \arr[4] [7:0] $end
+$scope module main $end
+$var wire 4 ! bat [3:0] $end
+$var parameter 4 " bar $end
+$var parameter 4 # foo $end
 $upscope $end
 $enddefinitions $end
 $comment Show the parameter values. $end
 $dumpall
+b101 #
+b111 "
 $end
 #0
 $dumpvars
-b0 !
+b1100 !
 $end
 #1
-b11111111 !

--- a/ivtest/gold/pr2859628.vcd.gold
+++ b/ivtest/gold/pr2859628.vcd.gold
@@ -1,5 +1,5 @@
 $date
-	Tue Sep 15 16:56:35 2009
+	Sun May 15 18:19:07 2022
 $end
 $version
 	Icarus Verilog
@@ -16,6 +16,9 @@ $scope module top $end
 $var reg 4 " \array[1] [3:0] $end
 $upscope $end
 $enddefinitions $end
+$comment Show the parameter values. $end
+$dumpall
+$end
 #0
 $dumpvars
 bx "

--- a/ivtest/gold/vcd-dup.vcd.gold
+++ b/ivtest/gold/vcd-dup.vcd.gold
@@ -1,5 +1,5 @@
 $date
-	Fri Oct 16 08:46:35 2009
+	Sun May 15 15:15:18 2022
 $end
 $version
 	Icarus Verilog
@@ -53,6 +53,9 @@ $upscope $end
 $upscope $end
 $upscope $end
 $enddefinitions $end
+$comment Show the parameter values. $end
+$dumpall
+$end
 #0
 $dumpvars
 x/

--- a/ivtest/ivltests/br_gh156.v
+++ b/ivtest/ivltests/br_gh156.v
@@ -1,0 +1,17 @@
+
+//
+// This tests that the parameter and localparam show up in the vcd dump.
+//
+module main;
+   parameter [3:0] foo = 4'd5;
+   localparam [3:0] bar = 7;
+   wire [3:0] bat = foo + bar;
+
+   initial begin
+      $dumpfile("work/br_gh156.vcd");
+      $dumpvars(0, main);
+      #1 $finish;
+      
+   end
+   
+endmodule // main

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -309,6 +309,7 @@ br_gh127e		normal			ivltests gold=br_gh127e.gold
 br_gh127f		normal			ivltests gold=br_gh127f.gold
 br_gh142		CE			ivltests
 br_gh152		CE			ivltests
+br_gh156		normal			ivltests diff=work/br_gh156.vcd:gold/br_gh156.vcd.gold:2
 br_gh157		CE			ivltests gold=br_gh157.gold
 br_gh162		normal			ivltests
 br_gh163		CE			ivltests

--- a/vpi/vcd_priv.h
+++ b/vpi/vcd_priv.h
@@ -129,6 +129,35 @@ EXTERN void vcd_work_emit_bits(struct lxt2_wr_symbol*sym, const char*bits);
 /* The compiletf routines are common for the VCD, LXT and LXT2 dumpers. */
 EXTERN PLI_INT32 sys_dumpvars_compiletf(ICARUS_VPI_CONST PLI_BYTE8 *name);
 
+/*
+ * The vcd_list is the list of all the objects that are tracked for
+ * dumping. The vcd_checkpoint goes through the list to dump the current
+ * values for everything. When the item has a value change, it is added to the
+ * vcd_dmp_list for dumping in the current time step.
+ *
+ * The vcd_const_list is a list of all of the parameters that are being
+ * dumped. This list is scanned less often, since parameters do not change
+ * values.
+ */
+#define DECLARE_VCD_INFO(type_name, ident_type) \
+      struct type_name { \
+	    vpiHandle item; \
+	    vpiHandle cb;\
+	    struct t_vpi_time time; \
+	    struct vcd_info *next; \
+	    struct vcd_info *dmp_next; \
+	    int scheduled; \
+	    ident_type ident; \
+      }
+
+#define ITERATE_VCD_INFO(use_list, use_type, use_next, method)	\
+      do {							\
+	    struct use_type*cur;				\
+	    for (cur = use_list ; cur ; cur = cur->use_next)	\
+		  method(cur);					\
+      } while (0)
+
+
 #undef EXTERN
 
 #endif /* IVL_vcd_priv_H */

--- a/vvp/README.txt
+++ b/vvp/README.txt
@@ -133,10 +133,9 @@ objects.
 
 The syntax of a parameter is:
 
-	<label> .param/str <name>, <value>;
-	<label> .param/b <name>, <value> [<msb>,<lsb>];
-	<label> .param/l <name>, <value> [<msb>,<lsb>];
-	<label> .param/r <name>, <value>;
+	<label> .param/str <name> <local-flag> <file-idx> <lineno>, <value>;
+	<label> .param/l <name> <local-flag> <file-idx> <lineno>, <value>;
+	<label> .param/r <name> <local-flag> <file-idx> <lineno>, <value>;
 
 The <name> is a string that names the parameter. The name is placed in
 the current scope as a vpiParameter object. The .param suffix
@@ -144,7 +143,6 @@ specifies the parameter type.
 
 	.param/str    -- The parameter has a string value
 	.param/l      -- The parameter has a logic vector value
-	.param/b      -- The parameter has a boolean vector value
 	.param/r      -- The parameter has a real value
 
 The value, then, is appropriate for the data type. For example:


### PR DESCRIPTION
Writing parameters into VCD files makes the values available to waveform
tools. This can be done easily enough by writing out a $dumpadd section
at the beginning of the file that sets the parameter values. We don't need
to track the values over change, because by definition they do not change.

This changes the typical vcd output as well, so a few of the regression tests
need to be adjusted to account for this.

Also, while tracking this down, found and fixed the vvp/README.txt documention
for the .param/x records.

This fixes #156

TODO: Fix the fst dumper as well.