### PR TITLE
 Add support for void cast function call

### DIFF
--- a/Statement.h
+++ b/Statement.h
@@ -235,6 +235,7 @@ class PCallTask  : public Statement {
       NetProc*elaborate_function_(Design*des, NetScope*scope) const;
       NetProc*elaborate_void_function_(Design*des, NetScope*scope,
 				       NetFuncDef*def) const;
+      NetProc *elaborate_non_void_function_(Design *des, NetScope *scope) const;
 
       NetProc*elaborate_build_call_(Design*des, NetScope*scope,
 				    NetScope*task, NetExpr*use_this) const;

--- a/Statement.h
+++ b/Statement.h
@@ -226,6 +226,8 @@ class PCallTask  : public Statement {
 
       bool elaborate_elab(Design*des, NetScope*scope) const;
 
+      void void_cast() { void_cast_ = true; }
+
     private:
       NetProc* elaborate_sys(Design*des, NetScope*scope) const;
       NetProc* elaborate_usr(Design*des, NetScope*scope) const;
@@ -257,6 +259,7 @@ class PCallTask  : public Statement {
       PPackage*package_;
       pform_name_t path_;
       std::vector<PExpr*> parms_;
+      bool void_cast_ = false;
 };
 
 class PCase  : public Statement {

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3390,10 +3390,14 @@ NetProc* PCondit::elaborate(Design*des, NetScope*scope) const
 
 NetProc* PCallTask::elaborate(Design*des, NetScope*scope) const
 {
-      if (peek_tail_name(path_)[0] == '$')
-	    return elaborate_sys(des, scope);
-      else
+      if (peek_tail_name(path_)[0] == '$') {
+	    if (void_cast_)
+		  return elaborate_non_void_function_(des, scope);
+	    else
+		  return elaborate_sys(des, scope);
+      } else {
 	    return elaborate_usr(des, scope);
+      }
 }
 
 /*
@@ -3690,8 +3694,10 @@ NetProc* PCallTask::elaborate_method_func_(NetScope*scope,
 					   perm_string method_name,
                                            const char*sys_task_name) const
 {
-      cerr << get_fileline() << ": warning: method function '"
-           << method_name << "' is being called as a task." << endl;
+      if (!void_cast_) {
+	    cerr << get_fileline() << ": warning: method function '"
+		 << method_name << "' is being called as a task." << endl;
+      }
 
 	// Generate the function.
       NetESFunc*sys_expr = new NetESFunc(sys_task_name, type, 1);
@@ -3906,8 +3912,11 @@ NetProc *PCallTask::elaborate_non_void_function_(Design *des, NetScope *scope) c
       PAssign*tmp = new PAssign(0, rval);
       tmp->set_file(get_file());
       tmp->set_lineno(get_lineno());
-      cerr << get_fileline() << ": warning: User function '"
-           << peek_tail_name(path_) << "' is being called as a task." << endl;
+      if (!void_cast_) {
+	    cerr << get_fileline() << ": warning: User function '"
+		 << peek_tail_name(path_) << "' is being called as a task." << endl;
+      }
+
 	// Elaborate the assignment to a dummy variable.
       return tmp->elaborate(des, scope);
 }
@@ -3962,11 +3971,23 @@ NetProc* PCallTask::elaborate_build_call_(Design*des, NetScope*scope,
 	      // that we can catch more errors.
 	    test_task_calls_ok_(des, scope);
 
+	    if (void_cast_) {
+		  cerr << get_fileline() << ": error: void casting user task '"
+		       << peek_tail_name(path_) << "' is not allowed." << endl;
+		  des->errors++;
+	    }
+
       } else if (task->type() == NetScope::FUNC) {
 	    NetFuncDef*tmp = task->func_def();
 	    if (!tmp->is_void())
 		  return elaborate_non_void_function_(des, scope);
 	    def = tmp;
+
+	    if (void_cast_) {
+		  cerr << get_fileline() << ": error: void casting user void function '"
+		       << peek_tail_name(path_) << "' is not allowed." << endl;
+		  des->errors++;
+	    }
       }
 
 	/* The caller has checked the parms_ size to make sure it

--- a/ivtest/ivltests/sv_void_cast1.v
+++ b/ivtest/ivltests/sv_void_cast1.v
@@ -1,0 +1,37 @@
+// Check that void casts are supported
+
+module test;
+
+  int a;
+  real b;
+  string c;
+
+  function int f1(int x);
+    a = x;
+    return x;
+  endfunction
+
+  function real f2(real x);
+    b = x;
+    return x;
+  endfunction
+
+  function string f3(string x);
+    c = x;
+    return x;
+  endfunction
+
+
+  initial begin
+    void'(f1(10));
+    void'(f2(1.0));
+    void'(f3("10"));
+
+    if (a === 10 && b == 1.0 && c == "10") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_void_cast2.v
+++ b/ivtest/ivltests/sv_void_cast2.v
@@ -1,0 +1,41 @@
+// Check that void casts on class methods are supported
+
+module test;
+
+  int a;
+  real b;
+  string c;
+
+  class C;
+    function int f1(int x);
+      a = x;
+      return x;
+    endfunction
+
+    function real f2(real x);
+      b = x;
+      return x;
+    endfunction
+
+    function string f3(string x);
+      c = x;
+      return x;
+    endfunction
+  endclass
+
+  C d;
+
+  initial begin
+    d = new;
+    void'(d.f1(10));
+    void'(d.f2(1.0));
+    void'(d.f3("10"));
+
+    if (a === 10 && b == 1.0 && c == "10") begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_void_cast3.v
+++ b/ivtest/ivltests/sv_void_cast3.v
@@ -1,0 +1,18 @@
+// Check that void casts on methods of built-in types is supported
+
+module test;
+
+  int q[$];
+
+  initial begin
+    q.push_back(1);
+    void'(q.pop_back());
+
+    if (q.size() === 0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_void_cast4.v
+++ b/ivtest/ivltests/sv_void_cast4.v
@@ -1,0 +1,11 @@
+// Check that void casts on SystemFunctions is supported
+
+module test;
+
+  initial begin
+    void'($clog2(10));
+
+    $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_void_cast_fail1.v
+++ b/ivtest/ivltests/sv_void_cast_fail1.v
@@ -1,0 +1,12 @@
+// Check that void casting a void function results in an error
+
+module test;
+
+  function void f(int x);
+  endfunction
+
+  initial begin
+    void'(f(10));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_void_cast_fail2.v
+++ b/ivtest/ivltests/sv_void_cast_fail2.v
@@ -1,0 +1,12 @@
+// Check that void casting a task results in an error
+
+module test;
+
+  task t(int x);
+  endtask
+
+  initial begin
+    void'(t(10));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_void_cast_fail3.v
+++ b/ivtest/ivltests/sv_void_cast_fail3.v
@@ -1,0 +1,9 @@
+// Check that void casting an expression results in an error
+
+module test;
+
+  initial begin
+    void'(1+2);
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -803,6 +803,13 @@ sv_var_module_output1	normal,-g2005-sv	ivltests
 sv_var_module_output2	normal,-g2005-sv	ivltests
 sv_var_package		normal,-g2005-sv	ivltests
 sv_var_task		normal,-g2005-sv	ivltests
+sv_void_cast1		normal,-g2005-sv	ivltests
+sv_void_cast2		normal,-g2005-sv	ivltests
+sv_void_cast3		normal,-g2005-sv	ivltests
+sv_void_cast4		normal,-g2005-sv	ivltests
+sv_void_cast_fail1	CE,-g2005-sv		ivltests
+sv_void_cast_fail2	CE,-g2005-sv		ivltests
+sv_void_cast_fail3	CE,-g2005-sv		ivltests
 sv_wildcard_import1	normal,-g2009		ivltests
 sv_wildcard_import2	normal,-g2009		ivltests
 sv_wildcard_import3	normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -515,6 +515,9 @@ sv_typedef_queue_base1	CE,-g2009		ivltests  # queue
 sv_typedef_queue_base2	CE,-g2009		ivltests  # queue
 sv_typedef_queue_base3	CE,-g2009		ivltests  # queue
 sv_typedef_queue_base4	CE,-g2009		ivltests  # queue
+sv_void_cast1		CE,-g2009,-pallowsigned=1	ivltests # string
+sv_void_cast2		CE,-g2009,-pallowsigned=1	ivltests # string, class
+sv_void_cast3		CE,-g2009,-pallowsigned=1	ivltests # queue
 wait_fork		CE,-g2009		ivltests  # wait fork and join_*
 wild_cmp_err		CE,-g2009		ivltests  # ==?/!=?
 wild_cmp_err2		CE,-g2009		ivltests  # ==?/!=?
@@ -977,6 +980,7 @@ sv_var_module_output1	normal,-g2005-sv,-pallowsigned=1	ivltests
 sv_var_module_output2	normal,-g2005-sv,-pallowsigned=1	ivltests
 sv_var_package		normal,-g2005-sv,-pallowsigned=1	ivltests
 sv_var_task		normal,-g2005-sv,-pallowsigned=1	ivltests
+sv_void_cast4		normal,-g2009,-pallowsigned=1		ivltests
 test_dispwided		normal,-pallowsigned=1	ivltests gold=test_dispwided.gold
 test_inc_dec		normal,-g2009,-pallowsigned=1	ivltests
 test_enumsystem		normal,-g2009,-pallowsigned=1,ivltests/enumsystem.vhd	ivltests


### PR DESCRIPTION
SystemVerilog has explicit support for calling a function
as a statement. This is allowed when the function call is encapsulated in
`void'(...)`. E.g. `void'(f(1, 2, 3));`

We already support calling function calls as statements without the void
cast and emit a warning when doing so.

Adding support for void casts only requires to update the parser to handle
the void cast and then do not emit the warning if a function is called as
a statement as part of a void cast.

Void casting a task or void function call is not allowed and will generate
an elaboration error.

Also be consistent between allowing to call non-void function and non-void
class methods as statements. The former currently generates a warning
the latter an error. Change it so that both report a warning.

Resolves #434 