### PR TITLE
 Support type parameters

### DIFF
--- a/PScope.h
+++ b/PScope.h
@@ -113,6 +113,8 @@ class LexicalScope {
 	    bool local_flag;
 	      // Whether the parameter can be overridden
 	    bool overridable;
+	      // Whether the parameter is a type parameter
+	    bool type_flag = false;
 
 	    SymbolType symbol_type() const;
       };

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -128,9 +128,7 @@ static void collect_parm_item(Design*des, NetScope*scope, perm_string name,
       // not yet known, don't try to guess here, put the type guess off. Also
       // don't try to elaborate it here, because there may be references to
       // other parameters still being located during scope elaboration.
-      scope->set_parameter(name, is_annotatable, cur.expr, cur.data_type,
-			   cur.local_flag, cur.overridable, range_list, cur);
-
+      scope->set_parameter(name, is_annotatable, cur, range_list);
 }
 
 static void collect_scope_parameters(Design*des, NetScope*scope,

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -476,3 +476,16 @@ ivl_type_t typedef_t::elaborate_type(Design *des, NetScope *scope)
 
       return elab_type;
 }
+
+ivl_type_t type_parameter_t::elaborate_type_raw(Design *des, NetScope*scope) const
+{
+      ivl_type_t type;
+
+      scope->get_parameter(des, name, type);
+
+      // Recover
+      if (!type)
+	    return netvector_t::integer_type();
+
+      return type;
+}

--- a/ivl.def
+++ b/ivl.def
@@ -172,6 +172,7 @@ ivl_nexus_ptr_switch
 ivl_parameter_basename
 ivl_parameter_expr
 ivl_parameter_file
+ivl_parameter_is_type
 ivl_parameter_lineno
 ivl_parameter_local
 ivl_parameter_lsb

--- a/ivl_target.h
+++ b/ivl_target.h
@@ -1695,6 +1695,9 @@ extern ivl_signal_t ivl_nexus_ptr_sig(ivl_nexus_ptr_t net);
  *    Return whether parameter was local (localparam, implicit genvar etc)
  *    or not.
  *
+ * ivl_parameter_is_type
+ *    Return whether the parameter is a type parameter or not.
+ *
  * ivl_parameter_file
  * ivl_parameter_lineno
  *    Returns the file and line where this parameter is defined
@@ -1707,6 +1710,7 @@ extern int         ivl_parameter_lsb(ivl_parameter_t net);
 extern unsigned    ivl_parameter_width(ivl_parameter_t net);
 extern int         ivl_parameter_signed(ivl_parameter_t net);
 extern int         ivl_parameter_local(ivl_parameter_t net);
+extern int         ivl_parameter_is_type(ivl_parameter_t net);
 extern const char* ivl_parameter_file(ivl_parameter_t net);
 extern unsigned    ivl_parameter_lineno(ivl_parameter_t net);
 

