### PR TITLE
vvp: Remove `wid` parameter from `recv_vec{4,8}_pv()`

### DIFF
--- a/vvp/arith.cc
+++ b/vvp/arith.cc
@@ -54,10 +54,9 @@ void vvp_arith_::dispatch_operand_(vvp_net_ptr_t ptr, const vvp_vector4_t&bit)
 }
 
 void vvp_arith_::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			      unsigned base, unsigned wid, unsigned vwid,
-                              vvp_context_t ctx)
+			      unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 vvp_arith_abs::vvp_arith_abs()
@@ -91,10 +90,9 @@ void vvp_arith_abs::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_arith_abs::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				 unsigned base, unsigned wid, unsigned vwid,
-				 vvp_context_t ctx)
+				 unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 void vvp_arith_abs::recv_real(vvp_net_ptr_t ptr, double bit,
@@ -137,10 +135,10 @@ void vvp_arith_cast_real::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_arith_cast_real::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				       unsigned base, unsigned wid, unsigned vwid,
+				       unsigned base, unsigned vwid,
 				       vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 vvp_arith_cast_vec2::vvp_arith_cast_vec2(unsigned wid)
@@ -166,10 +164,9 @@ void vvp_arith_cast_vec2::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_arith_cast_vec2::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				       unsigned base, unsigned wid, unsigned vwid,
-				       vvp_context_t ctx)
+				       unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 // Division

--- a/vvp/arith.h
+++ b/vvp/arith.h
@@ -38,8 +38,7 @@ class vvp_arith_  : public vvp_net_fun_t {
       explicit vvp_arith_(unsigned wid);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     protected:
       void dispatch_operand_(vvp_net_ptr_t ptr, const vvp_vector4_t&bit);
@@ -64,8 +63,7 @@ class vvp_arith_abs : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
 };
@@ -91,8 +89,7 @@ class vvp_arith_cast_real : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
       bool signed_;
@@ -109,8 +106,7 @@ class vvp_arith_cast_vec2 : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
       unsigned wid_;

--- a/vvp/array.cc
+++ b/vvp/array.cc
@@ -617,7 +617,7 @@ void __vpiArray::set_word(unsigned address, unsigned part_off, const vvp_vector4
       struct __vpiSignal*vsig = dynamic_cast<__vpiSignal*>(word);
       assert(vsig);
 
-      vsig->node->send_vec4_pv(val, part_off, val.size(), vpip_size(vsig), 0);
+      vsig->node->send_vec4_pv(val, part_off, vpip_size(vsig), 0);
       word_change(address);
 }
 

--- a/vvp/bufif.cc
+++ b/vvp/bufif.cc
@@ -83,8 +83,7 @@ void vvp_fun_bufif::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_bufif::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid,
-                                 vvp_context_t ctx)
+			         unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }

--- a/vvp/bufif.h
+++ b/vvp/bufif.h
@@ -41,8 +41,7 @@ class vvp_fun_bufif  : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
       vvp_vector4_t bit_;

--- a/vvp/concat.cc
+++ b/vvp/concat.cc
@@ -66,12 +66,10 @@ void vvp_fun_concat::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_concat::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-                                  unsigned base, unsigned wid, unsigned vwid,
-                                  vvp_context_t)
+                                  unsigned base, unsigned vwid, vvp_context_t)
 {
-      assert(bit.size() == wid);
-
       unsigned pdx = port.port();
+      unsigned wid = bit.size();
 
       if (vwid != wid_[pdx]) {
 	    cerr << "internal error: port " << pdx
@@ -137,11 +135,10 @@ void vvp_fun_concat8::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_concat8::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid,
-				   vvp_context_t)
+				   unsigned base, unsigned vwid, vvp_context_t)
 {
       vvp_vector8_t bit8 (bit, 6, 6);
-      recv_vec8_pv(port, bit8, base, wid, vwid);
+      recv_vec8_pv(port, bit8, base, vwid);
 }
 
 void vvp_fun_concat8::recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit)
@@ -167,11 +164,10 @@ void vvp_fun_concat8::recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit)
 }
 
 void vvp_fun_concat8::recv_vec8_pv(vvp_net_ptr_t port, const vvp_vector8_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid)
+				   unsigned base, unsigned vwid)
 {
-      assert(bit.size() == wid);
-
       unsigned pdx = port.port();
+      unsigned wid = bit.size();
 
       if (vwid != wid_[pdx]) {
 	    cerr << "internal error: port " << pdx

--- a/vvp/delay.cc
+++ b/vvp/delay.cc
@@ -335,10 +335,9 @@ void vvp_fun_delay::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_delay::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid,
-                                 vvp_context_t ctx)
+			         unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 /* See the recv_vec4 comment above. */
@@ -407,9 +406,9 @@ void vvp_fun_delay::recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit)
 }
 
 void vvp_fun_delay::recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid)
+			         unsigned base, unsigned vwid)
 {
-      recv_vec8_pv_(ptr, bit, base, wid, vwid);
+      recv_vec8_pv_(ptr, bit, base, vwid);
 }
 
 void vvp_fun_delay::recv_real(vvp_net_ptr_t port, double bit,

--- a/vvp/delay.h
+++ b/vvp/delay.h
@@ -100,10 +100,9 @@ class vvp_fun_delay  : public vvp_net_fun_t, private vvp_gen_event_s {
 	//void recv_long(vvp_net_ptr_t port, long bit);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
       void recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid);
+			unsigned base, unsigned vwid);
 
     private:
       virtual void run_run();

