### PR TITLE
Improve parsing of package scoped identifiers 

### DIFF
--- a/ivtest/ivltests/sv_ps_function4.v
+++ b/ivtest/ivltests/sv_ps_function4.v
@@ -1,0 +1,30 @@
+// Check that it is possible to reference a package scoped function, even if
+// there is a type identifier of the same name in the current scope.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr !== val) begin \
+    $display("FAILED: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+package P;
+  function integer T(integer x);
+    return x + 1;
+  endfunction
+endpackage
+
+module test;
+  typedef integer T;
+  initial begin
+    integer x;
+
+    x = P::T(10);
+    `check(x, 11)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_ps_type1.v
+++ b/ivtest/ivltests/sv_ps_type1.v
@@ -1,0 +1,26 @@
+// Check that it is possible to reference a package scoped type identifier, even if
+// there is a identifier of the same name in the current scope.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr !== val) begin \
+    $display("FAILED: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+package P;
+  typedef logic [31:0] T;
+endpackage
+
+module test;
+  logic T;
+  initial begin
+    P::T x;
+    `check($bits(x), 32)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_ps_var1.v
+++ b/ivtest/ivltests/sv_ps_var1.v
@@ -1,0 +1,27 @@
+// Check that it is possible to reference a package scoped identifier, even if
+// there is a type identifier of the same name in the current scope.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr !== val) begin \
+    $display("FAILED: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+package P;
+  integer T = 10;
+endpackage
+
+module test;
+  typedef integer T;
+  integer x;
+  initial begin
+    x = P::T;
+    `check(x, 10)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -618,6 +618,9 @@ sv_port_default14	CE,-g2009		ivltests
 sv_ps_function1		normal,-g2009		ivltests
 sv_ps_function2		normal,-g2009		ivltests
 sv_ps_function3		normal,-g2009		ivltests
+sv_ps_function4		normal,-g2009		ivltests
+sv_ps_type1		normal,-g2009		ivltests
+sv_ps_var1		normal,-g2009		ivltests
 sv_queue1		normal,-g2009		ivltests
 sv_queue2		normal,-g2009		ivltests
 sv_queue3		normal,-g2009		ivltests


### PR DESCRIPTION
In order to avoid conflicts in the grammar the lexer distinguishes between
identifiers and type identifiers. To correctly classify an identifier the
lexer needs to know in which scope a token is parsed. E.g. when the parser
encounters a package scope operator it calls `lex_in_package_scope()` to tell
the lexer which scope the following identifier should be classified in.

Currently the `lex_in_package_scope()` is only used when a type identifiers is
parsed, but on for normal identifiers. As a result it is not possible to
reference variables or function from a package scope that have the same
name as a type identifier in the current scope. E.g.

```SystemVerilog
package P;
  int T;
endpackage

module test;
  typedef int T;
  initial $display(P::T);
endmodule
```

Another problem is that in expressions both type identifiers and signal
identifiers can be referenced. As a result there are two rules in an
expression that can be reduced

  * `<PACKAGE_TYPE> :: <TYPE_IDENTIFIER>`
  * `<PACKAGE_TYPE> :: <IDENTIFIER>`

The way the rules are formulated at the moment the parser has to use token
lookahead to decide which rule to follow before it can reduce the package
scope operator. As a result the lexer detects the token before
lex_in_package_scope() is called and the identifier does not get evaluated
in the package scope, but in the current scope. Which can cause the
identifier to be misclassified. E.g.

```SystemVerilog
package P;
  typedef int T;
  shortint X;
endpackage

module test;
   typedef byte X;
   initial $display($bits(P::T));
   initial $display($bits(P::X));
endmodule
```

Here `P::T` gets classified as a signal identifier and `P::X` gets classified
as a type identifier.

To solve this introduce a common rule for the package scope operator. Using
the same rule everywhere allows the parser to reduce it unconditionally
without using lookahead.

Note that there are additional problems with resolving the type of a scoped
type identifiers in expressions, but this is a prerequisite to solve that.