### PR TITLE
Remove unused functions/methods

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -53,11 +53,6 @@ bool PExpr::has_aa_term(Design*, NetScope*) const
       return false;
 }
 
-bool PExpr::is_the_same(const PExpr*that) const
-{
-      return typeid(this) == typeid(that);
-}
-
 NetNet* PExpr::elaborate_lnet(Design*, NetScope*) const
 {
       cerr << get_fileline() << ": error: "
@@ -512,15 +507,6 @@ PENumber::~PENumber()
 const verinum& PENumber::value() const
 {
       return *value_;
-}
-
-bool PENumber::is_the_same(const PExpr*that) const
-{
-      const PENumber*obj = dynamic_cast<const PENumber*>(that);
-      if (obj == 0)
-	    return false;
-
-      return *value_ == *obj->value_;
 }
 
 PEString::PEString(char*s)

--- a/PExpr.h
+++ b/PExpr.h
@@ -180,11 +180,6 @@ class PExpr : public LineInfo {
       virtual bool is_collapsible_net(Design*des, NetScope*scope,
                                       NetNet::PortType port_type) const;
 
-	// This method returns true if that expression is the same as
-	// this expression. This method is used for comparing
-	// expressions that must be structurally "identical".
-      virtual bool is_the_same(const PExpr*that) const;
-
     protected:
       unsigned fix_width_(width_mode_t mode);
 
@@ -638,8 +633,6 @@ class PENumber : public PExpr {
 					 NetScope*scope,
 					 bool is_cassign,
 					 bool is_force) const;
-
-      virtual bool is_the_same(const PExpr*that) const;
 
     private:
       verinum*const value_;

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -250,11 +250,6 @@ ivl_variable_type_t NetEConcat::expr_type() const
       return expr_type_;
 }
 
-bool NetEConcat::has_width() const
-{
-      return true;
-}
-
 void NetEConcat::set(unsigned idx, NetExpr*e)
 {
       assert(idx < parms_.size());
@@ -292,11 +287,6 @@ NetECReal::~NetECReal()
 const verireal& NetECReal::value() const
 {
       return value_;
-}
-
-bool NetECReal::has_width() const
-{
-      return true;
 }
 
 ivl_variable_type_t NetECReal::expr_type() const
@@ -471,11 +461,6 @@ ivl_variable_type_t NetESelect::expr_type() const
 const netenum_t* NetESelect::enumeration() const
 {
       return dynamic_cast<const netenum_t*> (use_type_);
-}
-
-bool NetESelect::has_width() const
-{
-      return true;
 }
 
 NetESFunc::NetESFunc(const char*n, ivl_variable_type_t t,

--- a/net_func.cc
+++ b/net_func.cc
@@ -50,24 +50,6 @@ NetUserFunc::~NetUserFunc()
 {
 }
 
-ivl_variable_type_t NetUserFunc::data_type(unsigned port) const
-{
-      NetFuncDef*fdef = def_->func_def();
-
-	/* Port 0 is the return port. */
-      if (port == 0) {
-	    const NetNet*sig = fdef->return_sig();
-	    assert(sig);
-	    return sig->data_type();
-      }
-
-      port -= 1;
-      assert(port < fdef->port_count());
-      const NetNet*port_sig = fdef->port(port);
-
-      return port_sig->data_type();
-}
-
 unsigned NetUserFunc::port_width(unsigned port) const
 {
       NetFuncDef*fdef = def_->func_def();

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -77,17 +77,6 @@ netenum_t* Definitions::enumeration_for_key(const enum_type_t*key) const
 }
 
 /*
- * This locates the enumeration TYPE for the given enumeration literal.
- */
-const netenum_t*Definitions::enumeration_for_name(perm_string name)
-{
-      NetEConstEnum*tmp = enum_names_[name];
-      assert(tmp != 0);
-
-      return tmp->enumeration();
-}
-
-/*
  * This locates the VALUE for the given enumeration literal.
  */
 const NetExpr* Definitions::enumeration_expr(perm_string key)
@@ -270,31 +259,6 @@ NetScope*NetScope::find_typedef_scope(const Design*des, data_type_t*type)
       }
 
       return 0;
-}
-
-/*
- * Look for the enumeration in the current scope and any parent scopes.
- */
-const netenum_t*NetScope::find_enumeration_for_name(const Design*des, perm_string name)
-{
-      NetScope *cur_scope = this;
-      while (cur_scope) {
-	    NetEConstEnum*tmp = cur_scope->enum_names_[name];
-	    if (tmp) break;
-	    NetScope*import_scope = cur_scope->find_import(des, name);
-	    if (import_scope)
-		  cur_scope = import_scope;
-	    else if (cur_scope == unit_)
-		  return 0;
-	    else
-		  cur_scope = cur_scope->parent();
-
-	    if (cur_scope == 0)
-		  cur_scope = unit_;
-      }
-
-      assert(cur_scope);
-      return cur_scope->enum_names_[name]->enumeration();
 }
 
 /*

--- a/netlist.h
+++ b/netlist.h
@@ -2187,9 +2187,6 @@ class NetECReal  : public NetExpr {
 
       const verireal&value() const;
 
-	// This type has no self-determined width. This is false.
-      virtual bool has_width() const;
-
 	// The type of this expression is ET_REAL
       ivl_variable_type_t expr_type() const;
 
@@ -4401,7 +4398,6 @@ class NetEConcat  : public NetExpr {
       virtual ivl_variable_type_t expr_type() const;
       virtual NexusSet* nex_input(bool rem_out = true, bool always_sens = false,
                                   bool nested_func = false) const;
-      virtual bool has_width() const;
       virtual NetEConcat* dup_expr() const;
       virtual NetEConst*  eval_tree();
       virtual NetExpr* evaluate_function(const LineInfo&loc,
@@ -4458,7 +4454,6 @@ class NetESelect  : public NetExpr {
 
       virtual NexusSet* nex_input(bool rem_out = true, bool always_sens = false,
                                   bool nested_func = false) const;
-      virtual bool has_width() const;
       virtual void expr_scan(struct expr_scan_t*) const;
       virtual NetEConst* eval_tree();
       virtual NetExpr*evaluate_function(const LineInfo&loc,

--- a/netlist.h
+++ b/netlist.h
@@ -886,10 +886,6 @@ class Definitions {
 
       bool add_enumeration_name(netenum_t*enum_set, perm_string enum_name);
 
-	// Look up the enumeration literal in this scope. if the name
-	// is present, then return the enumeration type that declares it.
-      const netenum_t* enumeration_for_name(perm_string name);
-
 	// Look up the enumeration set that was added with the given
 	// key. This is used by enum_type_t::elaborate_type to locate
 	// a previously elaborated enumeration.
@@ -948,10 +944,6 @@ class NetScope : public Definitions, public Attrib {
 
         /* Search the scope hierarchy for the scope where 'type' was defined. */
       NetScope*find_typedef_scope(const Design*des, data_type_t*type);
-
-	/* Routine to search for the enumeration given a name. It basically
-	 * does what enumeration_for_name() does but searched the hierarchy. */
-      const netenum_t*find_enumeration_for_name(const Design*des, perm_string name);
 
 	/* Parameters exist within a scope, and these methods allow
 	   one to manipulate the set. In these cases, the name is the

--- a/netlist.h
+++ b/netlist.h
@@ -1919,7 +1919,6 @@ class NetUserFunc  : public NetNode {
       NetUserFunc(NetScope*s, perm_string n, NetScope*def, NetEvWait*trigger__);
       ~NetUserFunc();
 
-      ivl_variable_type_t data_type(unsigned port) const;
       unsigned port_width(unsigned port) const;
 
       const NetScope* def() const;

--- a/parse.y
+++ b/parse.y
@@ -149,17 +149,6 @@ static std::list<pform_port_t>* make_port_list(list<pform_port_t>*tmp,
       return tmp;
 }
 
-list<pform_range_t>* make_range_from_width(uint64_t wid)
-{
-      pform_range_t range;
-      range.first  = new PENumber(new verinum(wid-1, integer_width));
-      range.second = new PENumber(new verinum((uint64_t)0, integer_width));
-
-      std::list<pform_range_t>*rlist = new std::list<pform_range_t>;
-      rlist->push_back(range);
-      return rlist;
-}
-
 static std::list<perm_string>* list_from_identifier(char*id)
 {
       std::list<perm_string>*tmp = new std::list<perm_string>;

--- a/pform.h
+++ b/pform.h
@@ -97,7 +97,6 @@ struct parmvalue_t {
 struct str_pair_t { ivl_drive_t str0, str1; };
 
 
-extern std::list<pform_range_t>* make_range_from_width(uint64_t wid);
 extern std::list<pform_range_t>* copy_range(std::list<pform_range_t>* orig);
 
   /* Use this function to transform the parted form of the attribute


### PR DESCRIPTION
Remove a few unused or unnecessary functions and methods.Most of these had users at some point, but all the users have been removed.

- `PExpr::is_the_same()`
- `NetUserFunc::data_type()`
- `make_range_from_width()`
- `{find_,}enumeration_for_name()`
- Unnecessary overrides of `NetExpr::has_width()` in `NetEConcat`, `NetECReal` and `NetESelect`