--- a/vvp/dff.cc
+++ b/vvp/dff.cc
@@ -104,10 +104,9 @@ void vvp_dff::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_dff::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			   unsigned base, unsigned wid, unsigned vwid,
-                           vvp_context_t ctx)
+			   unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 /*

--- a/vvp/dff.h
+++ b/vvp/dff.h
@@ -45,8 +45,7 @@ class vvp_dff : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
       virtual void recv_async(vvp_net_ptr_t port);

--- a/vvp/event.cc
+++ b/vvp/event.cc
@@ -107,7 +107,7 @@ evctl_vector::evctl_vector(vvp_net_ptr_t ptr, const vvp_vector4_t&value,
 void evctl_vector::run_run()
 {
       if (wid_ != 0) {
-	    vvp_send_vec4_pv(ptr_, value_, off_, value_.size(), wid_, 0);
+	    vvp_send_vec4_pv(ptr_, value_, off_, wid_, 0);
       } else {
 	    vvp_send_vec4(ptr_, value_, 0);
       }
@@ -278,13 +278,12 @@ void vvp_fun_edge_sa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_edge_sa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid,
-				   vvp_context_t)
+				   unsigned base, unsigned vwid, vvp_context_t)
 {
       assert(base == 0);
       if (recv_vec4_(bit, bits_[port.port()], threads_)) {
 	    vvp_net_t*net = port.ptr();
-	    net->send_vec4_pv(bit, base, wid, vwid, 0);
+	    net->send_vec4_pv(bit, base, vwid, 0);
       }
 }
 
@@ -382,7 +381,7 @@ class anyedge_vec4_value : public anyedge_value {
       bool recv_vec4(const vvp_vector4_t&bit);
 
       bool recv_vec4_pv(const vvp_vector4_t&bit, unsigned base,
-			unsigned wid, unsigned vwid);
+			unsigned vwid);
 
     private:
       vvp_vector4_t old_bits;
@@ -529,13 +528,12 @@ bool anyedge_vec4_value::recv_vec4(const vvp_vector4_t&bit)
 }
 
 bool anyedge_vec4_value::recv_vec4_pv(const vvp_vector4_t&bit, unsigned base,
-				      unsigned wid, unsigned vwid)
+				      unsigned vwid)
 {
       vvp_vector4_t tmp = old_bits;
       if (tmp.size() == 0)
 	    tmp = vvp_vector4_t(vwid, BIT4_Z);
-      assert(wid == bit.size());
-      assert(base+wid <= vwid);
+      assert(base + bit.size()<= vwid);
       assert(tmp.size() == vwid);
       tmp.set_vec(base, bit);
 
@@ -604,12 +602,11 @@ void vvp_fun_anyedge_sa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_anyedge_sa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				      unsigned base, unsigned wid, unsigned vwid,
-				      vvp_context_t)
+				      unsigned base, unsigned vwid, vvp_context_t)
 {
       anyedge_vec4_value*value = get_vec4_value(last_value_[port.port()]);
       assert(value);
-      if (value->recv_vec4_pv(bit, base, wid, vwid)) {
+      if (value->recv_vec4_pv(bit, base, vwid)) {
 	    run_waiting_threads_(threads_);
 	    vvp_net_t*net = port.ptr();
 	    net->send_vec4(bit, 0);

--- a/vvp/event.h
+++ b/vvp/event.h
@@ -185,8 +185,7 @@ class vvp_fun_edge_sa : public vvp_fun_edge {
       void recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
                      vvp_context_t context);
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-			vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
 
     private:
       vthread_t threads_;
@@ -257,8 +256,7 @@ class vvp_fun_anyedge_sa : public vvp_fun_anyedge {
       void recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
                      vvp_context_t context);
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-			vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
 
       void recv_real(vvp_net_ptr_t port, double bit,
                      vvp_context_t context);

--- a/vvp/extend.cc
+++ b/vvp/extend.cc
@@ -53,8 +53,7 @@ void vvp_fun_extend_signed::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bi
 }
 
 void vvp_fun_extend_signed::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-					 unsigned base, unsigned wid, unsigned vwid,
-					 vvp_context_t ctx)
+					 unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }

--- a/vvp/latch.cc
+++ b/vvp/latch.cc
@@ -71,10 +71,9 @@ void vvp_latch::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_latch::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			     unsigned base, unsigned wid, unsigned vwid,
-                             vvp_context_t ctx)
+			     unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 void compile_latch(char*label, unsigned width,

--- a/vvp/latch.h
+++ b/vvp/latch.h
@@ -38,8 +38,7 @@ class vvp_latch : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
       vvp_bit4_t en_;

--- a/vvp/logic.cc
+++ b/vvp/logic.cc
@@ -55,13 +55,11 @@ void vvp_fun_boolean_::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_boolean_::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				    unsigned base, unsigned wid, unsigned vwid,
-                                    vvp_context_t)
+				    unsigned base, unsigned vwid, vvp_context_t)
 {
       unsigned port = ptr.port();
 
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
 
 	// Set the part for the input. If nothing changes, then break.
       bool flag = input_[port] .set_vec(base, bit);
@@ -191,14 +189,12 @@ void vvp_fun_buf::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_buf::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-                               unsigned base, unsigned wid, unsigned vwid,
-                               vvp_context_t)
+                               unsigned base, unsigned vwid, vvp_context_t)
 {
       if (ptr.port() != 0)
 	    return;
 
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
 
 	// Set the input part. If nothing changes, then break.
       bool flag = input_.set_vec(base, bit);
@@ -244,13 +240,12 @@ void vvp_fun_bufz::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_bufz::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-                                unsigned base, unsigned wid, unsigned vwid,
-                                vvp_context_t)
+                                unsigned base, unsigned vwid, vvp_context_t)
 {
       if (ptr.port() != 0)
 	    return;
 
-      ptr.ptr()->send_vec4_pv(bit, base, wid, vwid, 0);
+      ptr.ptr()->send_vec4_pv(bit, base, vwid, 0);
 }
 
 void vvp_fun_bufz::recv_real(vvp_net_ptr_t ptr, double bit,
@@ -415,11 +410,9 @@ void vvp_fun_muxz::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_muxz::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				unsigned base, unsigned wid, unsigned vwid,
-                                vvp_context_t)
+				unsigned base, unsigned vwid, vvp_context_t)
 {
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
       bool flag;
 
       switch (ptr.port()) {
@@ -434,7 +427,7 @@ void vvp_fun_muxz::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 	    if (select_ == SEL_PORT0) return; // The other port is selected.
 	    break;
 	  case 2:
-	    assert((base == 0) && (wid == 1));
+	    assert((base == 0) && (bit.size() == 1));
 	    recv_vec4(ptr, bit, 0);
 	  default:
 	    return;
@@ -517,14 +510,12 @@ void vvp_fun_not::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_not::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-                               unsigned base, unsigned wid, unsigned vwid,
-                               vvp_context_t)
+                               unsigned base, unsigned vwid, vvp_context_t)
 {
       if (ptr.port() != 0)
 	    return;
 
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
 
 	// Set the part value. If nothing changes, then break.
       bool flag = input_.set_vec(base, bit);

--- a/vvp/logic.h
+++ b/vvp/logic.h
@@ -35,8 +35,7 @@ class vvp_fun_boolean_ : public vvp_net_fun_t, protected vvp_gen_event_s {
       void recv_vec4(vvp_net_ptr_t p, const vvp_vector4_t&bit,
                      vvp_context_t);
       void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
     protected:
       vvp_vector4_t input_[4];
@@ -89,8 +88,7 @@ class vvp_fun_buf: public vvp_net_fun_t, private vvp_gen_event_s {
       void recv_vec4(vvp_net_ptr_t p, const vvp_vector4_t&bit,
                      vvp_context_t);
       void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
     private:
       void run_run();
@@ -113,8 +111,7 @@ class vvp_fun_bufz: public vvp_net_fun_t {
       void recv_vec4(vvp_net_ptr_t p, const vvp_vector4_t&bit,
                      vvp_context_t);
       void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 	//void recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit);
       void recv_real(vvp_net_ptr_t p, double bit,
                      vvp_context_t);
@@ -155,8 +152,7 @@ class vvp_fun_muxz : public vvp_net_fun_t, private vvp_gen_event_s {
       void recv_vec4(vvp_net_ptr_t p, const vvp_vector4_t&bit,
                      vvp_context_t);
       void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
     private:
       void run_run();
@@ -199,8 +195,7 @@ class vvp_fun_not: public vvp_net_fun_t, private vvp_gen_event_s {
       void recv_vec4(vvp_net_ptr_t p, const vvp_vector4_t&bit,
                      vvp_context_t);
       void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
     private:
       void run_run();

--- a/vvp/npmos.cc
+++ b/vvp/npmos.cc
@@ -45,16 +45,15 @@ void vvp_fun_pmos_::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_pmos_::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid,
-                                 vvp_context_t ctx)
+			         unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 void vvp_fun_pmos_::recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid)
+			         unsigned base, unsigned vwid)
 {
-      recv_vec8_pv_(ptr, bit, base, wid, vwid);
+      recv_vec8_pv_(ptr, bit, base, vwid);
 }
 
 void vvp_fun_pmos_::generate_output_(vvp_net_ptr_t ptr)
@@ -169,16 +168,15 @@ void vvp_fun_cmos_::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t &bit,
 }
 
 void vvp_fun_cmos_::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid,
-                                 vvp_context_t ctx)
+			         unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 void vvp_fun_cmos_::recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-			         unsigned base, unsigned wid, unsigned vwid)
+			         unsigned base, unsigned vwid)
 {
-      recv_vec8_pv_(ptr, bit, base, wid, vwid);
+      recv_vec8_pv_(ptr, bit, base, vwid);
 }
 
 void vvp_fun_cmos_::generate_output_(vvp_net_ptr_t ptr)

--- a/vvp/npmos.h
+++ b/vvp/npmos.h
@@ -52,10 +52,9 @@ class vvp_fun_pmos_ : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
       void recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid);
+			unsigned base, unsigned vwid);
 
     protected:
       void generate_output_(vvp_net_ptr_t port);
@@ -115,10 +114,9 @@ class vvp_fun_cmos_ : public vvp_net_fun_t {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
       void recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid);
+			unsigned base, unsigned vwid);
 
     protected:
       void generate_output_(vvp_net_ptr_t port);

--- a/vvp/part.cc
+++ b/vvp/part.cc
@@ -78,11 +78,8 @@ void vvp_fun_part_sa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
  * defined behavior.
  */
 void vvp_fun_part_sa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid,
