### PR TITLE
 Implement has_aa_term() for cast expressions

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -142,6 +142,11 @@ PECastSize::~PECastSize()
 {
 }
 
+bool PECastSize::has_aa_term(Design *des, NetScope *scope) const
+{
+	return base_->has_aa_term(des, scope);
+}
+
 PECastType::PECastType(data_type_t*t, PExpr*b)
 : target_(t), base_(b)
 {
@@ -151,10 +156,20 @@ PECastType::~PECastType()
 {
 }
 
+bool PECastType::has_aa_term(Design *des, NetScope *scope) const
+{
+	return base_->has_aa_term(des, scope);
+}
+
 PECastSign::PECastSign(bool signed_flag, PExpr *base)
 : base_(base)
 {
     signed_flag_ = signed_flag;
+}
+
+bool PECastSign::has_aa_term(Design *des, NetScope *scope) const
+{
+	return base_->has_aa_term(des, scope);
 }
 
 PEBComp::PEBComp(char op, PExpr*l, PExpr*r)

--- a/PExpr.h
+++ b/PExpr.h
@@ -972,6 +972,8 @@ class PECastSize  : public PExpr {
 				     unsigned expr_wid,
                                      unsigned flags) const;
 
+      virtual bool has_aa_term(Design *des, NetScope *scope) const;
+
       virtual unsigned test_width(Design*des, NetScope*scope,
 				  width_mode_t&mode);
 
@@ -997,6 +999,8 @@ class PECastType  : public PExpr {
       virtual NetExpr*elaborate_expr(Design*des, NetScope*scope,
 				     unsigned expr_wid, unsigned flags) const;
 
+      virtual bool has_aa_term(Design *des, NetScope *scope) const;
+
       virtual unsigned test_width(Design*des, NetScope*scope,
 				  width_mode_t&mode);
 
@@ -1019,6 +1023,8 @@ class PECastSign : public PExpr {
 
       NetExpr* elaborate_expr(Design *des, NetScope *scope,
 			      unsigned expr_wid, unsigned flags) const;
+
+      virtual bool has_aa_term(Design *des, NetScope *scope) const;
 
       unsigned test_width(Design *des, NetScope *scope, width_mode_t &mode);
 

--- a/ivtest/ivltests/automatic_error16.v
+++ b/ivtest/ivltests/automatic_error16.v
@@ -1,0 +1,21 @@
+// Check that an expression is correctly detected to contain an automatic
+// variable if the variable is in a SystemVerilog size cast expression.
+
+module automatic_error;
+
+  reg g;
+
+  task automatic auto_task;
+    reg l;
+
+    begin: block
+      assign g = 1'(l);
+    end
+  endtask
+
+  initial begin
+    auto_task;
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/automatic_error17.v
+++ b/ivtest/ivltests/automatic_error17.v
@@ -1,0 +1,22 @@
+// Check that an expression is correctly detected to contain an automatic
+// variable if the variable is in a SystemVerilog sign cast expression.
+
+module test;
+
+  reg g;
+
+  task automatic auto_task;
+    reg l;
+
+    begin: block
+      assign g = signed'(l);
+    end
+
+  endtask
+
+  initial begin
+    auto_task;
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/automatic_error18.v
+++ b/ivtest/ivltests/automatic_error18.v
@@ -1,0 +1,22 @@
+// Check that an expression is correctly detected to contain an automatic
+// variable if the variable is in a SystemVerilog type cast expression.
+
+module test;
+
+  reg g;
+
+  task automatic auto_task;
+    reg l;
+
+    begin: block
+      assign g = reg'(l);
+    end
+
+  endtask
+
+  initial begin
+    auto_task;
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -106,6 +106,9 @@ assign_op_real_array_oob normal,-g2009		ivltests
 assign_op_type		normal,-g2009		ivltests
 automatic_error14	CE,-g2005-sv		ivltests
 automatic_error15	CE,-g2005-sv		ivltests
+automatic_error16	CE,-g2005-sv		ivltests
+automatic_error17	CE,-g2005-sv		ivltests
+automatic_error18	CE,-g2005-sv		ivltests
 bitp1			normal,-g2005-sv	ivltests
 bits			normal,-g2005-sv	ivltests
 bits2			normal,-g2005-sv	ivltests


### PR DESCRIPTION
If the base expression of a cast expression has an automatic term then the
cast expression itself has an automatic term.

Make sure this is implemented so that an error is properly reported when
using such an expression in a context where automatic variables are not
allowed.