### PR TITLE
 Insert drivers for undriven nets

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -185,7 +185,7 @@ void PGAssign::elaborate(Design*des, NetScope*scope) const
 	// expression. In this case, we will need to create a driver
 	// (later) to carry strengths.
       bool need_driver_flag = false;
-      if (dynamic_cast<NetESignal*>(rval_expr))
+      if (dynamic_cast<NetESignal*>(rval_expr) ||!rval->is_linked())
 	    need_driver_flag = true;
 
 	// expression elaboration should have caused the rval width to

--- a/ivtest/ivltests/br_gh793.v
+++ b/ivtest/ivltests/br_gh793.v
@@ -1,0 +1,17 @@
+// Check that $signed/$unsigned works when being combinatorially assigned with a
+// delay and the target of the function is a net without any drivers.
+
+module top ();
+	wire [7:0] a;
+	wire signed [7:0] b;
+	assign #1 b = $signed(a);
+
+	initial begin
+		#10
+		if (b === 8'hzz) begin
+			$display("PASSED");
+		end else begin
+			$display("FAILED");
+		end
+	end
+endmodule

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -349,6 +349,7 @@ br_gh632b		normal,-S		ivltests
 br_gh632c		normal			ivltests
 br_gh674		normal			ivltests
 br_gh732		normal			ivltests gold=br_gh732.gold
+br_gh793		normal			ivltests
 br_ml20150315		normal			ivltests gold=br_ml_20150315.gold
 br_ml20150321		CE			ivltests
 br_mw20171108		normal			ivltests


### PR DESCRIPTION
Trying to add a drive strength or delay to a undriven net will result in an
assertion. Make sure that a driver is added to undriven nets.

A driver is already added for all NetESignals, which covers most expression that
can produce a raw net rvalue. But there are other ways we can end up with just a
net as the rvalue, e.g.  when applying a sign cast to a net. The following
example triggers the issue

```SystemVerilog
wire [7:0] a;
wire [7:0] b = $signed(a);
```

This addresses #793 