-                                   vvp_context_t)
+				   unsigned base, unsigned vwid, vvp_context_t)
 {
-      assert(bit.size() == wid);
-
       vvp_vector4_t tmp (vwid, BIT4_Z);
       tmp.set_vec(base_, val_);
       tmp.set_vec(base, bit);
@@ -163,12 +160,9 @@ void vvp_fun_part_aa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
  * defined behavior.
  */
 void vvp_fun_part_aa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid,
-                                   vvp_context_t context)
+				   unsigned base, unsigned vwid, vvp_context_t context)
 {
       if (context) {
-            assert(bit.size() == wid);
-
             vvp_vector4_t*val = static_cast<vvp_vector4_t*>
                   (vvp_get_context_item(context, context_idx_));
 
@@ -179,7 +173,7 @@ void vvp_fun_part_aa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
       } else {
             context = context_scope_->live_contexts;
             while (context) {
-                  recv_vec4_pv(port, bit, base, wid, vwid, context);
+                  recv_vec4_pv(port, bit, base, vwid, context);
                   context = vvp_get_next_context(context);
             }
       }
@@ -207,22 +201,20 @@ void vvp_fun_part_pv::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
       }
       assert(bit.size() == wid_);
 
-      port.ptr()->send_vec4_pv(bit, base_, wid_, vwid_, context);
+      port.ptr()->send_vec4_pv(bit, base_, vwid_, context);
 }
 
 void vvp_fun_part_pv::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-                                 unsigned base, unsigned wid, unsigned vwid,
-                                 vvp_context_t ctx)
+                                 unsigned base, unsigned vwid, vvp_context_t ctx)
 {
       assert(port.port() == 0);
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
       assert(vwid == wid_);
 
       vvp_vector4_t tmp(wid_, BIT4_Z);
       tmp.set_vec(base, bit);
 
-      port.ptr()->send_vec4_pv(tmp, base_, wid_, vwid_, ctx);
+      port.ptr()->send_vec4_pv(tmp, base_, vwid_, ctx);
 }
 
 void vvp_fun_part_pv::recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit)
