### PR TITLE
ci: Remove the Ubuntu 18.04 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          '18.04',
-          '20.04'
+          '20.04',
+          '22.04'
         ]
     runs-on: ubuntu-${{ matrix.os }}
     name: '🐧 Ubuntu ${{ matrix.os }}'


### PR DESCRIPTION
Github has [announced](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) that it is going to remove support for the Ubuntu 18.04 runner. It will start introducing temporary failures at increasing frequency in October 22 and completely remove support for it in April 23.


To avoid CI failing remove the Ubuntu 18.04 runner and add the 22.04 runner instead.