### PR TITLE
Support default port values in port declarations lists

### DIFF
--- a/ivtest/ivltests/module_inout_port_list_def.v
+++ b/ivtest/ivltests/module_inout_port_list_def.v
@@ -1,0 +1,22 @@
+// Check that it is an error to specify a default value for inout port
+// declarations.
+
+module M (
+  inout [31:0] x, y = 1 // inout ports do not support default values
+);
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule
+
+module test;
+
+  wire [31:0] x, y;
+
+  M i_m (
+    .x(x),
+    .y(y)
+  );
+
+endmodule

--- a/ivtest/ivltests/module_input_port_list_def.v
+++ b/ivtest/ivltests/module_input_port_list_def.v
@@ -1,0 +1,31 @@
+// Check that it is possible to specify a default port value for each port in a
+// input port declaration list.
+
+module M (
+  input [31:0] x = 1, y = 2
+);
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d): %s, expected %0h got %0h", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  reg failed = 1'b0;
+
+  initial begin
+    `check(x, 1)
+    `check(y, 2)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule
+
+module test;
+
+  M i_m ();
+
+endmodule

--- a/ivtest/ivltests/module_output_port_list_def.v
+++ b/ivtest/ivltests/module_output_port_list_def.v
@@ -1,0 +1,31 @@
+// Check that it is possible to specify a default port value for each port in a
+// output port declaration list.
+
+module M (
+  output [31:0] x = 1, y = 2
+);
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d): %s, expected %0h got %0h", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  reg failed = 1'b0;
+
+  initial begin
+    `check(x, 1)
+    `check(y, 2)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule
+
+module test;
+
+  M i_m ();
+
+endmodule

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -78,6 +78,7 @@ br_gh567		normal			ivltests
 check_constant_3	normal			ivltests
 function4		normal			ivltests
 module_inout_port_type	normal			ivltests
+module_input_port_list_def normal,-g2005-sv	ivltests
 module_input_port_type	normal			ivltests
 parameter_in_generate1	normal			ivltests
 parameter_no_default	normal			ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -651,7 +651,9 @@ mixed_width_case	normal			ivltests
 modparam		normal			ivltests top # Override parameter via passed down value
 module3.12A		normal			ivltests main
 module3.12B		normal			ivltests
+module_inout_port_list_def CE			ivltests # inout ports do not support default values
 module_inout_port_type	CE			ivltests
+module_input_port_list_def CE			ivltests # input ports only support default values in SV
 module_input_port_type	CE			ivltests
 module_nonansi_integer1	normal			ivltests
 module_nonansi_integer2	normal			ivltests
@@ -659,6 +661,7 @@ module_nonansi_time1	normal			ivltests
 module_nonansi_time2	normal			ivltests
 module_nonansi_vec1	normal			ivltests
 module_nonansi_vec2	normal			ivltests
+module_output_port_list_def normal		ivltests
 module_output_port_var1	normal			ivltests
 module_output_port_var2	normal			ivltests
 module_port_range_mismatch CE			ivltests

--- a/parse.y
+++ b/parse.y
@@ -4524,7 +4524,7 @@ port_declaration
 	}
 	ptmp = pform_module_port_reference(@2, name);
 	pform_module_define_port(@2, name, NetNet::POUTPUT, use_type, $4, $1);
-	port_declaration_context.port_type = NetNet::PINOUT;
+	port_declaration_context.port_type = NetNet::POUTPUT;
 	port_declaration_context.port_net_type = use_type;
 	port_declaration_context.data_type = $4;
 

--- a/parse.y
+++ b/parse.y
@@ -4332,13 +4332,29 @@ list_of_port_declarations
 		  tmp->push_back($3);
 		  $$ = tmp;
 		}
-	| list_of_port_declarations ',' IDENTIFIER
+	| list_of_port_declarations ',' IDENTIFIER initializer_opt
 		{ Module::port_t*ptmp;
 		  perm_string name = lex_strings.make($3);
 		  ptmp = pform_module_port_reference(@3, name);
 		  std::vector<Module::port_t*>*tmp = $1;
 		  tmp->push_back(ptmp);
 
+		  if ($4) {
+		        switch (port_declaration_context.port_type) {
+		            case NetNet::PINOUT:
+			      yyerror(@4, "error: Default port value not allowed for inout ports.");
+			      break;
+			    case NetNet::PINPUT:
+			      pform_requires_sv(@4, "Default port value");
+			      ptmp->default_value = $4;
+			      break;
+			    case NetNet::POUTPUT:
+			      pform_make_var_init(@3, name, $4);
+			      break;
+			    default:
+			      break;
+			}
+		  }
 		    /* Get the port declaration details, the port type
 		       and what not, from context data stored by the
 		       last port_declaration rule. */


### PR DESCRIPTION
Both Verilog (2005) and SystemVerilog support default port values for
variable output ports. SystemVerilog also supports default port values for
input ports. For port declaration lists it is possible to specify the
default value for port identifier.

E.g.

```systemverilog
module M (
  input integer x, y = 1,
  output integer z, w = 2
) ...
```

Currently the parser only supports specifying the default value for the
first identifier in the list. Extend the parser to also allow to specify
the default value for identifiers in the list.

This resolves #754.