@@ -237,7 +229,7 @@ void vvp_fun_part_pv::recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit)
       }
       assert(bit.size() == wid_);
 
-      port.ptr()->send_vec8_pv(bit, base_, wid_, vwid_);
+      port.ptr()->send_vec8_pv(bit, base_, vwid_);
 }
 
 vvp_fun_part_var::vvp_fun_part_var(unsigned w, bool is_signed)
@@ -307,11 +299,8 @@ void vvp_fun_part_var_sa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_part_var_sa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				       unsigned base, unsigned wid, unsigned vwid,
-                                       vvp_context_t)
+				       unsigned base, unsigned vwid, vvp_context_t)
 {
-      assert(bit.size() == wid);
-
       vvp_vector4_t tmp = source_;
       if (tmp.size() == 0)
 	    tmp = vvp_vector4_t(vwid);
@@ -384,14 +373,11 @@ void vvp_fun_part_var_aa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_part_var_aa::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				       unsigned base, unsigned wid, unsigned vwid,
-                                       vvp_context_t context)
+				       unsigned base, unsigned vwid, vvp_context_t context)
 {
       if (context) {
             vvp_fun_part_var_state_s*state = static_cast<vvp_fun_part_var_state_s*>
                   (vvp_get_context_item(context, context_idx_));
-
-            assert(bit.size() == wid);
 
             vvp_vector4_t tmp = state->source;
             if (tmp.size() == 0)

--- a/vvp/part.h
+++ b/vvp/part.h
@@ -53,8 +53,7 @@ class vvp_fun_part_sa  : public vvp_fun_part, public vvp_gen_event_s {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned, unsigned, unsigned,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
     private:
       void run_run();
@@ -84,8 +83,7 @@ class vvp_fun_part_aa  : public vvp_fun_part, public automatic_hooks_s {
                      vvp_context_t context);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned, unsigned, unsigned,
-                        vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
 
     private:
       __vpiScope*context_scope_;
@@ -110,8 +108,7 @@ class vvp_fun_part_pv  : public vvp_net_fun_t {
                      vvp_context_t context);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-                        unsigned, unsigned, unsigned,
-                        vvp_context_t);
+                        unsigned base, unsigned vwid, vvp_context_t);
 
       void recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit);
 
@@ -155,8 +152,7 @@ class vvp_fun_part_var_sa  : public vvp_fun_part_var {
                      vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned, unsigned, unsigned,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
     private:
       int base_;
@@ -185,8 +181,7 @@ class vvp_fun_part_var_aa  : public vvp_fun_part_var, public automatic_hooks_s {
                      vvp_context_t context);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned, unsigned, unsigned,
-                        vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
 
     private:
       __vpiScope*context_scope_;

--- a/vvp/reduce.cc
+++ b/vvp/reduce.cc
@@ -40,8 +40,7 @@ class vvp_reduce_base : public vvp_net_fun_t {
       void recv_vec4(vvp_net_ptr_t prt, const vvp_vector4_t&bit,
                      vvp_context_t context);
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
 
       virtual vvp_bit4_t calculate_result() const =0;
 
@@ -67,15 +66,13 @@ void vvp_reduce_base::recv_vec4(vvp_net_ptr_t prt, const vvp_vector4_t&bit,
 }
 
 void vvp_reduce_base::recv_vec4_pv(vvp_net_ptr_t prt, const vvp_vector4_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid,
-                                   vvp_context_t context)
+				   unsigned base, unsigned vwid, vvp_context_t context)
 {
       if (bits_.size() == 0) {
 	    bits_ = vvp_vector4_t(vwid);
       }
       assert(bits_.size() == vwid);
 
-      assert(bit.size() == wid);
       bits_.set_vec(base, bit);
       vvp_bit4_t res = calculate_result();
       vvp_vector4_t rv (1, res);

--- a/vvp/resolv.cc
+++ b/vvp/resolv.cc
@@ -52,9 +52,9 @@ resolv_core::~resolv_core()
 }
 
 void resolv_core::recv_vec4_pv_(unsigned port, const vvp_vector4_t&bit,
-				unsigned base, unsigned wid, unsigned vwid)
+				unsigned base, unsigned vwid)
 {
-      assert(bit.size() == wid);
+      unsigned wid = bit.size();
       vvp_vector4_t res (vwid);
 
       for (unsigned idx = 0 ;  idx < base ;  idx += 1)
@@ -70,9 +70,9 @@ void resolv_core::recv_vec4_pv_(unsigned port, const vvp_vector4_t&bit,
 }
 
 void resolv_core::recv_vec8_pv_(unsigned port, const vvp_vector8_t&bit,
-				unsigned base, unsigned wid, unsigned vwid)
+				unsigned base, unsigned vwid)
 {
-      assert(bit.size() == wid);
+      unsigned wid = bit.size();
       vvp_vector8_t res (vwid);
 
       for (unsigned idx = 0 ;  idx < base ;  idx += 1)

--- a/vvp/resolv.h
+++ b/vvp/resolv.h
@@ -44,13 +44,12 @@ class resolv_core : public vvp_net_fun_t {
             { recv_vec8_(port.port(), bit); }
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t)
-            { recv_vec4_pv_(port.port(), bit, base, wid, vwid); }
+			unsigned base, unsigned vwid, vvp_context_t)
+            { recv_vec4_pv_(port.port(), bit, base, vwid); }
 
       void recv_vec8_pv(vvp_net_ptr_t port, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid)
-            { recv_vec8_pv_(port.port(), bit, base, wid, vwid); }
+			unsigned base, unsigned vwid)
+            { recv_vec8_pv_(port.port(), bit, base, vwid); }
 
       virtual void count_drivers(unsigned bit_idx, unsigned counts[3]) =0;
 
