### PR TITLE
Support for range indexing of arrays with swapped ranges within structs

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -2186,11 +2186,10 @@ bool calculate_part(const LineInfo*li, Design*des, NetScope*scope,
 	    return true;
 
 	  case index_component_t::SEL_PART:
+	    off = lsb;
 	    if (msb >= lsb) {
-		  off = lsb;
 		  wid = msb - lsb + 1;
 	    } else {
-		  off = msb;
 		  wid = lsb - msb + 1;
 	    }
 	    return true;

--- a/ivtest/ivltests/struct10.v
+++ b/ivtest/ivltests/struct10.v
@@ -1,0 +1,47 @@
+module main;
+
+   struct packed {
+      bit [7:0][7:0] a;
+      bit [15:0] b;
+   } foo;
+
+   struct packed {
+      bit [0:7] [7:0] a;
+      bit [0:15] b;
+   } bar;
+
+   initial begin
+      foo = '0;
+      foo.a[2:1] = 16'h1234;
+      foo.a[5] = 8'h42;
+      foo.a[7] = '1;
+      foo.a[7][1:0] = '0;
+      foo.b = '1;
+      foo.b[1:0] = '0;
+
+      $display("foo = %h", foo);
+
+      bar = '0;
+      bar.a[5:6] = 16'h1234;
+      bar.a[2] = 8'h42;
+      bar.a[0] = '1;
+      bar.a[0][1:0] = '0;
+      bar.b = '1;
+      bar.b[14:15] = '0;
+
+      $display("bar = %h", bar);
+
+      if (foo !== 80'hFC00_4200_0012_3400_FFFC) begin
+	 $display("FAILED -- foo=%h", foo);
+	 $finish;
+      end
+
+      if (foo !== bar) begin
+	 $display("FAILED -- bar != foo");
+	 $finish;
+      end
+
+      $display("PASSED");
+   end
+
+endmodule // main

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -471,6 +471,7 @@ struct6			normal,-g2009		ivltests
 struct7			normal,-g2009		ivltests
 struct8			normal,-g2009		ivltests
 struct9			normal,-g2009		ivltests
+struct10		normal,-g2009		ivltests
 struct_line_info	CE,-g2009		ivltests gold=struct_line_info.gold
 struct_member_signed	normal,-g2009		ivltests
 struct_packed_array	normal,-g2009		ivltests


### PR DESCRIPTION
This patch corrects range indexing of members in structs such as:

struct packed {
   bit [0:7] [7:0] a;
   bit [0:15] b;
} bar;