### PR TITLE
 tgt-vvp: Handle signedness when passing struct member to system function

### DIFF
--- a/ivtest/ivltests/struct_packed_sysfunct2.v
+++ b/ivtest/ivltests/struct_packed_sysfunct2.v
@@ -1,0 +1,46 @@
+// Check that the signedness of a struct member is handled correctly when passed
+// to a system function
+
+module test;
+
+  bit failed = 1'b0;
+
+  struct packed {
+    int s;
+    int unsigned u;
+  } x;
+
+  int s;
+  int unsigned u;
+
+  logic [16*8-1:0] s1;
+  logic [16*8-1:0] s2;
+
+  initial begin
+    u = -10;
+    s = -20;
+    x.u = u;
+    x.s = s;
+
+    $swrite(s1, s);
+    $swrite(s2, x.s);
+
+    if (s1 != s2) begin
+      failed = 1'b1;
+      $display("FAILED. Expected %s, got %s.", s1, s2);
+    end
+
+    $swrite(s1, u);
+    $swrite(s2, x.u);
+
+    if (s1 != s2) begin
+      failed = 1'b1;
+      $display("FAILED. Expected %s, got %s.", s1, s2);
+    end
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -456,6 +456,7 @@ struct_member_signed	normal,-g2009		ivltests
 struct_packed_array	normal,-g2009		ivltests
 struct_packed_array2	normal,-g2009		ivltests
 struct_packed_sysfunct	normal,-g2009		ivltests
+struct_packed_sysfunct2	normal,-g2009		ivltests
 struct_packed_write_read2	normal,-g2009	ivltests
 struct_invalid_member	CE,-g2009		ivltests gold=struct_invalid_member.gold
 struct_signed		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -927,6 +927,7 @@ size_cast5		normal,-g2009,-pallowsigned=1	ivltests
 struct_member_signed	normal,-g2009,-pallowsigned=1	ivltests
 struct_packed_array	normal,-g2009,-pallowsigned=1	ivltests
 struct_packed_array2	normal,-g2009,-pallowsigned=1	ivltests
+struct_packed_sysfunct2 normal,-g2009,-pallowsigned=1	ivltests
 struct_signed		normal,-g2009,-pallowsigned=1	ivltests
 sv_for_variable  normal,-g2009,-pallowsigned=1	ivltests
 sv_foreach1		normal,-g2009,-pallowsigned=1	ivltests

--- a/tgt-vvp/draw_vpi.c
+++ b/tgt-vvp/draw_vpi.c
@@ -199,6 +199,11 @@ static int get_vpi_taskfunc_signal_arg(struct args_info *result,
 	    if (ivl_expr_value(vexpr) == IVL_VT_DARRAY)
 		  return 0;
 
+	      /* Part select is always unsigned. If the expression is signed
+	       * fallback. */
+	    if (ivl_expr_signed(expr))
+		  return 0;
+
 	      /* The signal is part of an array. */
 	      /* Add &APV<> code here when it is finished. */
 	    bexpr = ivl_expr_oper2(expr);


### PR DESCRIPTION
Access to members in packed struct fields is internally implemented using a
part select.

vvp has a special syntax for passing a part select of a vector to a system
function. This special syntax assumes that the part select is unsigned like
it is for normal Verilog part selects.

As a result passing a signed struct member to a system function will
interpret it as unsigned.

E.g.
```SystemVerilog
struct packed {
   shortint x;
} s;
s.x = -1;
$display(s.x); // Will print 65535, should print -1
```

Add a check to make sure that the expression is actually unsigned. If it is
not fall back to evaluating the expression on the vector stack and pass the
value on the stack to the system function.

