### PR TITLE
Post type support refactoring cleanup

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -433,7 +433,7 @@ void PEIdent::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 
                   ss = ss->parent_scope();
             }
-            PWire*net = new PWire(name, type, NetNet::NOT_A_PORT, IVL_VT_LOGIC);
+            PWire*net = new PWire(name, type, NetNet::NOT_A_PORT);
             net->set_file(get_file());
             net->set_lineno(get_lineno());
             scope->wires[name] = net;

--- a/PWire.cc
+++ b/PWire.cc
@@ -28,10 +28,8 @@ using namespace std;
 PWire::PWire(perm_string n,
 	     NetNet::Type t,
 	     NetNet::PortType pt,
-	     ivl_variable_type_t dt,
 	     PWSRType rt)
-: name_(n), type_(t), port_type_(pt), data_type_(dt),
-  signed_(false),
+: name_(n), type_(t), port_type_(pt), signed_(false),
   port_set_(false), net_set_(false), is_scalar_(false),
   error_cnt_(0), discipline_(0)
 {
@@ -107,21 +105,6 @@ bool PWire::set_port_type(NetNet::PortType pt)
 	    else
 		  return true;
       }
-}
-
-bool PWire::set_data_type(ivl_variable_type_t dt)
-{
-      if (data_type_ != IVL_VT_NO_TYPE) {
-	    if (data_type_ != dt)
-		  return false;
-	    else
-		  return true;
-      }
-
-      assert(data_type_ == IVL_VT_NO_TYPE);
-      data_type_ = dt;
-
-      return true;
 }
 
 void PWire::set_signed(bool flag)

