### PR TITLE
Refactoring of main() and fixed potential bug regarding std::map[]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# This is the root editorconfig
+root=true
+
+# Settings for all file types
+charset = utf-8
+end_of_line = lf
+
+# Configure settings for c++ code in all subdirs
+[**.{cc,h}]
+indent_style = space
+indent_size = 6
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Makefile.in
+++ b/Makefile.in
@@ -103,7 +103,7 @@ M = LineInfo.o StringHeap.o
 TT = t-dll.o t-dll-api.o t-dll-expr.o t-dll-proc.o t-dll-analog.o
 FF = cprop.o exposenodes.o nodangle.o synth.o synth2.o syn-rules.o
 
-O = main.o async.o design_dump.o discipline.o dup_expr.o elaborate.o \
+O = main.o logging.o async.o design_dump.o discipline.o dup_expr.o elaborate.o \
     elab_expr.o elaborate_analog.o elab_lval.o elab_net.o \
     elab_scope.o elab_sig.o elab_sig_analog.o elab_type.o \
     emit.o eval_attrib.o \

--- a/logging.cc
+++ b/logging.cc
@@ -1,0 +1,33 @@
+#include "logging.h"
+
+#include <algorithm>
+#include <cstdio>
+
+// By default only errors are logged
+static uint8_t severity_setting = 3;
+
+void log(LogSeverity severity, const char * message, ...) {
+      const uint8_t numeric_message_severity = static_cast<uint8_t>(severity);
+
+      // Don't log message with low severity if high severity was configured
+      if(numeric_message_severity < severity_setting) {
+            return;
+      }
+
+      // errors should be logged to stderr instead of stdout
+      FILE * outfd = numeric_message_severity < 3 ? stdout : stderr;
+
+      // Write message to stdout
+      va_list args;
+      va_start(args, message);
+      vfprintf(outfd, message, args);
+      va_end(args);
+}
+
+void set_min_log_severity(LogSeverity severity) {
+      set_min_log_severity(static_cast<uint8_t>(severity));
+}
+
+void set_min_log_severity(uint8_t severity) {
+      severity_setting = severity;
+}

--- a/logging.h
+++ b/logging.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdarg.h>
+#include <cstdint>
+
+// Log Severity is organized in 4 levels:
+//    0 / Debug   : log info + log internal information that is exclusively useful to developers with access to and knowledge of the code
+//    1 / Info    : log warnings + log internal information that might be interesting to some users in special situations. This is equivalent to what used to be logged with verbose_flag.
+//    2 / Warning : log errors + logs warnings for cases where there might be an error
+//    3 / Error   : only log errors that result in termination of the verilog simulation
+enum class LogSeverity {
+      Debug,
+      Info,
+      Warning,
+      Error
+};
+
+void log(LogSeverity severity, const char * message, ...);
+void set_min_log_severity(LogSeverity severity);
+void set_min_log_severity(uint8_t severity);


### PR DESCRIPTION
This is a small pull request to improve code quality: For now I only refactored the main() function to make it more readable. I plan to do further refactorings in this style in the future.

I also fixed a small (potential) bug with the usage of std::map's []-operator. See commit message for details.

My plan for the near-ish future is to do the following wherever it makes sense to do so:
- get rid of `goto` (found one in main, but there are dozens throughout the code)
- improve clarity of data-flow by reducing number of global variables
- get rid of unnecessary `extern` variables/functions/things through the use of headers
- split huge functions that do several different things into smaller functions that each do only one thing
- split huge files with several classes into several files with one class each (netlist.h contains declarations for 152 different classes)
- many other small things to reduce cognitive load during development

To accomplish this, I'd like to know which C++ version I should target? Is C++ 20 ok?