### PR TITLE
Add support for SystemVerilog sign cast

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -156,6 +156,12 @@ PECastType::~PECastType()
 {
 }
 
+PECastSign::PECastSign(bool signed_flag, PExpr *base)
+: base_(base)
+{
+    signed_flag_ = signed_flag;
+}
+
 PEBComp::PEBComp(char op, PExpr*l, PExpr*r)
 : PEBinary(op, l, r)
 {

--- a/PExpr.h
+++ b/PExpr.h
@@ -23,6 +23,7 @@
 # include  <string>
 # include  <vector>
 # include  <valarray>
+# include  <memory>
 # include  "netlist.h"
 # include  "verinum.h"
 # include  "LineInfo.h"
@@ -1010,6 +1011,26 @@ class PECastType  : public PExpr {
       data_type_t* target_;
       ivl_type_t target_type_;
       PExpr* base_;
+};
+
+/*
+ * Support the SystemVerilog sign cast.
+ */
+class PECastSign : public PExpr {
+
+    public:
+      explicit PECastSign(bool signed_flag, PExpr *base);
+      ~PECastSign() = default;
+
+      void dump(std::ostream &out) const;
+
+      NetExpr* elaborate_expr(Design *des, NetScope *scope,
+			      unsigned expr_wid, unsigned flags) const;
+
+      unsigned test_width(Design *des, NetScope *scope, width_mode_t &mode);
+
+    private:
+      std::unique_ptr<PExpr> base_;
 };
 
 /*

--- a/ivtest/ivltests/sv_sign_cast1.v
+++ b/ivtest/ivltests/sv_sign_cast1.v
@@ -1,0 +1,30 @@
+// Check that sign casts have the expected results when the value gets width
+// extended.
+
+module test;
+  bit failed = 1'b0;
+  reg [7:0] val;
+  reg signed [7:0] sval;
+
+  `define check(val, exp) \
+    if (exp !== val) begin \
+      $display("FAILED(%0d). Got %b, expected %b.", `__LINE__, val, exp); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    // An unsized number has an implicit width of integer width.
+    val = unsigned'(-4);
+    `check(val, 8'hfc);
+
+    val = unsigned'(-4'sd4);
+    `check(val, 8'h0c);
+
+    sval = signed'(4'hc);
+    `check(sval, -4);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_sign_cast2.v
+++ b/ivtest/ivltests/sv_sign_cast2.v
@@ -1,0 +1,74 @@
+// Check that unsigned arguments to a sign cast are evaluated as self-determined.
+
+module test;
+
+  reg [3:0] op1;
+  reg [2:0] op2;
+  reg [7:0] result;
+  bit failed = 1'b0;
+
+  `define check(val, exp) \
+    if (exp !== val) begin \
+      $display("FAILED(%0d). Got %b, expected %b.", `__LINE__, val, exp); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    // Addition tests
+    op1 = 4'b1111; op2 = 3'b111;
+    result = 8'sd0 + signed'(op1 + op2);
+    `check(result, 8'b00000110);
+    result = 8'sd0 + unsigned'(op1 + op2);
+    `check(result, 8'b00000110);
+
+    op1 = 4'b1000; op2 = 3'b011;
+    result = 8'sd0 + signed'(op1 + op2);
+    `check(result, 8'b11111011);
+    result = 8'sd0 + unsigned'(op1 + op2);
+    `check(result, 8'b00001011);
+
+    // Multiply tests
+    op1 = 4'b0101; op2 = 3'b100;
+    result = 8'sd0 + signed'(op1 * op2);
+    `check(result, 8'b00000100);
+    result = 8'sd0 + unsigned'(op1 * op2);
+    `check(result, 8'b00000100);
+
+    op1 = 4'b0010; op2 = 3'b100;
+    result = 8'sd0 + signed'(op1 * op2);
+    `check(result, 8'b11111000);
+    result = 8'sd0 + unsigned'(op1 * op2);
+    `check(result, 8'b00001000);
+
+    // Left ASR tests
+    op1 = 4'b1010;
+    result = 8'sd0 + signed'(op1 <<< 1);
+    `check(result, 8'b00000100);
+    result = 8'sd0 + unsigned'(op1 <<< 1);
+    `check(result, 8'b00000100);
+
+    op1 = 4'b0101;
+    result = 8'sd0 + signed'(op1 <<< 1);
+    `check(result, 8'b11111010);
+    result = 8'sd0 + unsigned'(op1 <<< 1);
+    `check(result, 8'b00001010);
+
+    // Right ASR tests
+    op1 = 4'b1010;
+    result = 8'sd0 + signed'(op1 >>> 1);
+    `check(result, 8'b00000101);
+    result = 8'sd0 + unsigned'(op1 >>> 1);
+    `check(result, 8'b00000101);
+
+    op1 = 4'b1010;
+    result = 8'sd0 + signed'(op1 >>> 0);
+    `check(result, 8'b11111010);
+    result = 8'sd0 + unsigned'(op1 >>> 0);
+    `check(result, 8'b00001010);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_sign_cast3.v
+++ b/ivtest/ivltests/sv_sign_cast3.v
@@ -1,0 +1,75 @@
+// Check that signed arguments to a sign cast are evaluated as self-determined.
+
+module test;
+
+  reg signed [3:0] op1;
+  reg signed [2:0] op2;
+  reg [7:0] result;
+  bit failed = 1'b0;
+
+  `define check(val, exp) \
+    if (exp !== val) begin \
+      $display("FAILED(%0d). Got %b, expected %b.", `__LINE__, val, exp); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+
+    // Addition tests
+    op1 = 4'b1111; op2 = 3'b111;
+    result = 8'sd0 + signed'(op1 + op2);
+    `check(result, 8'b11111110);
+    result = 8'sd0 + unsigned'(op1 + op2);
+    `check(result, 8'b00001110);
+
+    op1 = 4'b1000; op2 = 3'b011;
+    result = 8'sd0 + signed'(op1 + op2);
+    `check(result, 8'b11111011);
+    result = 8'sd0 + unsigned'(op1 + op2);
+    `check(result, 8'b00001011);
+
+    // Multiply tests
+    op1 = 4'b0101; op2 = 3'b100;
+    result = 8'sd0 + signed'(op1 * op2);
+    `check(result, 8'b11111100);
+    result = 8'sd0 + unsigned'(op1 * op2);
+    `check(result, 8'b00001100);
+
+    op1 = 4'b0010; op2 = 3'b100;
+    result = 8'sd0 + signed'(op1 * op2);
+    `check(result, 8'b11111000);
+    result = 8'sd0 + unsigned'(op1 * op2);
+    `check(result, 8'b00001000);
+
+    // Left ASR tests
+    op1 = 4'b1010;
+    result = 8'sd0 + signed'(op1 <<< 1);
+    `check(result, 8'b00000100);
+    result = 8'sd0 + unsigned'(op1 <<< 1);
+    `check(result, 8'b00000100);
+
+    op1 = 4'b0101;
+    result = 8'sd0 + signed'(op1 <<< 1);
+    `check(result, 8'b11111010);
+    result = 8'sd0 + unsigned'(op1 <<< 1);
+    `check(result, 8'b00001010);
+
+    // Right ASR tests
+    op1 = 4'b0101;
+    result = 8'sd0 + signed'(op1 >>> 1);
+    `check(result, 8'b00000010);
+    result = 8'sd0 + unsigned'(op1 >>> 1);
+    `check(result, 8'b00000010);
+
+    op1 = 4'b1010;
+    result = 8'sd0 + signed'(op1 >>> 1);
+    `check(result, 8'b11111101);
+    result = 8'sd0 + unsigned'(op1 >>> 1);
+    `check(result, 8'b00001101);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -628,6 +628,9 @@ sv_queue_vec_fail	CE,-g2009		ivltests gold=sv_queue_vec_fail.gold
 sv_root_class		normal,-g2009		ivltests gold=sv_root_class.gold
 sv_root_func		normal,-g2009		ivltests gold=sv_root_func.gold
 sv_root_task		normal,-g2009		ivltests gold=sv_root_task.gold
+sv_sign_cast1		normal,-g2005-sv	ivltests
+sv_sign_cast2		normal,-g2005-sv	ivltests
+sv_sign_cast3		normal,-g2005-sv	ivltests
 sv_string1		normal,-g2009		ivltests
 sv_string2		normal,-g2009		ivltests
 sv_string3		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -1034,6 +1034,9 @@ shift4			normal,-pallowsigned=1	ivltests
 signed5			normal,-pallowsigned=1	ivltests
 signed10		normal,-pallowsigned=1	ivltests gold=signed10.gold
 signed13		normal,-pallowsigned=1	ivltests
+sv_sign_cast1		normal,-g2005-sv,-pallowsigned=1 ivltests
+sv_sign_cast2		normal,-g2005-sv,-pallowsigned=1 ivltests
+sv_sign_cast3		normal,-g2005-sv,-pallowsigned=1 ivltests
 # Also tests have different output because of file name/line, etc. differences.
 readmem-error		normal,-pallowsigned=1	ivltests gold=readmem-error-vlog95.gold
 

--- a/parse.y
+++ b/parse.y
@@ -4045,6 +4045,16 @@ expr_primary
 	      $$ = base;
 	}
       }
+  | signing '\'' '(' expression ')'
+      { PExpr*base = $4;
+	if (pform_requires_sv(@1, "Signing cast")) {
+	      PECastSign*tmp = new PECastSign($1, base);
+	      FILE_NAME(tmp, @1);
+	      $$ = tmp;
+	} else {
+	      $$ = base;
+	}
+      }
 
   /* Aggregate literals are primaries. */
 

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -420,6 +420,15 @@ void PECastType::dump(ostream &out) const
       out << ")";
 }
 
+void PECastSign::dump(ostream &out) const
+{
+      if (!signed_flag_)
+	    out << "un";
+      out << "signed'(";
+      base_->dump(out);
+      out << ")";
+}
+
 void PEEvent::dump(ostream&out) const
 {
       switch (type_) {


### PR DESCRIPTION
SystemVerilog supports sign cast where it is possible to change the
signedness of an expression. Syntactical it is similar to width or type
casting, except that the keywords 'signed' or 'unsigned' are used in front
of the cast operator. E.g.

```SystemVerilog
  logic [3:0] a = 4'b1000;
  logic [7:0] b = signed'(a); // b is 8'b11111000;
  logic signed [3:0] c = 4'b1000;
  logic signed [7:0] d = unsigned'(c); // d is 8'b00001000;
```

As noted by the LRM section 6.24.1 ("Cast operator") applying a sign cast
to an expression is equivalent to calling the $signed() and $unsigned()
system functions on the expression.

This resolves #513.