### PR TITLE
Handle unpacked dimensions for struct and union members

### DIFF
--- a/elab_type.cc
+++ b/elab_type.cc
@@ -215,7 +215,8 @@ ivl_type_t struct_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 
 		  netstruct_t::member_t memb;
 		  memb.name = namep->name;
-		  memb.net_type = mem_vec;
+		  memb.net_type = elaborate_array_type(des, scope, *this,
+						       mem_vec, namep->index);
 		  res->append_member(des, memb);
 	    }
       }

--- a/ivtest/ivltests/struct_packed_darray_fail.v
+++ b/ivtest/ivltests/struct_packed_darray_fail.v
@@ -1,0 +1,14 @@
+// Check that declaring a dynamic array typed member in a packed struct is an
+// error.
+
+module test;
+
+  struct packed {
+    int x[];
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/struct_packed_queue_fail.v
+++ b/ivtest/ivltests/struct_packed_queue_fail.v
@@ -1,0 +1,13 @@
+// Check that declaring a queue typed member in a packed struct is an error.
+
+module test;
+
+  struct packed {
+    int x[$];
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/struct_packed_uarray_fail.v
+++ b/ivtest/ivltests/struct_packed_uarray_fail.v
@@ -1,0 +1,14 @@
+// Check that declaring an unpacked array typed member in a packed struct is an
+// error.
+
+module test;
+
+  struct packed {
+    int x[2];
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/union_packed_darray_fail.v
+++ b/ivtest/ivltests/union_packed_darray_fail.v
@@ -1,0 +1,14 @@
+// Check that declaring a dynamic array typed member in a packed union is an
+// error.
+
+module test;
+
+  union packed {
+    int x[];
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/union_packed_queue_fail.v
+++ b/ivtest/ivltests/union_packed_queue_fail.v
@@ -1,0 +1,14 @@
+// Check that declaring a queue typed member in a packed union is an
+// error.
+
+module test;
+
+  union packed {
+    int x[$];
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/union_packed_uarray_fail.v
+++ b/ivtest/ivltests/union_packed_uarray_fail.v
@@ -1,0 +1,15 @@
+// Check that declaring an unpacked array typed member in a packed union is an
+// error.
+
+module test;
+
+  struct packed {
+    int x;
+    shortint y[2];
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -470,8 +470,11 @@ struct_line_info	CE,-g2009		ivltests gold=struct_line_info.gold
 struct_member_signed	normal,-g2009		ivltests
 struct_packed_array	normal,-g2009		ivltests
 struct_packed_array2	normal,-g2009		ivltests
+struct_packed_darray_fail CE,-g2009		ivltests
+struct_packed_queue_fail CE,-g2009		ivltests
 struct_packed_sysfunct	normal,-g2009		ivltests
 struct_packed_sysfunct2	normal,-g2009		ivltests
+struct_packed_uarray_fail CE,-g2009		ivltests
 struct_packed_write_read2	normal,-g2009	ivltests
 struct_invalid_member	CE,-g2009		ivltests gold=struct_invalid_member.gold
 struct_signed		normal,-g2009		ivltests
@@ -752,6 +755,9 @@ ubyte_test		normal,-g2005-sv	ivltests
 uint_test		normal,-g2005-sv	ivltests
 ulongint_test		normal,-g2005-sv	ivltests
 undef_lval_select_SV	normal,-g2009		ivltests
+union_packed_darray_fail CE,-g2009		ivltests
+union_packed_queue_fail	CE,-g2009		ivltests
+union_packed_uarray_fail CE,-g2009		ivltests
 unp_array_typedef	normal,-g2005-sv	ivltests
 packed_dims_invalid_class CE,-g2005-sv		ivltests
 packed_dims_invalid_module CE,-g2005-sv		ivltests


### PR DESCRIPTION
Unpacked dimensions for struct or union members are currently silently
discarded. E.g.

```SystemVerilog
struct packed { int x[2]; } s;
```

will elaborate successfully as a struct with a non-array int typed field.

This should instead elaborate to an unpacked array of ints typed field. And
subsequently, since unpacked arrays are not allowed in a packed struct or
union, result in an error instead.