### PR TITLE
vvp: Remove unused index word instructions

### DIFF
--- a/vvp/compile.cc
+++ b/vvp/compile.cc
@@ -129,8 +129,6 @@ static const struct opcode_table_s opcode_table[] = {
       { "%cmp/we",  of_CMPWE,  0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%cmp/wne", of_CMPWNE, 0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%cmp/wr",  of_CMPWR,  0,  {OA_NONE,     OA_NONE,     OA_NONE} },
-      { "%cmp/ws",  of_CMPWS,  2,  {OA_BIT1,     OA_BIT2,     OA_NONE} },
-      { "%cmp/wu",  of_CMPWU,  2,  {OA_BIT1,     OA_BIT2,     OA_NONE} },
       { "%cmp/x",   of_CMPX,   0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%cmp/z",   of_CMPZ,   0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%cmpi/e",  of_CMPIE,  3,  {OA_BIT1,     OA_BIT2,     OA_NUMBER} },

--- a/vvp/compile.cc
+++ b/vvp/compile.cc
@@ -216,7 +216,6 @@ static const struct opcode_table_s opcode_table[] = {
       { "%mod",    of_MOD,    0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%mod/s",  of_MOD_S,  0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%mod/wr", of_MOD_WR, 0,  {OA_NONE,     OA_NONE,     OA_NONE} },
-      { "%mov/wu", of_MOV_WU, 2,  {OA_BIT1,     OA_BIT2,     OA_NONE} },
       { "%mul",    of_MUL,    0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%mul/wr", of_MUL_WR, 0,  {OA_NONE,     OA_NONE,     OA_NONE} },
       { "%muli",   of_MULI,   3,  {OA_BIT1,     OA_BIT2,     OA_NUMBER} },

--- a/vvp/opcodes.txt
+++ b/vvp/opcodes.txt
@@ -341,11 +341,6 @@ values from the real-value stack and writes the comparison result to
 bits 4/5. The expressions (a < b) and (a==b) are calculated, with (b)
 popped from the stack first, then (a).
 
-* %cmp/ws <bit-l>, <bit-r>
-* %cmp/wu <bit-l>, <bit-r>
-
-[compare signed/unsigned integer words.]
-
 * %cmp/z
 * %cmp/x
 

--- a/vvp/opcodes.txt
+++ b/vvp/opcodes.txt
@@ -806,8 +806,6 @@ The /s form does signed %.
 
 This opcode is the real-valued modulus of the two real values.
 
-* %mov/wu <dst>, <src>
-
 * %mul
 * %muli <vala>, <valb>, <wid>
 

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -4501,18 +4501,6 @@ bool of_PARTI_U(vthread_t thr, vvp_code_t cp)
 }
 
 /*
-*  %mov/wu <dst>, <src>
-*/
-bool of_MOV_WU(vthread_t thr, vvp_code_t cp)
-{
-      unsigned dst = cp->bit_idx[0];
-      unsigned src = cp->bit_idx[1];
-
-      thr->words[dst].w_uint = thr->words[src].w_uint;
-      return true;
-}
-
-/*
  * %mul
  */
 bool of_MUL(vthread_t thr, vvp_code_t)

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -2245,34 +2245,6 @@ bool of_CMPWR(vthread_t thr, vvp_code_t)
       return true;
 }
 
-bool of_CMPWS(vthread_t thr, vvp_code_t cp)
-{
-      int64_t l = thr->words[cp->bit_idx[0]].w_int;
-      int64_t r = thr->words[cp->bit_idx[1]].w_int;
-
-      vvp_bit4_t eq = (l == r)? BIT4_1 : BIT4_0;
-      vvp_bit4_t lt = (l <  r)? BIT4_1 : BIT4_0;
-
-      thr->flags[4] = eq;
-      thr->flags[5] = lt;
-
-      return true;
-}
-
-bool of_CMPWU(vthread_t thr, vvp_code_t cp)
-{
-      uint64_t l = thr->words[cp->bit_idx[0]].w_uint;
-      uint64_t r = thr->words[cp->bit_idx[1]].w_uint;
-
-      vvp_bit4_t eq = (l == r)? BIT4_1 : BIT4_0;
-      vvp_bit4_t lt = (l <  r)? BIT4_1 : BIT4_0;
-
-      thr->flags[4] = eq;
-      thr->flags[5] = lt;
-
-      return true;
-}
-
 /*
  * %cmp/z
  */


### PR DESCRIPTION
Remove some unused vvp instructions for the index words.

 * `%mov/wu`: It is identical to `%ix/mov`
 * `%cmp/ws` and `%cmp/wu`: These are for comparing index register and have not been used since the introduction of the vector stack