--- a/ivtest/ivltests/sv_type_param1.v
+++ b/ivtest/ivltests/sv_type_param1.v
@@ -1,0 +1,25 @@
+// Check that basic type parameter syntax is supported
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module test #(
+  parameter type T1 = integer
+);
+  T1 x;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param2.v
+++ b/ivtest/ivltests/sv_type_param2.v
@@ -1,0 +1,28 @@
+// Check that it is possible to declare multiple type parameters as a list with
+// a single type keyword.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module test #(
+  parameter type T1 = integer, T2 = real
+);
+  T1 x;
+  T2 y = 1.23;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+    `check(y, 1.23)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param3.v
+++ b/ivtest/ivltests/sv_type_param3.v
@@ -1,0 +1,26 @@
+// Check that it is possible to declare type parameters when omitting the
+// parameter keyword.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module test #(
+  type T1 = integer
+);
+  T1 x;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param4.v
+++ b/ivtest/ivltests/sv_type_param4.v
@@ -1,0 +1,27 @@
+// Check that it is possible to reference other parameters in the default value
+// of a type parameter.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module test #(
+  parameter A = 10,
+  parameter type T1 = logic [A-1:0]
+);
+  T1 x;
+
+  initial begin
+    `check($bits(x), A)
+    `check($bits(T1), A)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param5.v
+++ b/ivtest/ivltests/sv_type_param5.v
@@ -1,0 +1,27 @@
+// Check that it is possible to declare local type parameters.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module test;
+
+  parameter A = 10;
+  localparam type T1 = logic [A-1:0];
+
+  T1 x;
+
+  initial begin
+    `check($bits(x), A)
+    `check($bits(T1), A)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param6.v
+++ b/ivtest/ivltests/sv_type_param6.v
@@ -1,0 +1,91 @@
+// Check that various syntax variations for type parameters without a default
+// value are supported.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module M1 #(
+  parameter type T1
+);
+  T1 x;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+  end
+
+endmodule
+
+module M2 #(
+  type T1
+);
+  T1 x;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+  end
+
+endmodule
+
+module M3 #(
+  parameter type T1, T2
+);
+  T1 x;
+  T2 y = 1.23;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+    `check(y, 1.23)
+  end
+
+endmodule
+
+module M4 #(
+  type T1, T2
+);
+  T1 x;
+  T2 y = 1.23;
+
+  initial begin
+    `check($bits(x), $bits(integer))
+    `check($bits(T1), $bits(integer))
+    `check(y, 1.23)
+  end
+
+endmodule
+
+module test;
+
+  M1 #(
+    .T1 (integer)
+  ) i_m1 ();
+
+  M2 #(
+    .T1 (integer)
+  ) i_m2 ();
+
+  M3 #(
+    .T1 (integer),
+    .T2 (real)
+  ) i_m3();
+
+  M4 #(
+    .T1 (integer),
+    .T2 (real)
+  ) i_m4 ();
+
+  initial begin
+    #1
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param7.v
+++ b/ivtest/ivltests/sv_type_param7.v
@@ -1,0 +1,59 @@
+// Check that it is possible to overwrite type parameters and that the provided
+// type is evaluated in the scope instantiating the module.
+
+bit failed = 1'b0;
+
+`define check(expr, val) \
+  if (expr != val) begin \
+    $display("failed: %s, expected %0d, got %0d", `"expr`", val, expr); \
+    failed = 1'b1; \
+  end
+
+module M #(
+  parameter type T1 = integer,
+  parameter WIDTH = 0
+);
+  typedef logic [1:0] T2;
+  localparam A = 2;
+  T1 x;
+
+  initial begin
+    `check($bits(x), WIDTH)
+    `check($bits(T1), WIDTH)
+  end
+
+endmodule
+
+module test;
+  localparam A = 4;
+  typedef logic [A-1:0] T2;
+
+  M #(
+    .WIDTH ($bits(integer))
+  ) i_m1 ();
+
+  M #(
+    .T1 (logic [15:0]),
+    .WIDTH (16)
+  ) i_m2 ();
+
+  // `A` must be evauluated in this context
+  M #(
+    .T1 (logic [A-1:0]),
+    .WIDTH (4)
+  ) i_m3 ();
+
+  // `T2` must be evauluated in this context
+  M #(
+    .T1 (T2),
+    .WIDTH (4)
+  ) i_m4 ();
+
+  initial begin
+    #1
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_type_param_fail1.v
+++ b/ivtest/ivltests/sv_type_param_fail1.v
@@ -1,0 +1,23 @@
+// Check that overrideing a type parameter with an expression that is not a type
+// generates an error.
+
+module M #(
+  type T = int
+);
+
+  T x;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule
+
+module test;
+
+  M #(
+    .T(10)
+  ) m();
+
+endmodule
+

--- a/ivtest/ivltests/sv_type_param_fail2.v
+++ b/ivtest/ivltests/sv_type_param_fail2.v
@@ -1,0 +1,21 @@
+// Check that trying to override a type parameter using a defparam statement
+// generates an error.
+
+module M #(
+  type T = int
+);
+
+  T x;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule
+
+module test;
+
+  M m();
+  defparam m.T = real; // Error, this is illegal
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -711,6 +711,15 @@ sv_timeunit_prec_fail2	CE,-g2009,-u,\
   ./ivltests/sv_timeunit_prec_fail2a.v,\
   ./ivltests/sv_timeunit_prec_fail2b.v,\
   ./ivltests/sv_timeunit_prec_fail2c.v,		ivltests gold=sv_timeunit_prec_fail2.gold
+sv_type_param1		normal,-g2005-sv	ivltests
+sv_type_param2		normal,-g2005-sv	ivltests
+sv_type_param3		normal,-g2005-sv	ivltests
+sv_type_param4		normal,-g2005-sv	ivltests
+sv_type_param5		normal,-g2005-sv	ivltests
+sv_type_param6		normal,-g2005-sv	ivltests
+sv_type_param7		normal,-g2005-sv	ivltests
+sv_type_param_fail1	CE,-g2005-sv		ivltests
+sv_type_param_fail2	CE,-g2005-sv		ivltests
 sv_typedef_array_base1	normal,-g2009		ivltests
 sv_typedef_array_base2	normal,-g2009		ivltests
 sv_typedef_array_base3	normal,-g2009		ivltests

