### PR TITLE
 tgt-vvp: Handle assignment operator on real array entries

### DIFF
--- a/ivtest/ivltests/assign_op_after_cmp3.v
+++ b/ivtest/ivltests/assign_op_after_cmp3.v
@@ -1,0 +1,24 @@
+// Check that a assignment operator on an real array entry with an immediate
+// index works if it happes after a comparison that sets vvp flag 4 to 0.
+
+module test;
+
+  real r[1:0];
+  logic a = 1'b0;
+
+  initial begin
+    r[0] = 8.0;
+    if (a == 0) begin
+      // Make sure that this update happens, even though the compare above
+      // cleared set vvp flag 4
+      r[0] *= 2.0;
+    end
+
+    if (r[0] == 16.0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED. Expected %f, got %f", 16.0, r[0]);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/assign_op_real_array.v
+++ b/ivtest/ivltests/assign_op_real_array.v
@@ -1,0 +1,34 @@
+// Check that assignment operators on real arrays are supported.
+
+module test;
+
+  real r[1:0];
+  integer i = 1;
+
+  initial begin
+    // Immediate index
+    r[0] = 8.0;
+    r[0] += 1.0;
+    r[0] -= 2.0;
+    r[0] *= 3.0;
+    r[0] /= 7.0;
+    r[0]++;
+    r[0]--;
+
+    // Variable index
+    r[i] = 8.0;
+    r[i] += 1.0;
+    r[i] -= 2.0;
+    r[i] *= 3.0;
+    r[i] /= 7.0;
+    r[i]++;
+    r[i]--;
+
+    if (r[0] == 3.0 && r[1] == 3.0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED. Expected %f, got %f and %f", 3.0, r[0], r[1]);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/assign_op_real_array_oob.v
+++ b/ivtest/ivltests/assign_op_real_array_oob.v
@@ -1,0 +1,43 @@
+// Check that the assignment operator is supported for out-of-bounds indices on
+// real arrays. The write should be skipped, but side effects of the right-hand
+// side expression should still get evaluated.
+
+module test;
+
+  real a[1:0];
+  integer i;
+  real r = 0;
+
+  function real f;
+    r += 0.125;
+    return r;
+  endfunction
+
+  initial begin
+    a[0] = 23.0;
+    a[1] = 42.0;
+
+    // Immediate out-of-bounds indices
+    a[-1] += f();
+    a[2] += f();
+    a['hx] += f();
+
+    // Variable out-of-bounds indices
+    i = -1;
+    a[i] += f();
+    i = 2;
+    a[i] += f();
+    i = 'hx;
+    a[i] += f();
+
+    // Check that the in-bounds elements do not get affected by out-of-bounds
+    // updates. Check that the left-hand side of the operator assignment gets
+    // evaluated.
+    if (a[0] == 23.0 && a[1] == 42.0 && r == 0.75) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -98,8 +98,11 @@ array_unpacked_sysfunct	normal,-g2005-sv	ivltests
 array_packed		normal,-g2005-sv	ivltests
 assign_op_after_cmp1	normal,-g2009		ivltests
 assign_op_after_cmp2	normal,-g2009		ivltests
+assign_op_after_cmp3	normal,-g2009		ivltests
 assign_op_concat	normal,-g2009		ivltests
 assign_op_oob		normal,-g2009		ivltests
+assign_op_real_array	normal,-g2009		ivltests
+assign_op_real_array_oob normal,-g2009		ivltests
 assign_op_type		normal,-g2009		ivltests
 bitp1			normal,-g2005-sv	ivltests
 bits			normal,-g2005-sv	ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -212,6 +212,9 @@ array_select		CE,-pallowsigned=1	ivltests
 array_select_a		CE			ivltests
 array_unpacked_sysfunct	CE,-g2005-sv	ivltests
 array_word_width2	CE			ivltests
+assign_op_after_cmp3	CE,-g2009		ivltests
+assign_op_real_array	CE,-g2009		ivltests
+assign_op_real_array_oob CE,-g2009		ivltests
 br1008			CE			ivltests
 br1019			CE			ivltests
 br_gh556		CE,-g2009		ivltests


### PR DESCRIPTION
The basic structure for supporting assignment operators on real arrays
exists in the tgt-vvp backend. But there are a few problems, most
importantly it generates the wrong instruction for loading data from the
real array.

The instruction it uses is `%load/reala`, but that instruction does not
exist, the correct name is `%load/ar`.

In addition to this there are a few minor problems.
  * Out-of-bounds access on the array triggers an assert
  * Missing `%pop/real` instruction when skipping a write due to
    out-of-bounds access

Address these so assignment operators are supported on real array entries.