### PR TITLE
ci: Upgrade macOS runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,8 @@ jobs:
   mac:
     strategy:
       fail-fast: false
-      matrix:
-        os: [
-          '10.15'
-        ]
-    runs-on: macos-${{ matrix.os }}
-    name: '🍏 macos ${{ matrix.os }}'
+    runs-on: macos-latest
+    name: '🍏 macOS'
     steps:
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
Github had [deprecated MacOS 10.15 runner](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/) and it has now been removed and the corresponding test always fails. Similar to the Windows runner use the `latest` version to auto-upgrade the environment to a supported version.