### PR TITLE
tgt-vlog95: Consider scopes with only localparams as unique

### DIFF
--- a/t-dll.cc
+++ b/t-dll.cc
@@ -507,7 +507,8 @@ void dll_target::make_scope_parameters(ivl_scope_t scop, const NetScope*net)
 	    assert(idx < scop->param.size());
 	    ivl_parameter_t cur_par = &scop->param[idx];
 	    cur_par->basename = cur_pit->first;
-            cur_par->local = cur_pit->second.local_flag;
+	    cur_par->local = cur_pit->second.local_flag ||
+			     !cur_pit->second.overridable;
 	    calculate_param_range(cur_pit->second,
 				  cur_pit->second.ivl_type,
 				  cur_par->msb, cur_par->lsb,

--- a/tgt-vlog95/scope.c
+++ b/tgt-vlog95/scope.c
@@ -253,13 +253,27 @@ static void emit_net_def(ivl_scope_t scope, ivl_signal_t sig)
       }
 }
 
+static bool scope_is_unique(ivl_scope_t scope)
+{
+      unsigned int count = ivl_scope_params(scope);
+
+      for (unsigned int idx = 0; idx < count; idx++) {
+	    ivl_parameter_t par = ivl_scope_param(scope, idx);
+	    if (!ivl_parameter_local(par)) {
+		  return false;
+	    }
+      }
+
+      return true;
+}
+
 static void emit_mangled_name(ivl_scope_t scope, unsigned root)
 {
-	/* If the module has parameters and it's not a root module then it
-	 * may not be unique so we create a mangled name version instead.
-	 * The mangled name is of the form:
+	/* If the module has non-local parameters and it's not a root module then it
+	 * may not be unique so we create a mangled name version instead. The
+	 * mangled name is of the form:
 	 *   <module_name>[<full_instance_scope>]. */
-      if (ivl_scope_params(scope) && ! root) {
+      if (!root && !scope_is_unique(scope)) {
 	    char *name;
 	    size_t len = strlen(ivl_scope_name(scope)) +
 	                 strlen(ivl_scope_tname(scope)) + 3;
@@ -1244,7 +1258,7 @@ int emit_scope(ivl_scope_t scope, ivl_scope_t parent)
 			(void) emit_scope(scope_to_emit, 0);
 			  /* If we used a mangled name then the instance is
 			   * unique so don't add it to the list. */
-			if (ivl_scope_params(scope_to_emit)) continue;
+			if (!scope_is_unique(scope_to_emit)) continue;
 			add_scope_to_list(scope_to_emit);
 		  }
 		  free(scopes_to_emit);


### PR DESCRIPTION
For modules with parameters the vlog95 backend generates one module
declaration for each module instance. This is done so that different values
for the module parameters can be supported.

Local parameters are guaranteed to have the same value for all module
instances though. Add support for detecting the case that all module
parameters are local parameters and in that case only create one shared
module declaration. This is similar to what the vhdl backend does.