### PR TITLE
Explicitly refer to std::isnan to avoid clash with system standard library

### DIFF
--- a/vvp/vpi_callback.cc
+++ b/vvp/vpi_callback.cc
@@ -881,7 +881,7 @@ static void real_signal_value(struct t_vpi_value*vp, double rval)
 	    break;
 
 	  case vpiDecStrVal:
-	    if (isnan(rval))
+	    if (std::isnan(rval))
 		  sprintf(rbuf, "%s", "nan");
 	    else
 		  sprintf(rbuf, "%0.0f", vlg_round(rval));

--- a/vvp/vpi_vthr_vector.cc
+++ b/vvp/vpi_vthr_vector.cc
@@ -132,7 +132,7 @@ static void vthr_real_get_value(vpiHandle ref, s_vpi_value*vp)
 	    break;
 
 	  case vpiDecStrVal:
-	    if (isnan(val))
+	    if (std::isnan(val))
 		  sprintf(rbuf, "%s", "nan");
 	    else
 		  sprintf(rbuf, "%0.0f", vlg_round(val));


### PR DESCRIPTION
I noticed the master branch would not compile under redhat7.9, an obsolete release but still common in the digital CAD industry. The attached small patch fixes the problem by explicitly referencing the standard C++ library. This is should be harmless on other systems but I haven't got a suitable system to try at the moment, except OSX which is OK with it.