### PR TITLE
Fix $left/$right for C-style unpacked arrays

### DIFF
--- a/ivtest/ivltests/sv_array_query.v
+++ b/ivtest/ivltests/sv_array_query.v
@@ -1,0 +1,30 @@
+// Check that array query functions return the correct value for C style arrays
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr !== val) begin \
+      $display("FAILED: %s, expected %0d, got %0d", `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+  bit [1:0] a[10];
+
+  initial begin
+    `check($left(a), 0)
+    `check($right(a), 9)
+    `check($low(a), 0)
+    `check($high(a), 9)
+    `check($size(a), 10)
+    `check($increment(a), -1)
+    `check($dimensions(a), 2)
+    `check($unpacked_dimensions(a), 1)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -499,6 +499,7 @@ sv_assign_pattern_func	normal,-g2005-sv	ivltests
 sv_assign_pattern_op	normal,-g2005-sv	ivltests
 sv_assign_pattern_part	normal,-g2005-sv	ivltests
 sv_array_assign_pattern2	normal,-g2009	ivltests
+sv_array_query		normal,-g2005-sv	ivltests
 sv_cast_integer		normal,-g2005-sv	ivltests
 sv_cast_integer2		normal,-g2005-sv	ivltests
 sv_cast_packed_array	normal,-g2005-sv	ivltests

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1099,8 +1099,8 @@ bool evaluate_range(Design*des, NetScope*scope, const LineInfo*li,
                   if (!dimension_ok) {
                         // bail out
                   } else if (index_l > 0) {
-                        index_l = index_l - 1;
-                        index_r = 0;
+                        index_r = index_l - 1;
+                        index_l = 0;
                   } else {
                         cerr << range.first->get_fileline() << ": error: "
                                 "Dimension size must be greater than zero." << endl;


### PR DESCRIPTION
Unpacked array dimensions that are specified with only a single size value
(C-style unpacked arrays) have a $left of 0 and a $right of $size - 1. E.g.
`x[10]` is equivalent to `x[0:9]`. This is defined in the LRM (1800-2017)
section 7.4.2 ("Unpacked arrays").

Currently it is implemented the other way around. There are a few contexts
where this distinction matters. For example array to array assignments,
which supposed to be done left-to-right and not high-to-low.