@@ -60,9 +59,9 @@ class resolv_core : public vvp_net_fun_t {
       virtual void recv_vec8_(unsigned port, const vvp_vector8_t&bit) =0;
 
       void recv_vec4_pv_(unsigned port, const vvp_vector4_t&bit,
-			 unsigned base, unsigned wid, unsigned vwid);
+			 unsigned base, unsigned vwid);
       void recv_vec8_pv_(unsigned port, const vvp_vector8_t&bit,
-			 unsigned base, unsigned wid, unsigned vwid);
+			 unsigned base, unsigned vwid);
 
     protected:
       unsigned nports_;
@@ -83,15 +82,14 @@ class resolv_extend : public vvp_net_fun_t {
             { core_->recv_vec8_(port_base_ + port.port(), bit); }
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t)
+			unsigned base, unsigned vwid, vvp_context_t)
             { core_->recv_vec4_pv_(port_base_ + port.port(), bit,
-                                   base, wid, vwid); }
+                                   base, vwid); }
 
       void recv_vec8_pv(vvp_net_ptr_t port, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid)
+			unsigned base, unsigned vwid)
             { core_->recv_vec8_pv_(port_base_ + port.port(), bit,
-                                   base, wid, vwid); }
+                                   base, vwid); }
 
     private:
       resolv_core*core_;

--- a/vvp/schedule.cc
+++ b/vvp/schedule.cc
@@ -195,7 +195,7 @@ void assign_vector4_event_s::run_run(void)
 {
       count_assign_events += 1;
       if (vwid > 0)
-	    vvp_send_vec4_pv(ptr, val, base, val.size(), vwid, 0);
+	    vvp_send_vec4_pv(ptr, val, base, vwid, 0);
       else
 	    vvp_send_vec4(ptr, val, 0);
 }

--- a/vvp/substitute.cc
+++ b/vvp/substitute.cc
@@ -33,8 +33,7 @@ class vvp_fun_substitute : public vvp_net_fun_t {
       void recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit, vvp_context_t);
 
       void recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t ctx);
+			unsigned base, unsigned vwid, vvp_context_t ctx);
 
     private:
       unsigned wid_;
@@ -82,10 +81,9 @@ void vvp_fun_substitute::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_substitute::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				      unsigned base, unsigned wid, unsigned vwid,
-				      vvp_context_t ctx)
+				      unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 void compile_substitute(char*label, unsigned width,

--- a/vvp/vpi_signal.cc
+++ b/vvp/vpi_signal.cc
@@ -795,10 +795,10 @@ vpiHandle __vpiSignal::put_bit_value(struct __vpiBit*bit, p_vpi_value vp, int fl
 
       if ((get_type_code() == vpiNet) &&
           !dynamic_cast<vvp_island_port*>(node->fun)) {
-	    node->send_vec4_pv(val, index, 1, width(),
+	    node->send_vec4_pv(val, index, width(),
 	                            vthread_get_wt_context());
       } else {
-	    vvp_send_vec4_pv(dest, val, index, 1, width(),
+	    vvp_send_vec4_pv(dest, val, index, width(),
 	                     vthread_get_wt_context());
       }
 
@@ -1534,14 +1534,14 @@ static vpiHandle PV_put_value(vpiHandle ref, p_vpi_value vp, int flags)
 	    if (full_sig) {
 		  rfp->net->send_vec4(val, vthread_get_wt_context());
 	    } else {
-		  rfp->net->send_vec4_pv(val, base, width, sig_size,
+		  rfp->net->send_vec4_pv(val, base, sig_size,
 		                         vthread_get_wt_context());
 	    }
       } else {
 	    if (full_sig) {
 		  vvp_send_vec4(dest, val, vthread_get_wt_context());
 	    } else {
-		  vvp_send_vec4_pv(dest, val, base, width, sig_size,
+		  vvp_send_vec4_pv(dest, val, base, sig_size,
 	                           vthread_get_wt_context());
 	    }
       }

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -1654,7 +1654,7 @@ bool of_CASSIGN_VEC4_OFF(vthread_t thr, vvp_code_t cp)
       }
 
       vvp_net_ptr_t ptr (net, 1);
-      vvp_send_vec4_pv(ptr, value, base, wid, sig->value_size(), 0);
+      vvp_send_vec4_pv(ptr, value, base, sig->value_size(), 0);
       return true;
 }
 
@@ -6429,7 +6429,7 @@ bool of_STORE_VEC4(vthread_t thr, vvp_code_t cp)
       if (off==0 && val_size==(unsigned)sig_value_size)
 	    vvp_send_vec4(ptr, val, thr->wt_context);
       else
-	    vvp_send_vec4_pv(ptr, val, off, wid, sig_value_size, thr->wt_context);
+	    vvp_send_vec4_pv(ptr, val, off, sig_value_size, thr->wt_context);
 
       thr->pop_vec4(1);
       return true;

--- a/vvp/vvp_island.cc
+++ b/vvp/vvp_island.cc
@@ -184,11 +184,10 @@ void vvp_island_port::recv_vec4(vvp_net_ptr_t, const vvp_vector4_t&bit,
 }
 
 void vvp_island_port::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				   unsigned base, unsigned wid, unsigned vwid,
-                                   vvp_context_t)
+				   unsigned base, unsigned vwid, vvp_context_t)
 {
       vvp_vector8_t tmp(bit, 6, 6);
-      recv_vec8_pv(port, tmp, base, wid, vwid);
+      recv_vec8_pv(port, tmp, base, vwid);
 }
 
 
@@ -202,12 +201,12 @@ void vvp_island_port::recv_vec8(vvp_net_ptr_t, const vvp_vector8_t&bit)
 }
 
 void vvp_island_port::recv_vec8_pv(vvp_net_ptr_t, const vvp_vector8_t&bit,
-                                   unsigned base, unsigned wid, unsigned vwid)
+                                   unsigned base, unsigned vwid)
 {
       if (invalue.size() == 0) {
-	    assert(bit.size() == wid);
 	    invalue = part_expand(bit, vwid, base);
       } else {
+	    unsigned wid = bit.size();
 	    assert(invalue.size() == vwid);
 	    for (unsigned idx = 0; idx < wid ; idx += 1) {
 		  if ((base+idx) >= vwid)

--- a/vvp/vvp_island.h
+++ b/vvp/vvp_island.h
@@ -129,11 +129,10 @@ class vvp_island_port  : public vvp_net_fun_t {
       virtual void recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
                              vvp_context_t);
       virtual void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-				unsigned base, unsigned wid, unsigned vwid,
-                                vvp_context_t);
+				unsigned base, unsigned vwid, vvp_context_t);
       virtual void recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit);
       virtual void recv_vec8_pv(vvp_net_ptr_t p, const vvp_vector8_t&bit,
-				unsigned base, unsigned wid, unsigned vwid);
+				unsigned base, unsigned vwid);
 
 	// This is painful, but necessary. If the island is connected
 	// to a forced net, we need to rerun the calculations whenever

