### PR TITLE
Support class objects as function return values 

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -2783,10 +2783,14 @@ NetExpr* PECallFunction::elaborate_expr_(Design*des, NetScope*scope,
 NetExpr* PECallFunction::elaborate_expr(Design*des, NetScope*scope,
 					ivl_type_t type, unsigned flags) const
 {
-//cerr << "HERE: " << scope->basename() << ", " << *type << endl;
       const netdarray_t*darray = dynamic_cast<const netdarray_t*>(type);
-      assert(darray);
-      return elaborate_expr(des, scope, darray->element_type()->packed_width(), flags);
+      unsigned int width = 1;
+        // Icarus allows a dynamic array to be initialised with a single
+        // elementary value, in that case the expression needs to be evaluated
+        // with the rigth width.
+      if (darray)
+	    width = darray->element_type()->packed_width();
+      return elaborate_expr(des, scope, width, flags);
 }
 
 NetExpr* PECallFunction::elaborate_base_(Design*des, NetScope*scope, NetScope*dscope,

--- a/ivtest/ivltests/sv_class_return.v
+++ b/ivtest/ivltests/sv_class_return.v
@@ -1,0 +1,29 @@
+// Check that functions returning a class object are supported
+
+module test;
+
+  class C;
+    int i;
+    task t;
+      if (i == 10) begin
+        $display("PASSED");
+      end else begin
+        $display("FAILED");
+      end
+    endtask
+  endclass
+
+  function C f;
+    C c;
+    c = new;
+    c.i = 10;
+    return c;
+  endfunction
+
+  initial begin
+    C c;
+    c = f();
+    c.t;
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -532,6 +532,7 @@ sv_class_property_signed1	normal,-g2009	ivltests
 sv_class_property_signed2	normal,-g2009	ivltests
 sv_class_property_signed3	normal,-g2009	ivltests
 sv_class_property_signed4	normal,-g2009	ivltests
+sv_class_return		normal,-g2009		ivltests
 sv_class_static_prop1	normal,-g2009		ivltests
 sv_class_static_prop2	normal,-g2009		ivltests
 sv_class_static_prop3	normal,-g2009		ivltests


### PR DESCRIPTION
There is nothing special to do for return class objects from a function.
They can be handled the same as other objects such as dynamic arrays and
queues.

But there currently is an assert in the code that handles function calls
assigned to objects that will trigger if the target type is not an queue or
dynamic array.

This is because Icarus allows dynamic arrays to be initialized with a
single value and for that the element with of the dynamic array needs to be
known, so the single value expression can be evaluated correctly.

Since classes can not be initialized from vector expressions the width does
not matter in that case.

Update the code to only query the element width if the target type is an
dynamic array or queue and pass a placeholder value of 1 for the width
otherwise.