### PR TITLE
Handle default argument values for class function method calls 

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3185,13 +3185,13 @@ NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 	    NetNet*res = method->find_signal(method->basename());
 	    ivl_assert(*this, res);
 
-	    vector<NetExpr*>parms;
+	    vector<NetExpr*> parms(def->port_count());
+	    ivl_assert(*this, def->port_count() >= 1);
 
 	    NetESignal*ethis = new NetESignal(net);
 	    ethis->set_line(*this);
-	    parms.push_back(ethis);
+	    parms[0] = ethis;
 
-	    parms.resize(1 + parms_.size());
 	    elaborate_arguments_(des, scope, def, false, parms, 1);
 
 	    NetESignal*eres = new NetESignal(res);

--- a/ivtest/ivltests/sv_class_method_default1.v
+++ b/ivtest/ivltests/sv_class_method_default1.v
@@ -1,0 +1,41 @@
+// Check that default values on function methods are supported and it is
+// possible to omit any of the arguments.
+
+class C;
+  function integer f(integer x = 1, integer y = 2, integer z = 3);
+    return x + y + z;
+  endfunction
+endclass
+
+module test;
+
+  C c = new;
+
+  bit failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr !== val) begin \
+      $display("FAILED. %s, expected %d, got %d", `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    `check(c.f(), 6);
+    `check(c.f(4), 9);
+    `check(c.f(4, ), 9);
+    `check(c.f(4, , ), 9);
+    `check(c.f(4, 6), 13);
+    `check(c.f(4, 6, ), 13);
+    `check(c.f(4, , 8), 14);
+    `check(c.f(4, 6, 8), 18);
+    `check(c.f(, 6), 10);
+    `check(c.f(, 6, ), 10);
+    `check(c.f(, 6 ,8), 15);
+    `check(c.f(, , 8), 11);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_method_default2.v
+++ b/ivtest/ivltests/sv_class_method_default2.v
@@ -1,0 +1,54 @@
+// Check that default values on task methods are supported and it is possible to
+// omit any of the arguments.
+
+class C;
+  integer r;
+  task t(integer x = 1, integer y = 2, integer z = 3);
+    r = x + y + z;
+  endtask
+endclass
+
+module test;
+
+  C c = new;
+
+  bit failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr !== val) begin \
+      $display("FAILED. %s, expected %0d, got %0d", `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    c.t();
+    `check(c.r, 6);
+    c.t(4);
+    `check(c.r, 9);
+    c.t(4, );
+    `check(c.r, 9);
+    c.t(4, ,);
+    `check(c.r, 9);
+    c.t(4, 6);
+    `check(c.r, 13);
+    c.t(4, 6, );
+    `check(c.r, 13);
+    c.t(4, , 8);
+    `check(c.r, 14);
+    c.t(4, 6, 8);
+    `check(c.r, 18);
+    c.t(, 6);
+    `check(c.r, 10);
+    c.t(, 6, );
+    `check(c.r, 10);
+    c.t(, 6, 8);
+    `check(c.r, 15);
+    c.t(, , 8);
+    `check(c.r, 11);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -527,6 +527,8 @@ sv_class_new_fail1	CE,-g2009		ivltests
 sv_class_new_fail2	CE,-g2009		ivltests
 sv_class_new_init	normal,-g2009		ivltests
 sv_class_in_module_decl	normal,-g2009		ivltests
+sv_class_method_default1 normal,-g2009		ivltests
+sv_class_method_default2 normal,-g2009		ivltests
 sv_class_method_signed1	normal,-g2009		ivltests
 sv_class_method_signed2	normal,-g2009		ivltests
 sv_class_property_signed1	normal,-g2009	ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -407,6 +407,8 @@ sv_class_extends_scoped	CE,-g2009		ivltests
 sv_class_localparam	CE,-g2009		ivltests
 sv_class_new_init	CE,-g2009		ivltests
 sv_class_in_module_decl	CE,-g2009		ivltests
+sv_class_method_default1 CE,-g2009		ivltests
+sv_class_method_default2 CE,-g2009		ivltests
 sv_class_method_signed1	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_method_signed2	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_property_signed1	CE,-g2009,-pallowsigned=1	ivltests


### PR DESCRIPTION
For class function method calls currently only as many arguments as have
been supplied are elaborated. Any trailing arguments that might have default
values are skipped. This will trigger an assertion later on in the vvp code
generator backend.

Fix this by making sure that all arguments of the function are evaluated.

Note that this already works correctly for class task method calls.

This resolves #441