--- a/vvp/vvp_net.cc
+++ b/vvp/vvp_net.cc
@@ -3255,8 +3255,7 @@ void vvp_net_fun_t::recv_vec4(vvp_net_ptr_t, const vvp_vector4_t&,
 }
 
 void vvp_net_fun_t::recv_vec4_pv_(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-                                  unsigned base, unsigned wid, unsigned vwid,
-                                  vvp_context_t)
+                                  unsigned base, unsigned vwid, vvp_context_t)
 {
 	// The majority of functors don't normally expect to receive part
 	// values, because the primary operands of an expression will be
@@ -3271,8 +3270,7 @@ void vvp_net_fun_t::recv_vec4_pv_(vvp_net_ptr_t p, const vvp_vector4_t&bit,
 	// code, but we still need to handle it correctly. See GitHub
 	// issue #99 and br_gh99*.v in the test suite for examples.
 
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
 
       vvp_vector4_t tmp(vwid, BIT4_Z);
       tmp.set_vec(base, bit);
@@ -3280,12 +3278,11 @@ void vvp_net_fun_t::recv_vec4_pv_(vvp_net_ptr_t p, const vvp_vector4_t&bit,
 }
 
 void vvp_net_fun_t::recv_vec4_pv(vvp_net_ptr_t, const vvp_vector4_t&bit,
-                                 unsigned base, unsigned wid, unsigned vwid,
-                                 vvp_context_t)
+                                 unsigned base, unsigned vwid, vvp_context_t)
 {
       cerr << "internal error: " << typeid(*this).name() << ": "
 	   << "recv_vec4_pv(" << bit << ", " << base
-	   << ", " << wid << ", " << vwid << ") not implemented" << endl;
+	   << ", " << vwid << ") not implemented" << endl;
       assert(0);
 }
 
@@ -3295,12 +3292,11 @@ void vvp_net_fun_t::recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit)
 }
 
 void vvp_net_fun_t::recv_vec8_pv_(vvp_net_ptr_t p, const vvp_vector8_t&bit,
-				  unsigned base, unsigned wid, unsigned vwid)
+				  unsigned base, unsigned vwid)
 {
 	// This is the strength-aware version of recv_vec4_pv_.
 
-      assert(bit.size() == wid);
-      assert(base + wid <= vwid);
+      assert(base + bit.size() <= vwid);
 
       vvp_vector8_t tmp(vwid);
       tmp.set_vec(base, bit);
@@ -3308,9 +3304,9 @@ void vvp_net_fun_t::recv_vec8_pv_(vvp_net_ptr_t p, const vvp_vector8_t&bit,
 }
 
 void vvp_net_fun_t::recv_vec8_pv(vvp_net_ptr_t port, const vvp_vector8_t&bit,
-				 unsigned base, unsigned wid, unsigned vwid)
+				 unsigned base, unsigned vwid)
 {
-      recv_vec4_pv(port, reduce4(bit), base, wid, vwid, 0);
+      recv_vec4_pv(port, reduce4(bit), base, vwid, 0);
 }
 
 void vvp_net_fun_t::recv_real(vvp_net_ptr_t, double bit, vvp_context_t)
@@ -3375,10 +3371,9 @@ void vvp_fun_drive::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_drive::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				 unsigned base, unsigned wid, unsigned vwid,
-				 vvp_context_t ctx)
+				 unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 /* **** vvp_wide_fun_* methods **** */
@@ -3477,10 +3472,9 @@ void vvp_wide_fun_t::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
 }
 
 void vvp_wide_fun_t::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				  unsigned base, unsigned wid, unsigned vwid,
-				  vvp_context_t ctx)
+				  unsigned base, unsigned vwid, vvp_context_t ctx)
 {
-      recv_vec4_pv_(ptr, bit, base, wid, vwid, ctx);
+      recv_vec4_pv_(ptr, bit, base, vwid, ctx);
 }
 
 void vvp_wide_fun_t::recv_real(vvp_net_ptr_t port, double bit,

--- a/vvp/vvp_net.h
+++ b/vvp/vvp_net.h
@@ -1139,10 +1139,9 @@ class vvp_net_t {
       void send_object(vvp_object_t val, vvp_context_t context);
 
       void send_vec4_pv(const vvp_vector4_t&val,
-			unsigned base, unsigned wid, unsigned vwid,
-			vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
       void send_vec8_pv(const vvp_vector8_t&val,
-			unsigned base, unsigned wid, unsigned vwid);
+			unsigned base, unsigned vwid);
 
 
     public: // Methods to arrange for the output of this net to be forced.
@@ -1223,10 +1222,9 @@ class vvp_net_fun_t {
 
 	// Part select variants of above
       virtual void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-				unsigned base, unsigned wid, unsigned vwid,
-                                vvp_context_t context);
+				unsigned base, unsigned vwid, vvp_context_t context);
       virtual void recv_vec8_pv(vvp_net_ptr_t p, const vvp_vector8_t&bit,
-				unsigned base, unsigned wid, unsigned vwid);
+				unsigned base, unsigned vwid);
       virtual void recv_long_pv(vvp_net_ptr_t port, long bit,
                                 unsigned base, unsigned wid);
 