--- a/PWire.h
+++ b/PWire.h
@@ -57,7 +57,6 @@ class PWire : public PNamedItem {
       PWire(perm_string name,
 	    NetNet::Type t,
 	    NetNet::PortType pt,
-	    ivl_variable_type_t dt,
 	    PWSRType rt = SR_NET);
 
 	// Return a hierarchical name.
@@ -71,8 +70,6 @@ class PWire : public PNamedItem {
 
       void set_signed(bool flag);
       bool get_signed() const;
-
-      bool set_data_type(ivl_variable_type_t dt);
 
       void set_range(const std::list<pform_range_t>&ranges, PWSRType type);
 
@@ -101,7 +98,6 @@ class PWire : public PNamedItem {
       perm_string name_;
       NetNet::Type type_;
       NetNet::PortType port_type_;
-      ivl_variable_type_t data_type_;
       bool signed_;
 
 	// These members hold expressions for the bit width of the

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -962,7 +962,13 @@ ivl_type_t PWire::elaborate_type(Design*des, NetScope*scope,
 
       // Fallback method. Create vector type.
 
-      ivl_variable_type_t use_data_type = data_type_;
+      ivl_variable_type_t use_data_type;
+      if (vec_type) {
+	    use_data_type = vec_type->base_type;
+      } else {
+	    use_data_type = IVL_VT_LOGIC;
+      }
+
       if (use_data_type == IVL_VT_NO_TYPE) {
 	    use_data_type = IVL_VT_LOGIC;
 	    if (debug_elaborate) {
@@ -1009,9 +1015,10 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PWire::elaborate_sig: "
 		 << "Signal " << basename()
-		 << ", wtype=" << wtype
-		 << ", data_type_=" << data_type_
-		 << ", unpacked_.size()=" << unpacked_.size()
+		 << ", wtype=" << wtype;
+	    if (set_data_type_)
+		  cerr << ", set_data_type_=" << *set_data_type_;
+	    cerr << ", unpacked_.size()=" << unpacked_.size()
 		 << endl;
       }
 

--- a/parse.y
+++ b/parse.y
@@ -6883,7 +6883,7 @@ udp_port_decl
       { $$ = pform_make_udp_input_ports($2); }
   | K_output IDENTIFIER ';'
       { perm_string pname = lex_strings.make($2);
-	PWire*pp = new PWire(pname, NetNet::IMPLICIT, NetNet::POUTPUT, IVL_VT_LOGIC);
+	PWire*pp = new PWire(pname, NetNet::IMPLICIT, NetNet::POUTPUT);
 	vector<PWire*>*tmp = new std::vector<PWire*>(1);
 	(*tmp)[0] = pp;
 	$$ = tmp;
@@ -6891,7 +6891,7 @@ udp_port_decl
       }
   | K_reg IDENTIFIER ';'
       { perm_string pname = lex_strings.make($2);
-	PWire*pp = new PWire(pname, NetNet::REG, NetNet::PIMPLICIT, IVL_VT_LOGIC);
+	PWire*pp = new PWire(pname, NetNet::REG, NetNet::PIMPLICIT);
 	vector<PWire*>*tmp = new std::vector<PWire*>(1);
 	(*tmp)[0] = pp;
 	$$ = tmp;
@@ -6899,7 +6899,7 @@ udp_port_decl
       }
   | K_output K_reg IDENTIFIER ';'
       { perm_string pname = lex_strings.make($3);
-	PWire*pp = new PWire(pname, NetNet::REG, NetNet::POUTPUT, IVL_VT_LOGIC);
+	PWire*pp = new PWire(pname, NetNet::REG, NetNet::POUTPUT);
 	vector<PWire*>*tmp = new std::vector<PWire*>(1);
 	(*tmp)[0] = pp;
 	$$ = tmp;

--- a/pform.cc
+++ b/pform.cc
@@ -2085,7 +2085,7 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	/* Make the PWire for the output port. */
       pins[0] = new PWire(out_name,
 			  synchronous_flag? NetNet::REG : NetNet::WIRE,
-			  NetNet::POUTPUT, IVL_VT_LOGIC);
+			  NetNet::POUTPUT);
       FILE_NAME(pins[0], loc);
 
 	/* Make the PWire objects for the input ports. */
@@ -2096,7 +2096,7 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 		   ;  idx += 1, ++ cur) {
 	      assert(idx < pins.size());
 	      pins[idx] = new PWire(*cur, NetNet::WIRE,
-				    NetNet::PINPUT, IVL_VT_LOGIC);
+				    NetNet::PINPUT);
 	      FILE_NAME(pins[idx], loc);
 	}
 	assert(idx == pins.size());
@@ -2172,7 +2172,6 @@ static void pform_set_net_range(PWire *wire,
       if (range)
 	    wire->set_range(*range, rt);
       wire->set_signed(vec_type->signed_flag);
-      wire->set_data_type(vec_type->base_type);
 }
 
 /*
@@ -2583,7 +2582,7 @@ static PWire* pform_get_or_make_wire(const struct vlltype&li, perm_string name,
 	// to the scope. Do not delete the old wire - it will
 	// remain in the local symbol map.
 
-      cur = new PWire(name, type, ptype, IVL_VT_NO_TYPE, rt);
+      cur = new PWire(name, type, ptype, rt);
       FILE_NAME(cur, li);
 
       pform_put_wire_in_scope(name, cur);
@@ -2615,10 +2614,9 @@ void pform_module_define_port(const struct vlltype&li,
 
       PWire *cur = pform_get_or_make_wire(li, name, type, port_kind, SR_BOTH);
 
-      vector_type_t*vec_type = dynamic_cast<vector_type_t*> (vtype);
-      if (vec_type)
-	    pform_set_net_range(cur, vec_type, SR_BOTH);
-      else if (vtype)
+      pform_set_net_range(cur, dynamic_cast<vector_type_t*> (vtype), SR_BOTH);
+
+      if (vtype)
 	    cur->set_data_type(vtype);
 
       if (urange) {
@@ -2774,6 +2772,8 @@ static vector<pform_tf_port_t>*pform_make_task_ports_vec(const struct vlltype&lo
 		 port direction. If not, create it. */
 	    PWire*curw = pform_get_or_make_wire(loc, name, NetNet::IMPLICIT_REG,
 						pt, rt);
+	    if (rt == SR_BOTH)
+		  curw->set_data_type(vec_type);
 	    pform_set_net_range(curw, vec_type, rt);
 
 	    if (cur->udims) {
@@ -3275,8 +3275,7 @@ vector<PWire*>* pform_make_udp_input_ports(list<perm_string>*names)
 	    perm_string txt = *cur;
 	    PWire*pp = new PWire(txt,
 				 NetNet::IMPLICIT,
-				 NetNet::PINPUT,
-				 IVL_VT_LOGIC);
+				 NetNet::PINPUT);
 	    (*out)[idx] = pp;
 	    idx += 1;
       }

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -620,8 +620,6 @@ void PWire::dump(ostream&out, unsigned ind) const
 	    break;
       }
 
-      out << " " << data_type_;
-
       if (signed_) {
 	    out << " signed";
       }


### PR DESCRIPTION
With the refactoring of the type support complete and the parser being mostly type agnostic there are 2 small cleanups that can be done in the parser support code.

- Remove `ivl_variable_type_t` from `PWire`. Each `PWire` now either has an explicit data_type_t attached from which the base type can be queried or it is a implicit typed variable in which case it is a 4-state vector.
- `pform_make_task_ports_vec` and `do_make_task_ports` look very similar now and can be consolidated