### PR TITLE
 Elaborate class properties during signal phase instead of scope phase

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -513,29 +513,6 @@ static void elaborate_scope_class(Design*des, NetScope*scope, PClass*pclass)
       }
       elaborate_scope_enumerations(des, class_scope, pclass->enum_sets);
 
-	// Collect the properties, elaborate them, and add them to the
-	// elaborated class definition.
-      for (map<perm_string, class_type_t::prop_info_t>::iterator cur = use_type->properties.begin()
-		 ; cur != use_type->properties.end() ; ++ cur) {
-
-	    ivl_type_t tmp = cur->second.type->elaborate_type(des, class_scope);
-	    ivl_assert(*pclass, tmp);
-	    if (debug_scopes) {
-		  cerr << pclass->get_fileline() << ": elaborate_scope_class: "
-		       << "  Property " << cur->first
-		       << " type=" << *tmp << endl;
-	    }
-
-	    if (dynamic_cast<const netqueue_t *> (tmp)) {
-		  cerr << cur->second.get_fileline() << ": sorry: "
-		       << "Queues inside classes are not yet supported." << endl;
-		  des->errors++;
-	    }
-
-	    use_class->set_property(cur->first, cur->second.qual, tmp);
-
-      }
-
       for (map<perm_string,PTask*>::iterator cur = pclass->tasks.begin()
 		 ; cur != pclass->tasks.end() ; ++cur) {
 

--- a/ivtest/ivltests/sv_ps_type_class_prop.v
+++ b/ivtest/ivltests/sv_ps_type_class_prop.v
@@ -1,0 +1,23 @@
+// Check that it is possible to use a package scope type identifier for the type
+// of a property of class defined in the root scope
+
+package P;
+  typedef integer T;
+endpackage
+
+class C;
+  P::T x;
+endclass
+
+module test;
+  C c;
+  initial begin
+    c = new;
+    c.x = 32'h55aa55aa;
+    if (c.x === 32'h55aa55aa) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_typedef_fwd_class2.v
+++ b/ivtest/ivltests/sv_typedef_fwd_class2.v
@@ -1,0 +1,22 @@
+// Check that it is possible to use a forward declared class type as the type of
+// a property in another class.
+
+module test;
+
+  typedef class B;
+
+  class C;
+    B b;
+  endclass
+
+  class B;
+  endclass
+
+  C c;
+
+  initial begin
+    c = new;
+    $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -640,6 +640,7 @@ sv_ps_type1		normal,-g2009		ivltests
 sv_ps_type_cast1	normal,-g2009		ivltests
 sv_ps_type_cast2	normal,-g2009		ivltests
 sv_ps_type_class1	normal,-g2009		ivltests
+sv_ps_type_class_prop	normal,-g2009		ivltests
 sv_ps_type_enum1	normal,-g2009		ivltests
 sv_ps_type_expr1	normal,-g2009		ivltests
 sv_ps_type_expr2	normal,-g2009		ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -724,6 +724,7 @@ sv_typedef_darray_base3	normal,-g2009		ivltests
 sv_typedef_darray_base4	normal,-g2009		ivltests
 sv_typedef_fwd_base	normal,-g2009		ivltests
 sv_typedef_fwd_class	normal,-g2009		ivltests
+sv_typedef_fwd_class2	normal,-g2009		ivltests
 sv_typedef_fwd_union	normal,-g2009		ivltests
 sv_typedef_fwd_union_fail CE,-g2009		ivltests
 sv_typedef_fwd_enum1	normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -440,6 +440,7 @@ sv_port_default7	CE,-g2009,-pallowsigned=1	ivltests
 sv_port_default8	CE,-g2009,-pallowsigned=1	ivltests
 sv_port_default9	CE,-g2009		ivltests
 sv_ps_type_class1	CE,-g2009		ivltests
+sv_ps_type_class_prop	CE,-g2009		ivltests
 sv_root_class		CE,-g2009		ivltests
 sv_typedef_fwd_class	CE,-g2009		ivltests
 sv_typedef_fwd_class2	CE,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -442,6 +442,7 @@ sv_port_default9	CE,-g2009		ivltests
 sv_ps_type_class1	CE,-g2009		ivltests
 sv_root_class		CE,-g2009		ivltests
 sv_typedef_fwd_class	CE,-g2009		ivltests
+sv_typedef_fwd_class2	CE,-g2009		ivltests
 sv_typedef_fwd_enum3	CE,-g2009		ivltests
 sv_typedef_scope3	CE,-g2009		ivltests
 sv_unit2b		CE,-g2009		ivltests


### PR DESCRIPTION
Elaboration uses a multi stage approach. Currently non-static class
properties are elaborated during the scope elaboration phase. This can
cause problems if the type of a property is declared in a different scope.
In that case it is possible that the scope in which the type is defined has
not been elaborated yet and the type is not available. E.g.

```SystemVerilog
package P;
  typedef int T;
endpackage

class C;
  P::T x;
endclass
```

Another area where this is problematic is when a class has a property of a
another class that has a forward declaration. In this case the type of the
forward declared class, which is created when the scope is elaborated, is
not available when the scope of the class that is using it is elaborated.
E.g.

```SystemVerilog
typedef class B;

class A;
  B b;
endclass

class B;
endclass
```

To avoid this elaborate the properties during the signal elaboration phase.