### PR TITLE
Add -R option to print runtime paths (for now, includedir only)

### DIFF
--- a/Documentation/usage/command_line_flags.rst
+++ b/Documentation/usage/command_line_flags.rst
@@ -242,6 +242,11 @@ These flags affect the general behavior of the compiler.
   version information, including version details for the various components of
   the compiler.
 
+* -R
+
+  Print the runtime paths of the compiler. This can be useful to find, e.g.,
+  the include path of vpi_user.h.
+
 * -W<warning class>
 
   Enable/disable warnings. All the warning types (other then "all") can be

--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -95,7 +95,7 @@ cfparse%c cfparse%h: $(srcdir)/cfparse%y
 	mv $*.d dep
 
 main.o: main.c globals.h $(srcdir)/../version_base.h ../version_tag.h Makefile
-	$(CC) $(CPPFLAGS) $(CFLAGS) @DEPENDENCY_FLAG@ -c -DIVL_ROOT='"@libdir@/ivl$(suffix)"' -DIVL_SUFFIX='"$(suffix)"' -DIVL_INC='"@includedir@"' -DIVL_LIB='"@libdir@"' -DDLLIB='"@DLLIB@"' $(srcdir)/main.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) @DEPENDENCY_FLAG@ -c -DIVL_ROOT='"@libdir@/ivl$(suffix)"' -DIVL_SUFFIX='"$(suffix)"' -DIVL_INC='"@includedir@"' -DIVL_LIB='"@libdir@"' -DDLLIB='"@DLLIB@"' -DIVL_INCLUDE_INSTALL_DIR="\"$(realpath $(DESTDIR)/$(includedir))\"" $(srcdir)/main.c
 	mv $*.d dep
 
 cflexor.o: cflexor.c cfparse.h

--- a/driver/iverilog.man.in
+++ b/driver/iverilog.man.in
@@ -4,7 +4,7 @@ iverilog - Icarus Verilog compiler
 
 .SH SYNOPSIS
 .B iverilog
-[\-EiSuVv] [\-Bpath] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
+[\-EiRSuVv] [\-Bpath] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
 [\-Pparameter=value] [\-pflag=value] [\-dname]
 [\-g1995\:|\-g2001\:|\-g2005\:|\-g2005-sv\:|\-g2009\:|\-g2012\:|\-g<feature>]
 [\-Iincludedir] [\-Lmoduledir] [\-mmodule] [\-M[mode=]file] [\-Nfile]
@@ -270,6 +270,9 @@ indirectly execute the compiler output file.
 .TP 8
 .B -V
 Print the version of the compiler, and exit.
+.TP 8
+.B -R
+Print the runtime paths of the compiler, and exit.
 .TP 8
 .B -W\fIclass\fP
 Turn on different classes of warnings. See the \fBWARNING TYPES\fP

--- a/driver/main.c
+++ b/driver/main.c
@@ -38,7 +38,7 @@ const char NOTICE[] =
 ;
 
 const char HELP[] =
-"Usage: iverilog [-EiSuvV] [-B base] [-c cmdfile|-f cmdfile]\n"
+"Usage: iverilog [-EiRSuvV] [-B base] [-c cmdfile|-f cmdfile]\n"
 "                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012] [-g<feature>]\n"
 "                [-D macro[=defn]] [-I includedir] [-L moduledir]\n"
 "                [-M [mode=]depfile] [-m module]\n"
@@ -1088,6 +1088,10 @@ static void find_ivl_root(void)
       strcat(ivl_root, ivl_lib_suffix);
 }
 
+static void print_runtime_paths(void) {
+	printf("includedir: %s\n", IVL_INCLUDE_INSTALL_DIR);
+}
+
 int main(int argc, char **argv)
 {
       int e_flag = 0;
@@ -1157,7 +1161,7 @@ int main(int argc, char **argv)
 	}
       }
 
-      while ((opt = getopt(argc, argv, "B:c:D:d:Ef:g:hl:I:iL:M:m:N:o:P:p:Ss:T:t:uvVW:y:Y:")) != EOF) {
+      while ((opt = getopt(argc, argv, "B:c:D:d:Ef:g:hl:I:iL:M:m:N:o:P:p:RSs:T:t:uvVW:y:Y:")) != EOF) {
 
 	    switch (opt) {
 		case 'B':
@@ -1243,6 +1247,10 @@ int main(int argc, char **argv)
 		case 'o':
 		  opath = optarg;
 		  break;
+
+		case 'R':
+		  print_runtime_paths();
+		  return 0;
 
 		case 'S':
 		  synth_flag = 1;


### PR DESCRIPTION
This allows for, e.g., a Makefile to find the location of vpi_user.h in a portable manner. Similar to pkgconfig.