@@ -1238,10 +1236,9 @@ class vvp_net_fun_t {
 
    protected:
       void recv_vec4_pv_(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			 unsigned base, unsigned wid, unsigned vwid,
-                         vvp_context_t context);
+			 unsigned base, unsigned vwid, vvp_context_t context);
       void recv_vec8_pv_(vvp_net_ptr_t p, const vvp_vector8_t&bit,
-			 unsigned base, unsigned wid, unsigned vwid);
+			 unsigned base, unsigned vwid);
 
     public: // These objects are only permallocated.
       static void* operator new(std::size_t size) { return heap_.alloc(size); }
@@ -1392,8 +1389,7 @@ class vvp_fun_concat  : public vvp_net_fun_t {
                      vvp_context_t context);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
     private:
       unsigned wid_[4];
       vvp_vector4_t val_;
@@ -1411,10 +1407,9 @@ class vvp_fun_concat8  : public vvp_net_fun_t {
       void recv_vec8(vvp_net_ptr_t port, const vvp_vector8_t&bit);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
       void recv_vec8_pv(vvp_net_ptr_t p, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid);
+			unsigned base, unsigned vwid);
 
     private:
       unsigned wid_[4];
@@ -1484,8 +1479,7 @@ class vvp_fun_drive  : public vvp_net_fun_t {
 	//void recv_long(vvp_net_ptr_t port, long bit);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
     private:
       unsigned char drive0_;
       unsigned char drive1_;
@@ -1507,8 +1501,7 @@ class vvp_fun_extend_signed  : public vvp_net_fun_t {
                      vvp_context_t context);
 
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
     private:
       unsigned width_;
 };
@@ -1591,8 +1584,7 @@ class vvp_wide_fun_t : public vvp_net_fun_t {
                      vvp_context_t context);
 
       void recv_vec4_pv(vvp_net_ptr_t p, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t context);
+			unsigned base, unsigned vwid, vvp_context_t context);
 
     private:
       vvp_wide_fun_core*core_;
@@ -1650,8 +1642,7 @@ inline void vvp_send_object(vvp_net_ptr_t ptr, vvp_object_t val, vvp_context_t c
  *
  * The ptr is the destination input port to write to.
  *
- * <val> is the vector to be written. The width of this vector must
- * exactly match the <wid> vector.
+ * <val> is the vector to be written.
  *
  * The <base> is where in the receiver the bit vector is to be
  * written. This address is given in canonical units; 0 is the LSB, 1
@@ -1663,27 +1654,27 @@ inline void vvp_send_object(vvp_net_ptr_t ptr, vvp_object_t val, vvp_context_t c
  * mirror of the destination vector.
  */
 inline void vvp_send_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&val,
-			     unsigned base, unsigned wid, unsigned vwid,
+			     unsigned base, unsigned vwid,
 			     vvp_context_t context)
 {
       while (class vvp_net_t*cur = ptr.ptr()) {
 	    vvp_net_ptr_t next_val = cur->port[ptr.port()];
 
 	    if (cur->fun)
-		  cur->fun->recv_vec4_pv(ptr, val, base, wid, vwid, context);
+		  cur->fun->recv_vec4_pv(ptr, val, base, vwid, context);
 
 	    ptr = next_val;
       }
 }
 
 inline void vvp_send_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&val,
-			     unsigned base, unsigned wid, unsigned vwid)
+			     unsigned base, unsigned vwid)
 {
       while (class vvp_net_t*cur = ptr.ptr()) {
 	    vvp_net_ptr_t next_val = cur->port[ptr.port()];
 
 	    if (cur->fun)
-		  cur->fun->recv_vec8_pv(ptr, val, base, wid, vwid);
+		  cur->fun->recv_vec8_pv(ptr, val, base, vwid);
 
 	    ptr = next_val;
       }
@@ -1710,24 +1701,23 @@ inline void vvp_net_t::send_vec4(const vvp_vector4_t&val, vvp_context_t context)
 }
 
 inline void vvp_net_t::send_vec4_pv(const vvp_vector4_t&val,
-				    unsigned base, unsigned wid, unsigned vwid,
+				    unsigned base, unsigned vwid,
 				    vvp_context_t context)
 {
       if (fil == 0) {
-	    vvp_send_vec4_pv(out_, val, base, wid, vwid, context);
+	    vvp_send_vec4_pv(out_, val, base, vwid, context);
 	    return;
       }
 
-      assert(val.size() == wid);
       vvp_vector4_t rep;
       switch (fil->filter_vec4(val, rep, base, vwid)) {
 	  case vvp_net_fil_t::STOP:
 	    break;
 	  case vvp_net_fil_t::PROP:
-	    vvp_send_vec4_pv(out_, val, base, wid, vwid, context);
+	    vvp_send_vec4_pv(out_, val, base, vwid, context);
 	    break;
 	  case vvp_net_fil_t::REPL:
-	    vvp_send_vec4_pv(out_, rep, base, wid, vwid, context);
+	    vvp_send_vec4_pv(out_, rep, base, vwid, context);
 	    break;
       }
 }
@@ -1753,23 +1743,22 @@ inline void vvp_net_t::send_vec8(const vvp_vector8_t&val)
 }
 
 inline void vvp_net_t::send_vec8_pv(const vvp_vector8_t&val,
-				    unsigned base, unsigned wid, unsigned vwid)
+				    unsigned base, unsigned vwid)
 {
       if (fil == 0) {
-	    vvp_send_vec8_pv(out_, val, base, wid, vwid);
+	    vvp_send_vec8_pv(out_, val, base, vwid);
 	    return;
       }
 
-      assert(val.size() == wid);
       vvp_vector8_t rep;
       switch (fil->filter_vec8(val, rep, base, vwid)) {
 	  case vvp_net_fil_t::STOP:
 	    break;
 	  case vvp_net_fil_t::PROP:
-	    vvp_send_vec8_pv(out_, val, base, wid, vwid);
+	    vvp_send_vec8_pv(out_, val, base, vwid);
 	    break;
 	  case vvp_net_fil_t::REPL:
-	    vvp_send_vec8_pv(out_, rep, base, wid, vwid);
+	    vvp_send_vec8_pv(out_, rep, base, vwid);
 	    break;
       }
 }

