### PR TITLE
Handle empty for-loop init statement

### DIFF
--- a/design_dump.cc
+++ b/design_dump.cc
@@ -1381,7 +1381,12 @@ void NetForever::dump(ostream&o, unsigned ind) const
 
 void NetForLoop::dump(ostream&fd, unsigned ind) const
 {
-      fd << setw(ind) << "" << "FOR LOOP index=" << index_->name() << endl;
+      fd << setw(ind) << "" << "FOR LOOP index=";
+      if (index_)
+	    fd << index_->name();
+      else
+	    fd << "<nil>";
+      fd << endl;
       statement_->dump(fd, ind+4);
       step_statement_->dump(fd, ind+4);
 }

--- a/ivtest/ivltests/br_gh801.v
+++ b/ivtest/ivltests/br_gh801.v
@@ -1,0 +1,16 @@
+
+module main;
+   initial begin
+      int idx;
+      idx = 1;
+      for ( ; idx < 5 ; idx += 1) begin
+	 $display("... %02d", idx);
+      end
+      if (idx !== 5) begin
+	 $display("FAILED -- idx=%0d", idx);
+	 $finish;
+      end
+      $display("PASSED");
+      $finish;
+   end
+endmodule // main

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -221,6 +221,7 @@ br_gh672		normal,-g2009		ivltests
 br_gh699		CE,-g2009		ivltests
 br_gh756		normal,-g2009		ivltests
 br_gh782a		normal,-g2009		ivltests gold=br_gh782a.gold
+br_gh801		normal,-g2009		ivltests
 br_ml20171017		normal,-g2009		ivltests
 br_ml20180227		CE,-g2009		ivltests
 br_ml20180309a		normal,-g2009		ivltests

--- a/net_proc.cc
+++ b/net_proc.cc
@@ -207,12 +207,19 @@ NetForLoop::NetForLoop(NetNet*ind, NetExpr*iexpr, NetExpr*cond, NetProc*sub, Net
 void NetForLoop::wrap_up()
 {
       NetBlock*top = new NetBlock(NetBlock::SEQU, 0);
-      top->set_line(*this);
 
-      NetAssign_*lv = new NetAssign_(index_);
-      NetAssign*set_stmt = new NetAssign(lv, init_expr_);
-      set_stmt->set_line(*init_expr_);
-      top->append(set_stmt);
+      // Handle the case that we are missing the initialization
+      // statement. This can happen for example with statments like this:
+      //   for ( ; <condition> ; <step> ) <statement> ;
+      // If the index_ and init_expr_ are present, then generate the
+      // inital assignment and push it into the sequential block
+      if (index_ || init_expr_) {
+	    top->set_line(*this);
+	    NetAssign_*lv = new NetAssign_(index_);
+	    NetAssign*set_stmt = new NetAssign(lv, init_expr_);
+	    set_stmt->set_line(*init_expr_);
+	    top->append(set_stmt);
+      }
 
       NetBlock*internal_block = new NetBlock(NetBlock::SEQU, 0);
       internal_block->set_line(*this);

--- a/parse.y
+++ b/parse.y
@@ -1,7 +1,7 @@
 
 %{
 /*
- * Copyright (c) 1998-2021 Stephen Williams (steve@icarus.com)
+ * Copyright (c) 1998-2022 Stephen Williams (steve@icarus.com)
  * Copyright CERN 2012-2013 / Stephen Williams (steve@icarus.com)
  *
  *    This source code is free software; you can redistribute it
@@ -1619,6 +1619,14 @@ loop_statement /* IEEE1800-2005: A.6.8 */
   : K_for '(' lpvalue '=' expression ';' expression ';' for_step ')'
     statement_or_null
       { PForStatement*tmp = new PForStatement($3, $5, $7, $9, $11);
+	FILE_NAME(tmp, @1);
+	$$ = tmp;
+      }
+
+      // The initialization statement is optional.
+  | K_for '(' ';' expression ';' for_step ')'
+    statement_or_null
+      { PForStatement*tmp = new PForStatement(nullptr, nullptr, $4, $6, $8);
 	FILE_NAME(tmp, @1);
 	$$ = tmp;
       }

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -1142,8 +1142,22 @@ void PForever::dump(ostream&out, unsigned ind) const
 
 void PForStatement::dump(ostream&out, unsigned ind) const
 {
-      out << setw(ind) << "" << "for (" << *name1_ << " = " << *expr1_
-	  << "; " << *cond_ << "; <for_step>)" << endl;
+      out << setw(ind) << "" << "for (";
+      if (name1_)
+	    out << *name1_;
+      else
+	    out << "<no-name1>";
+      out << " = ";
+      if (expr1_)
+	    out << *expr1_;
+      else
+	    out << "<no-expr1>";
+      out << "; ";
+      if (cond_)
+	    out << *cond_;
+      else
+	    out << "<no-cond>";
+      out << "; <for_step>)" << endl;
       step_->dump(out, ind+6);
       if (statement_)
 	    statement_->dump(out, ind+3);

--- a/synth2.cc
+++ b/synth2.cc
@@ -1453,6 +1453,12 @@ bool NetForLoop::synth_async(Design*des, NetScope*scope,
 			     NexusSet&nex_map, NetBus&nex_out,
 			     NetBus&enables, vector<mask_t>&bitmasks)
 {
+      if (!index_) {
+	    cerr << get_fileline() << ": sorry: Unable to synthesize for-loop without explicit index variable." << endl;
+	    return false;
+      }
+
+      ivl_assert(*this, index_ && init_expr_);
       if (debug_synth2) {
 	    cerr << get_fileline() << ": NetForLoop::synth_async: "
 		 << "Index variable is " << index_->name() << endl;


### PR DESCRIPTION
It is legal systemverilog to have empty init statements in the for-loop statement. This unrolls as a while loop, and presumes that the programmer has handled loop variable initialization elsewhere. This precludes some clevernesses like synthesis or loop unrolling, but that should not be a problem in general.

This resolves #801
