### PR TITLE
Add br_gh800 test

### DIFF
--- a/ivtest/ivltests/br_gh800.v
+++ b/ivtest/ivltests/br_gh800.v
@@ -1,0 +1,52 @@
+
+// br_gh800 (github Issue #800)
+module AssignLiterals;
+   initial begin
+      string s;
+
+      // Note that the \0 in this string literal assigned to the string
+      // must disappear, leaving "AB" what is actually assigned to the
+      // string. See IEEE Std 1800-2017: 6.16 String data type.
+      s = "A\0B";
+      $display("1. '%s' len=%1d hex=%02h%02h%02h",s,s.len(), s[0], s[1], s[2]);
+      if (s.len() != 2 || s != "AB" || s[0] !== 'h41 || s[1] !== 'h42) begin
+	 $display("FAILED");
+	 $finish;
+      end
+
+      s = "A\015\12B";
+      $display("2. len=%1d hex=%02h%02h%02h%02h",s.len(), s[0], s[1], s[2], s[3]);
+      if (s.len() != 4 || s[0] !== 'h41 || s[1] !== 'h0d
+	  || s[2] !== 'h0a || s[3] !== 'h42) begin
+	 $display("FAILED");
+	 $finish;
+      end
+
+      s = {"A","\015","\012","B"};
+      $display("3. len=%1d hex=%02h%02h%02h%02h",s.len(), s[0], s[1], s[2], s[3]);
+      if (s.len() != 4 || s[0] !== 'h41 || s[1] !== 'h0d
+	  || s[2] !== 'h0a || s[3] !== 'h42) begin
+	 $display("FAILED");
+	 $finish;
+      end
+
+      s = "A\170\171B";
+      $display("4. '%s' len=%1d hex=%02h%02h%02h%02h",s,s.len(),
+	       s[0], s[1], s[2], s[3]);
+      if (s.len() != 4 || s[0] !== 'h41 || s[1] !== 'h78 || s[2] !== 'h79
+	  || s[3] !== 'h42) begin
+	 $display("FAILED");
+	 $finish;
+      end
+
+      s = {"A",8'o15,8'o12,"\012","B"};
+      $display("5. len=%1d hex=%02h%02h%02h%02h%02h",s.len(), s[0], s[1], s[2], s[3], s[4]);
+      if (s.len() != 5 || s[0] !== 'h41 || s[1] !== 'h0d
+	  || s[2] !== 'h0a || s[3] !== 'h0a || s[4] !== 'h42) begin
+	 $display("FAILED");
+	 $finish;
+      end
+
+      $display("PASSED");
+    end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -228,6 +228,7 @@ br_gh699		CE,-g2009		ivltests
 br_gh756		normal,-g2009		ivltests
 br_gh782a		normal,-g2009		ivltests gold=br_gh782a.gold
 br_gh782b		normal,-g2009		ivltests gold=br_gh782b.gold
+br_gh800		normal,-g2009		ivltests
 br_gh801		normal,-g2009		ivltests
 br_gh801b		normal,-g2009		ivltests
 br_ml20171017		normal,-g2009		ivltests


### PR DESCRIPTION
Issue #800 is apparently not a problem with the compiler, but with the regression test suite. This PR adds a detailed test that shows the correct output, but on windows, the compare with the gold file seems to not work. The issue is wrapped around the \r\n characters being treaded weird on Windows machines. So do address this, change the test to not use the gold file, and instead self-test by looking at values that are assigned to the string.

fixes #800 
