### PR TITLE
Add #include <cstdarg> to all source files that use va_list

### DIFF
--- a/lexor.lex
+++ b/lexor.lex
@@ -27,6 +27,7 @@
       //# define YYSTYPE lexval
 
 # include  <cstdarg>
+# include  <iostream>
 # include  "compiler.h"
 # include  "parse_misc.h"
 # include  "parse_api.h"

--- a/lexor.lex
+++ b/lexor.lex
@@ -26,7 +26,7 @@
 
       //# define YYSTYPE lexval
 
-# include  <iostream>
+# include  <cstdarg>
 # include  "compiler.h"
 # include  "parse_misc.h"
 # include  "parse_api.h"

--- a/lexor_keyword.gperf
+++ b/lexor_keyword.gperf
@@ -9,6 +9,7 @@
 %{
 /* Command-line: gperf -o -i 7 -C -k '1-4,6,9,$' -H keyword_hash -N check_identifier -t ./lexor_keyword.gperf  */
 
+#include <cstdarg>
 #include "config.h"
 #include "parse_misc.h"
 #include "parse.h"

--- a/parse.y
+++ b/parse.y
@@ -22,6 +22,7 @@
 
 # include "config.h"
 
+# include  <cstdarg>
 # include  "parse_misc.h"
 # include  "compiler.h"
 # include  "pform.h"

--- a/parse_misc.cc
+++ b/parse_misc.cc
@@ -19,8 +19,8 @@
 
 # include "config.h"
 
-# include  "parse_misc.h"
 # include  <cstdarg>
+# include  "parse_misc.h"
 # include  <cstdio>
 # include  <iostream>
 

--- a/pform.cc
+++ b/pform.cc
@@ -20,6 +20,7 @@
 
 # include "config.h"
 
+# include  <cstdarg>
 # include  "compiler.h"
 # include  "pform.h"
 # include  "parse_misc.h"

--- a/pform_analog.cc
+++ b/pform_analog.cc
@@ -17,6 +17,7 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+# include  <cstdarg>
 # include  "config.h"
 # include  "compiler.h"
 # include  "pform.h"

--- a/pform_disciplines.cc
+++ b/pform_disciplines.cc
@@ -17,6 +17,7 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+# include  <cstdarg>
 # include  "config.h"
 # include  "compiler.h"
 # include  "pform.h"

--- a/pform_package.cc
+++ b/pform_package.cc
@@ -18,6 +18,7 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+# include  <cstdarg>
 # include  "pform.h"
 # include  "PPackage.h"
 # include  "parse_misc.h"

--- a/pform_pclass.cc
+++ b/pform_pclass.cc
@@ -17,6 +17,7 @@
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+# include  <cstdarg>
 # include  "pform.h"
 # include  "PClass.h"
 # include  "parse_misc.h"


### PR DESCRIPTION
While building on NetBSD I found that a bunch of files either use "va_list" or they #include a header that uses "va_list" without #including the required <cstdarg> header. 

I'm going to guess that Linux has some header file that #includes stdarg when NetBSD doesn't. 

I added <cstdarg> to most include lists that needed it. There was one case where <cstdarg> was already there, but not early enough in the list and so I moved it to the front of the list of included header files.