--- a/vvp/vvp_net_sig.cc
+++ b/vvp/vvp_net_sig.cc
@@ -222,11 +222,10 @@ void vvp_fun_signal4_sa::recv_vec8(vvp_net_ptr_t ptr, const vvp_vector8_t&bit)
 }
 
 void vvp_fun_signal4_sa::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				      unsigned base, unsigned wid, unsigned vwid,
-                                      vvp_context_t)
+				      unsigned base, unsigned vwid, vvp_context_t)
 {
-      assert(bit.size() == wid);
       assert(bits4_.size() == vwid);
+      unsigned wid = bit.size();
 
       switch (ptr.port()) {
 	  case 0: // Normal input
@@ -273,9 +272,9 @@ void vvp_fun_signal4_sa::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit
 }
 
 void vvp_fun_signal4_sa::recv_vec8_pv(vvp_net_ptr_t ptr, const vvp_vector8_t&bit,
-				      unsigned base, unsigned wid, unsigned vwid)
+				      unsigned base, unsigned vwid)
 {
-      recv_vec4_pv(ptr, reduce4(bit), base, wid, vwid, 0);
+      recv_vec4_pv(ptr, reduce4(bit), base, vwid, 0);
 }
 
 void vvp_fun_signal_base::deassign()
@@ -389,17 +388,16 @@ void vvp_fun_signal4_aa::recv_vec4(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
 }
 
 void vvp_fun_signal4_aa::recv_vec4_pv(vvp_net_ptr_t ptr, const vvp_vector4_t&bit,
-				      unsigned base, unsigned wid, unsigned vwid,
-                                      vvp_context_t context)
+				      unsigned base, unsigned vwid, vvp_context_t context)
 {
       assert(ptr.port() == 0);
-      assert(bit.size() == wid);
       assert(size_ == vwid);
       assert(context);
 
       vvp_vector4_t*bits4 = static_cast<vvp_vector4_t*>
             (vvp_get_context_item(context, context_idx_));
 
+      unsigned wid = bit.size();
       for (unsigned idx = 0 ;  idx < wid ;  idx += 1) {
             if (base+idx >= bits4->size()) break;
             bits4->set_bit(base+idx, bit.value(idx));
@@ -1001,7 +999,7 @@ void vvp_wire_vec4::release_pv(vvp_net_ptr_t ptr, unsigned base, unsigned wid, b
 	    release_mask(mask);
 	    needs_init_ = ! force4_.subvalue(base,wid) .eeq(bits4_.subvalue(base,wid));
 	    ptr.ptr()->send_vec4_pv(bits4_.subvalue(base,wid),
-				    base, wid, bits4_.size(), 0);
+				    base, bits4_.size(), 0);
 	    run_vpi_callbacks();
       } else {
 	      // Variables keep the current value.
@@ -1009,7 +1007,7 @@ void vvp_wire_vec4::release_pv(vvp_net_ptr_t ptr, unsigned base, unsigned wid, b
 	    for (unsigned idx=0; idx<wid; idx += 1)
 		  res.set_bit(idx,value(base+idx));
 	    release_mask(mask);
-	    ptr.ptr()->fun->recv_vec4_pv(ptr, res, base, wid, bits4_.size(), 0);
+	    ptr.ptr()->fun->recv_vec4_pv(ptr, res, base, bits4_.size(), 0);
       }
 }
 
@@ -1167,7 +1165,7 @@ void vvp_wire_vec8::release_pv(vvp_net_ptr_t ptr, unsigned base, unsigned wid, b
       if (net_flag) {
 	    needs_init_ = !force8_.subvalue(base,wid) .eeq((bits8_.subvalue(base,wid)));
 	    ptr.ptr()->send_vec8_pv(bits8_.subvalue(base,wid),
-				    base, wid, bits8_.size());
+				    base, bits8_.size());
 	    run_vpi_callbacks();
       } else {
 	// Variable do not know about strength so this should not be able
@@ -1175,7 +1173,7 @@ void vvp_wire_vec8::release_pv(vvp_net_ptr_t ptr, unsigned base, unsigned wid, b
 	// hard to fix this code like was done for vvp_wire_vec4 above.
 	    assert(0);
 //	    ptr.ptr()->fun->recv_vec8_pv(ptr, force8_.subvalue(base,wid),
-//					 base, wid, force8_.size());
+//					 base, force8_.size());
       }
 }
 

--- a/vvp/vvp_net_sig.h
+++ b/vvp/vvp_net_sig.h
@@ -143,10 +143,9 @@ class vvp_fun_signal4_sa : public vvp_fun_signal_vec {
 
 	// Part select variants of above
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
       void recv_vec8_pv(vvp_net_ptr_t port, const vvp_vector8_t&bit,
-			unsigned base, unsigned wid, unsigned vwid);
+			unsigned base, unsigned vwid);
 
 	// Get information about the vector value.
       const vvp_vector4_t& vec4_unfiltered_value() const;
@@ -175,8 +174,7 @@ class vvp_fun_signal4_aa : public vvp_fun_signal_vec, public automatic_signal_ba
 
 	// Part select variants of above
       void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
-			unsigned base, unsigned wid, unsigned vwid,
-                        vvp_context_t);
+			unsigned base, unsigned vwid, vvp_context_t);
 
 	// Get information about the vector value.
       unsigned   value_size() const;


### PR DESCRIPTION
The `recv_vec{4,8}_pv()` functions are used to implement a partial write to
a vector. As parameters they take both the value and the width of the
value.

All callers of of these functions pass `val.size()` or a variation thereof
as the width of the value. And all implementations that do anything with
the data have an assert that `val.size() == wid`.

Remove the `wid` parameter from these functions and just use `val.size()`
directly where needed. This allows to simplify the interface and also
to remove the asserts.