### PR TITLE
Prevent non-blocking writes to fields of automatic structs

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -446,19 +446,17 @@ void PEIdent::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 
 bool PEIdent::has_aa_term(Design*des, NetScope*scope) const
 {
-      NetNet*       net = 0;
-      ivl_type_t    cls_val;
-      const NetExpr*par = 0;
-      ivl_type_t    par_type;
-      NetEvent*     eve = 0;
+      symbol_search_results sr;
+      if (!symbol_search(this, des, scope, path_, &sr))
+	    return false;
 
-      scope = symbol_search(this, des, scope, path_, net, par, eve,
-                            par_type, cls_val);
+      // Class properties are not considered automatic since a non-blocking
+      // assignment to an object stored in an automatic variable is supposed to
+      // capture a reference to the object, not the variable.
+      if (!sr.path_tail.empty() && sr.net && sr.net->class_type())
+	    return false;
 
-      if (scope)
-            return scope->is_auto();
-      else
-            return false;
+      return sr.scope->is_auto();
 }
 
 PENewArray::PENewArray(PExpr*size_expr, PExpr*init_expr)

--- a/ivtest/ivltests/automatic_error14.v
+++ b/ivtest/ivltests/automatic_error14.v
@@ -1,0 +1,18 @@
+// Check that it is not possible to perform non-blocking assignments to fields
+// of structs with automatic lifetime.
+
+module test;
+
+  task automatic auto_task;
+    struct packed {
+      logic x;
+    } s;
+    s.x <= 10;
+    $display("FAILED");
+  endtask
+
+  initial begin
+    auto_task;
+  end
+
+endmodule

--- a/ivtest/ivltests/automatic_error15.v
+++ b/ivtest/ivltests/automatic_error15.v
@@ -1,0 +1,19 @@
+// Check that it is not possible to perform non-blocking assignments to a class
+// object variable with automatic lifetime.
+
+module test;
+
+  class C;
+  endclass
+
+  task automatic auto_task;
+    C c1, c2;
+    c1 <= c2;
+    $display("FAILED");
+  endtask
+
+  initial begin
+    auto_task;
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -104,6 +104,8 @@ assign_op_oob		normal,-g2009		ivltests
 assign_op_real_array	normal,-g2009		ivltests
 assign_op_real_array_oob normal,-g2009		ivltests
 assign_op_type		normal,-g2009		ivltests
+automatic_error14	CE,-g2005-sv		ivltests
+automatic_error15	CE,-g2005-sv		ivltests
 bitp1			normal,-g2005-sv	ivltests
 bits			normal,-g2005-sv	ivltests
 bits2			normal,-g2005-sv	ivltests


### PR DESCRIPTION
The `PEIdent::has_aa_term()` method still uses the old `symbol_search()`
and will fail to find the variable if part of the identifier path is a
member select of a variable.

As a result such writes to fields of automatic structs can be classified as
static and it is possible to do non-blocking assignments to them. E.g.

```SystemVerilog
task automatic t;
  struct packed {
    logic x;
  } s;
  s <= ...; // This fails
  s.x <= ...; // This works, but should fail
endtask
```

Switch to the new symbol search to make sure this case is handled
correctly. The new symbol search will correctly handle identifier paths
that have a trailing item after the variable, while the old symbol search
will always return an error in that case.

Note that while it is not allowed to do a non-blocking write to a class
object automatic variable, it is allowed to do a non-blocking write to a
property of a class object that is stored in an automatic variable, as the
non-blocking write is supposed to capture a reference to the object and not
reference the variable. E.g.

```SystemVerilog
class C;
  int x;
endclass

task automatic t;
  C c;
  c <= ...; // Not allowed
  c.x <= ...; // Allowed
endtask
```

Non-blocking access to class properties is not yet support in
Icarus in general, but the error handling for that needs to be done
somewhere else.