--- a/pform.cc
+++ b/pform.cc
@@ -2961,8 +2961,21 @@ LexicalScope::range_t* pform_parameter_value_range(bool exclude_flag,
       return tmp;
 }
 
+static void pform_set_type_parameter(const struct vlltype&loc, perm_string name,
+				     LexicalScope::range_t*value_range)
+{
+      pform_requires_sv(loc, "Type parameter");
+
+      if (value_range)
+	    VLerror(loc, "error: type parameter must not have value range.");
+
+      type_parameter_t *type = new type_parameter_t(name);
+      pform_set_typedef(loc, name, type, 0);
+}
+
 void pform_set_parameter(const struct vlltype&loc,
-			 perm_string name, bool is_local, data_type_t*data_type, PExpr*expr,
+			 perm_string name, bool is_local, bool is_type,
+			 data_type_t*data_type, PExpr*expr,
 			 LexicalScope::range_t*value_range)
 {
       LexicalScope*scope = lexical_scope;
@@ -3008,13 +3021,17 @@ void pform_set_parameter(const struct vlltype&loc,
       Module::param_expr_t*parm = new Module::param_expr_t();
       FILE_NAME(parm, loc);
 
-      add_local_symbol(scope, name, parm);
+      if (is_type)
+	    pform_set_type_parameter(loc, name, value_range);
+      else
+	    add_local_symbol(scope, name, parm);
 
       parm->expr = expr;
       parm->data_type = data_type;
       parm->range = value_range;
       parm->local_flag = is_local;
       parm->overridable = overridable;
+      parm->type_flag = is_type;
 
       scope->parameters[name] = parm;
 

--- a/pform.h
+++ b/pform.h
@@ -390,7 +390,7 @@ extern LexicalScope::range_t* pform_parameter_value_range(bool exclude_flag,
 
 extern void pform_set_parameter(const struct vlltype&loc,
 				perm_string name,
-				bool is_local,
+				bool is_local, bool is_type,
 				data_type_t*data_type,
 				PExpr*expr, LexicalScope::range_t*value_range);
 extern void pform_set_specparam(const struct vlltype&loc,

--- a/pform_types.h
+++ b/pform_types.h
@@ -212,6 +212,13 @@ private:
       typedef_t *type;
 };
 
+struct type_parameter_t : data_type_t {
+      explicit type_parameter_t(perm_string n) : name(n) { }
+      ivl_type_t elaborate_type_raw(Design *des, NetScope *scope) const;
+
+      perm_string name;
+};
+
 struct void_type_t : public data_type_t {
       virtual void pform_dump(std::ostream&out, unsigned indent) const;
 };

--- a/t-dll-api.cc
+++ b/t-dll-api.cc
@@ -1877,6 +1877,12 @@ extern "C" int ivl_parameter_local(ivl_parameter_t net)
       return net->local;
 }
 
+extern "C" int ivl_parameter_is_type(ivl_parameter_t net)
+{
+      assert(net);
+      return net->is_type;
+}
+
 extern "C" int ivl_parameter_signed(ivl_parameter_t net)
 {
       assert(net);

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -509,10 +509,7 @@ void dll_target::make_scope_parameters(ivl_scope_t scop, const NetScope*net)
 	    cur_par->basename = cur_pit->first;
 	    cur_par->local = cur_pit->second.local_flag ||
 			     !cur_pit->second.overridable;
-	    calculate_param_range(cur_pit->second,
-				  cur_pit->second.ivl_type,
-				  cur_par->msb, cur_par->lsb,
-				  cur_pit->second.val->expr_width());
+	    cur_par->is_type = cur_pit->second.type_flag;
 
 	    if (cur_pit->second.ivl_type == 0) {
 		  cerr << "?:?: internal error: "
@@ -525,14 +522,23 @@ void dll_target::make_scope_parameters(ivl_scope_t scop, const NetScope*net)
 	    cur_par->scope = scop;
 	    FILE_NAME(cur_par, &(cur_pit->second));
 
-	    NetExpr*etmp = cur_pit->second.val;
-	    if (etmp == 0) {
-		  cerr << "?:?: internal error: What is the parameter "
-		       << "expression for " << cur_pit->first
-		       << " in " << net->fullname() << "?" << endl;
+	      // Type parameters don't have a range or expression
+	    if (!cur_pit->second.type_flag) {
+		  calculate_param_range(cur_pit->second,
+					cur_pit->second.ivl_type,
+					cur_par->msb, cur_par->lsb,
+					cur_pit->second.val->expr_width());
+
+		  NetExpr*etmp = cur_pit->second.val;
+		  if (etmp == 0) {
+			cerr << "?:?: internal error: What is the parameter "
+			     << "expression for " << cur_pit->first
+			     << " in " << net->fullname() << "?" << endl;
+		  }
+		  assert(etmp);
+		  make_scope_param_expr(cur_par, etmp);
 	    }
-	    assert(etmp);
-	    make_scope_param_expr(cur_par, etmp);
+
 	    idx += 1;
       }
 }

--- a/t-dll.h
+++ b/t-dll.h
@@ -638,6 +638,7 @@ struct ivl_parameter_s {
       long          lsb;
       bool  signed_flag;
       bool        local;
+      bool      is_type;
       perm_string file;
       unsigned lineno;
 };

--- a/tgt-vhdl/scope.cc
+++ b/tgt-vhdl/scope.cc
@@ -940,9 +940,15 @@ static void create_skeleton_entity_for(ivl_scope_t scope, int depth)
    unsigned nparams = ivl_scope_params(scope);
    for (unsigned i = 0; i < nparams; i++) {
       ivl_parameter_t param = ivl_scope_param(scope, i);
-      ss << "\n  " << ivl_parameter_basename(param) << " = ";
+
+      // Type parameter usages get replaced with their actual type
+      if (ivl_parameter_is_type(param))
+	    continue;
 
       ivl_expr_t value = ivl_parameter_expr(param);
+
+      ss << "\n  " << ivl_parameter_basename(param) << " = ";
+
       switch (ivl_expr_type(value)) {
          case IVL_EX_STRING:
             ss << "\"" << ivl_expr_string(value) << "\"";

--- a/tgt-vhdl/state.cc
+++ b/tgt-vhdl/state.cc
@@ -264,6 +264,14 @@ static bool same_scope_type_name(ivl_scope_t a, ivl_scope_t b)
                  ivl_parameter_basename(param_b)) != 0)
          return false;
 
+      if (ivl_parameter_local(param_a) && ivl_parameter_local(param_b))
+	    continue;
+
+      // If this is a type parameter consider the scopes not equal since we do
+      // not have support for comparing the actual types yet.
+      if (ivl_parameter_is_type(param_a) || ivl_parameter_is_type(param_b))
+	    return false;
+
       ivl_expr_t value_a = ivl_parameter_expr(param_a);
       ivl_expr_t value_b = ivl_parameter_expr(param_b);
 

--- a/tgt-vlog95/scope.c
+++ b/tgt-vlog95/scope.c
@@ -309,6 +309,13 @@ void emit_scope_variables(ivl_scope_t scope)
       count = ivl_scope_params(scope);
       for (idx = 0; idx < count; idx += 1) {
 	    ivl_parameter_t par = ivl_scope_param(scope, idx);
+	      // vlog95 does not support type parameters. Places where type
+	      // parameters have been used it will be replaced with the actual
+	      // type that the module was instantiated with. Similar to
+	      // typedefs.
+	    if (ivl_parameter_is_type(par))
+		  continue;
+
 	    ivl_expr_t pex = ivl_parameter_expr(par);
 	    fprintf(vlog_out, "%*cparameter ", indent, ' ');
 	    emit_id(ivl_parameter_basename(par));

--- a/tgt-vvp/vvp_scope.c
+++ b/tgt-vvp/vvp_scope.c
@@ -2415,6 +2415,13 @@ int draw_scope(ivl_scope_t net, ivl_scope_t parent)
 
       for (idx = 0 ;  idx < ivl_scope_params(net) ;  idx += 1) {
 	    ivl_parameter_t par = ivl_scope_param(net, idx);
+
+	      // Skip type parameters for now. Support for type parameters
+	      // should be added together with support for quering types through
+	      // VPI.
+	    if (ivl_parameter_is_type(par))
+		  continue;
+
 	    ivl_expr_t pex = ivl_parameter_expr(par);
 	    switch (ivl_expr_type(pex)) {
 		case IVL_EX_STRING:


### PR DESCRIPTION
SystemVerilog supports type parameters. These are similar to value
parameters, but they allow to pass a type to a module or similar when
instantiating it.

E.g.

```SystemVerilog
module A #(parameter type T = int);
endmodule

module B;
  A #(.T(real)) i_a;
endmodule
```

Add support for handling type parameters.

For the vlog95 and vhdl backends type parameters, similar to typedefs, get
replaced with their actual value. For modules with non-local type
parameters for each module instance a unique module or architecture is
generated with the actual type.

Querying type parameters through VPI is not yet supported.

This resolves #417