### PR TITLE
tgt-vvp: Fix syntax when using multiple events for non-blocking event control

### DIFF
--- a/ivtest/ivltests/nb_ec_multi_ev.v
+++ b/ivtest/ivltests/nb_ec_multi_ev.v
@@ -1,0 +1,54 @@
+// Check that non-blocking event control assignments with multiple events in the
+// event control expression are supported.
+
+module test;
+  reg failed = 1'b0;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED. Expected %d, got %d.", exp, val); \
+      failed = 1'b1; \
+    end
+
+  integer x = 0;
+
+  event e1, e2, e3;
+
+  initial begin
+    // Any of them should trigger the event
+    x <= @(e1 or e2 or e3) x + 1;
+    #1
+    `check(x, 0);
+    ->e1;
+    `check(x, 1);
+
+    x <= @(e1 or e2 or e3) x + 1;
+    #1
+    `check(x, 1);
+    ->e2;
+    `check(x, 2);
+
+    // Alternative syntax, but still the same behavior
+    x <= @(e1, e2, e3) x + 1;
+    #1
+    `check(x, 2);
+    ->e3;
+    `check(x, 3);
+
+    // In combination with repeat
+    x <= repeat(3) @(e1, e2, e3) x + 1;
+    #1
+    `check(x, 3);
+    ->e1;
+    `check(x, 3);
+    ->e2;
+    `check(x, 3);
+    ->e3;
+    `check(x, 4);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -677,6 +677,7 @@ named_event_no_edges	CE			ivltests
 nb_assign		normal			ivltests
 nb_delay		normal			ivltests
 nb_ec_concat		normal			ivltests
+nb_ec_multi_ev		normal			ivltests
 nblkorder		normal			ivltests # Validates Non-blocking order determinism
 negative_genvar		normal			ivltests
 negvalue		normal			ivltests gold=negvalue.gold

--- a/tgt-vvp/vvp_process.c
+++ b/tgt-vvp/vvp_process.c
@@ -505,6 +505,8 @@ static int show_stmt_assign_nb(ivl_statement_t net)
 			ev = ivl_stmt_events(net, idx);
 			fprintf(vvp_out, ", E_%p", ev);
 		  }
+
+		  fprintf(vvp_out, ";\n");
 		  snprintf(name, sizeof(name), "Eassign_%u", cascade_counter);
 		  cascade_counter += 1;
 	    }


### PR DESCRIPTION
When multiple events are used in a non-blocking event control they need to
be combined into a single event using `event/or`.
    
The generated `event/or` statement is missing the trailing semicolon and
newline, which results in parser error when vvp tries to run.
    
E.g.

```SystemVerilog
event e, f;
integer x;
x <= @(e or f) 10;
```
    
Add the missing semicolon and newline to fix this.