### PR TITLE
Allow package scoped functions to be called without arguments 

### DIFF
--- a/ivtest/ivltests/sv_ps_function1.v
+++ b/ivtest/ivltests/sv_ps_function1.v
@@ -1,0 +1,20 @@
+// Check that it is possible to call a package scoped function.
+
+package P;
+  function integer T(integer x, integer y);
+    return x + y;
+  endfunction
+endpackage
+
+module test;
+  initial begin
+    integer x;
+    x = P::T(1, 2);
+    if (x === 3) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED. x = %d, expected 3", x);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ps_function2.v
+++ b/ivtest/ivltests/sv_ps_function2.v
@@ -1,0 +1,21 @@
+// Check that it is possible to call a package scoped function with no
+// arguments.
+
+package P;
+  function integer T();
+    return 1;
+  endfunction
+endpackage
+
+module test;
+  initial begin
+    integer x;
+    x = P::T();
+    if (x === 1) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED: x = %d, expected 1", x);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ps_function3.v
+++ b/ivtest/ivltests/sv_ps_function3.v
@@ -1,0 +1,21 @@
+// Check that it is possible to call a package scoped function with empty
+// positional arguments.
+
+package P;
+  function integer T(integer x = 1, integer y = 2);
+    return x + y;
+  endfunction
+endpackage
+
+module test;
+  initial begin
+    integer x;
+    x = P::T(, 4);
+    if (x === 5) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED. x = %d, expected 5", x);
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -609,6 +609,9 @@ sv_port_default11	normal,-g2009		ivltests
 sv_port_default12	normal,-g2009		ivltests
 sv_port_default13	CE,-g2009		ivltests
 sv_port_default14	CE,-g2009		ivltests
+sv_ps_function1		normal,-g2009		ivltests
+sv_ps_function2		normal,-g2009		ivltests
+sv_ps_function3		normal,-g2009		ivltests
 sv_queue1		normal,-g2009		ivltests
 sv_queue2		normal,-g2009		ivltests
 sv_queue3		normal,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -3723,7 +3723,7 @@ expr_primary
 	delete $3;
 	$$ = tmp;
       }
-  | PACKAGE_IDENTIFIER K_SCOPE_RES IDENTIFIER '(' expression_list_proper ')'
+  | PACKAGE_IDENTIFIER K_SCOPE_RES IDENTIFIER '(' expression_list_with_nuls ')'
       { perm_string use_name = lex_strings.make($3);
 	PECallFunction*tmp = new PECallFunction($1, use_name, *$5);
 	FILE_NAME(tmp, @3);

--- a/parse.y
+++ b/parse.y
@@ -3704,6 +3704,7 @@ expr_primary
 	PECallFunction*tmp = pform_make_call_function(@1, *$1, *expr_list);
 	delete $1;
 	delete $2;
+	delete expr_list;
 	$$ = tmp;
       }
   | class_hierarchy_identifier '(' expression_list_with_nuls ')'
@@ -3711,6 +3712,7 @@ expr_primary
 	strip_tail_items(expr_list);
 	PECallFunction*tmp = pform_make_call_function(@1, *$1, *expr_list);
 	delete $1;
+	delete expr_list;
 	$$ = tmp;
       }
   | SYSTEM_IDENTIFIER '(' expression_list_proper ')'
@@ -3718,6 +3720,7 @@ expr_primary
 	PECallFunction*tmp = new PECallFunction(tn, *$3);
 	FILE_NAME(tmp, @1);
 	delete[]$1;
+	delete $3;
 	$$ = tmp;
       }
   | PACKAGE_IDENTIFIER K_SCOPE_RES IDENTIFIER '(' expression_list_proper ')'
@@ -3725,6 +3728,7 @@ expr_primary
 	PECallFunction*tmp = new PECallFunction($1, use_name, *$5);
 	FILE_NAME(tmp, @3);
 	delete[]$3;
+	delete $5;
 	$$ = tmp;
       }
   | SYSTEM_IDENTIFIER '('  ')'


### PR DESCRIPTION
The parser currently only allows package scoped functions to be called if
there is at least one argument. But package scoped functions are the same
as normal functions and it is allowed to call them with no arguments. It is
even possible to pass no value for a positional argument, if the positional
argument has a default value.

Update the parser to handle this.

Also fix a small memory leak when parsing function calls where the
argument list is not freed.