### PR TITLE
Fix sscanf overflows

### DIFF
--- a/vpi/vhdl_textio.c
+++ b/vpi/vhdl_textio.c
@@ -188,7 +188,7 @@ static int read_vector(const char *string, s_vpi_value *val, vpiHandle var)
  */
 static int read_time(const char *string, s_vpi_value *val, PLI_INT32 scope_unit) {
     PLI_UINT64 period;
-    char units[2];
+    char units[3];
     int time_unit, processed_chars;
 
     if(sscanf(string, "%" PLI_UINT64_FMT " %2s%n", &period, units, &processed_chars) != 2)
@@ -720,7 +720,7 @@ static PLI_INT32 ivlh_read_calltf(ICARUS_VPI_CONST PLI_BYTE8*name)
 
         case FORMAT_BOOL:
         {
-            char buf[5];
+            char buf[6];
 
             val.format = vpiIntVal;
             if(sscanf(string, "%5s%n", buf, &processed_chars) == 1)


### PR DESCRIPTION
Without this fix, ivlh_textio was failing at step 11 where the time is read from the file. This was because clang happens to put period directly after the units buffer on the stack. sscanf writes the terminating NUL overwriting the low byte of period, which is 100, so it returns 0.

These were the only two points where clang identified an issue.

Example clang warning fixed:

warning: 'sscanf' may overflow; destination buffer in argument 4 has size 2, but the corresponding specifier may require size 3 [-Wfortify-source]