### PR TITLE
Clean up warnings

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -4023,7 +4023,7 @@ unsigned PEIdent::test_width_method_(Design*des, NetScope*scope, width_mode_t&)
 	    }
       }
 
-      if (const struct netqueue_t *queue = net->queue_type()) {
+      if (const class netqueue_t *queue = net->queue_type()) {
 	    if (member_name == "pop_back" || member_name == "pop_front") {
 		  expr_type_ = queue->element_base_type();
 		  expr_width_ = queue->element_width();
@@ -6601,7 +6601,6 @@ NetExpr* PENewClass::elaborate_expr_constructor_(Design*des, NetScope*scope,
       parms[0] = obj;
 
       int missing_parms = 0;
-      int parm_errors = 0;
       for (size_t idx = 1 ; idx < parms.size() ; idx += 1) {
 	      // While there are default arguments, check them.
 	    if (idx <= parms_.size() && parms_[idx-1]) {
@@ -6609,8 +6608,9 @@ NetExpr* PENewClass::elaborate_expr_constructor_(Design*des, NetScope*scope,
 		  parms[idx] = elaborate_rval_expr(des, scope,
 						   def->port(idx)->net_type(),
 						   tmp, false);
-		  if (parms[idx] == 0)
-			parm_errors += 1;
+		  // NOTE: if elaborate_rval_expr fails, it will return a
+		  // nullptr, but it will also increment des->errors so there
+		  // is nothing we need to do here.
 
 		  continue;
 	    }
@@ -6632,7 +6632,6 @@ NetExpr* PENewClass::elaborate_expr_constructor_(Design*des, NetScope*scope,
       if (missing_parms > 0) {
 	    cerr << get_fileline() << ": error: The " << scope_path(new_scope)
 		 << " constructor call is missing arguments." << endl;
-	    parm_errors += 1;
 	    des->errors += 1;
       }
 

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -140,7 +140,7 @@ ivl_type_t enum_type_t::elaborate_type_raw(Design *des, NetScope *scope) const
 {
       ivl_type_t base = base_type->elaborate_type(des, scope);
 
-      const struct netvector_t *vec_type = dynamic_cast<const netvector_t*>(base);
+      const class netvector_t *vec_type = dynamic_cast<const netvector_t*>(base);
 
       if (!vec_type && !dynamic_cast<const netparray_t*>(base)) {
 	    cerr << get_fileline() << ": error: "

--- a/pform.cc
+++ b/pform.cc
@@ -3400,9 +3400,9 @@ int pform_parse(const char*path)
 	    char unit_name[20];
 	    static unsigned nunits = 0;
 	    if (separate_compilation)
-		  sprintf(unit_name, "$unit#%u", ++nunits);
+		  snprintf(unit_name, sizeof(unit_name)-1, "$unit#%u", ++nunits);
 	    else
-		  sprintf(unit_name, "$unit");
+		  snprintf(unit_name, sizeof(unit_name)-1, "$unit");
 
 	    PPackage*unit = new PPackage(lex_strings.make(unit_name), 0);
 	    unit->default_lifetime = LexicalScope::STATIC;

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -673,7 +673,7 @@ bool dll_target::start_design(const Design*des)
       if ((dll_ == 0) && (dll_path_[0] != '/')) {
 	    size_t len = strlen(basedir) + 1 + strlen(dll_path_) + 1;
 	    char*tmp = new char[len];
-	    sprintf(tmp, "%s/%s", basedir, dll_path_);
+	    snprintf(tmp, len, "%s/%s", basedir, dll_path_);
 	    dll_ = ivl_dlopen(tmp);
 	    delete[]tmp;
       }
@@ -2847,7 +2847,7 @@ void dll_target::test_version(const char*target_name)
       if ((dll_ == 0) && (target_name[0] != '/')) {
 	    size_t len = strlen(basedir) + 1 + strlen(target_name) + 1;
 	    char*tmp = new char[len];
-	    sprintf(tmp, "%s/%s", basedir, target_name);
+	    snprintf(tmp, len, "%s/%s", basedir, target_name);
 	    dll_ = ivl_dlopen(tmp);
 	    delete[]tmp;
       }

--- a/tgt-vhdl/state.cc
+++ b/tgt-vhdl/state.cc
@@ -78,7 +78,7 @@ static vhdl_entity *g_active_entity = NULL;
 
 // Set of scopes that are treated as the default examples of
 // that type. Any other scopes of the same type are ignored.
-typedef vector<ivl_scope_t> default_scopes_t;
+typedef std::vector<ivl_scope_t> default_scopes_t;
 static default_scopes_t g_default_scopes;
 
 // True if signal `sig' has already been encountered by the code
@@ -304,14 +304,13 @@ static bool same_scope_type_name(ivl_scope_t a, ivl_scope_t b)
  */
 bool seen_this_scope_type(ivl_scope_t s)
 {
-   if (find_if(g_default_scopes.begin(), g_default_scopes.end(),
-               bind1st(ptr_fun(same_scope_type_name), s))
-       == g_default_scopes.end()) {
-      g_default_scopes.push_back(s);
-      return false;
+   for (auto cur = g_default_scopes.begin() ; cur != g_default_scopes.end() ; cur++) {
+     if (same_scope_type_name(s, *cur))
+       return true;
    }
-   else
-      return true;
+
+   g_default_scopes.push_back(s);
+   return false;
 }
 
 /*

--- a/vhdlpp/parse.y
+++ b/vhdlpp/parse.y
@@ -1563,7 +1563,7 @@ index_subtype_definition_list
 instantiation_list
   : identifier_list
      {
-  instant_list_t* tmp = new instant_list_t(instant_list_t::NONE, $1);
+  instant_list_t* tmp = new instant_list_t(instant_list_t::NO_DOMAIN, $1);
   $$ = tmp;
      }
   | K_others

--- a/vhdlpp/parse_types.h
+++ b/vhdlpp/parse_types.h
@@ -57,7 +57,7 @@ class entity_aspect_t {
 
 class instant_list_t {
     public:
-      typedef enum { ALL = 0, OTHERS, NONE } application_domain_t;
+      typedef enum { ALL = 0, OTHERS, NO_DOMAIN } application_domain_t;
 
       instant_list_t(application_domain_t d, std::list<perm_string>* l) : domain_(d), labels_(l) {}
       ~instant_list_t() { delete labels_; }

--- a/vvp/vpi_callback.cc
+++ b/vvp/vpi_callback.cc
@@ -860,7 +860,8 @@ static double vlg_round(double rval)
 
 static void real_signal_value(struct t_vpi_value*vp, double rval)
 {
-      char*rbuf = (char *) need_result_buf(64 + 1, RBUF_VAL);
+      static const size_t RBUF_SIZE = 64 + 1;
+      char*rbuf = (char *) need_result_buf(RBUF_SIZE, RBUF_VAL);
 
       switch (vp->format) {
 	  case vpiObjTypeVal:
@@ -882,14 +883,14 @@ static void real_signal_value(struct t_vpi_value*vp, double rval)
 
 	  case vpiDecStrVal:
 	    if (std::isnan(rval))
-		  sprintf(rbuf, "%s", "nan");
+		  snprintf(rbuf, RBUF_SIZE, "%s", "nan");
 	    else
-		  sprintf(rbuf, "%0.0f", vlg_round(rval));
+		  snprintf(rbuf, RBUF_SIZE, "%0.0f", vlg_round(rval));
 	    vp->value.str = rbuf;
 	    break;
 
 	  case vpiHexStrVal:
-	    sprintf(rbuf, "%" PRIx64, (uint64_t)vlg_round(rval));
+	    snprintf(rbuf, RBUF_SIZE, "%" PRIx64, (uint64_t)vlg_round(rval));
 	    vp->value.str = rbuf;
 	    break;
 

--- a/vvp/vpi_cobject.cc
+++ b/vvp/vpi_cobject.cc
@@ -68,7 +68,8 @@ void __vpiCobjectVar::vpi_get_value(p_vpi_value val)
 {
 // FIXME: We need to get the assigned object address if one is assigned.
 //fprintf(stderr, "HERE: %p\n", get_net());
-      char*rbuf = (char *) need_result_buf(64 + 1, RBUF_VAL);
+      static const size_t RBUF_USE_SIZE = 64 + 1;
+      char*rbuf = (char *) need_result_buf(RBUF_USE_SIZE, RBUF_VAL);
 
       switch (val->format) {
 	case vpiObjTypeVal:
@@ -79,7 +80,7 @@ void __vpiCobjectVar::vpi_get_value(p_vpi_value val)
 	case vpiOctStrVal:
 	case vpiHexStrVal:
 	case vpiStringVal:
-	    sprintf(rbuf, "    null");
+	    snprintf(rbuf, RBUF_USE_SIZE, "    null");
 	    val->value.str = rbuf;
 	    break;
 

--- a/vvp/vpi_const.cc
+++ b/vvp/vpi_const.cc
@@ -137,21 +137,28 @@ void __vpiStringConst::vpi_get_value(p_vpi_value vp)
 	    break;
 
           case vpiDecStrVal:
-	      if (size > 4){
+	    // Take the (up to 4) characters of the text, convert the characters
+	    // to a numerical value, and convert that value to a decimal string.
+	    // For example, the string "A" is ASCII 65, so the resulting string
+	    // will be "65". and the string "AB" is 65*256 + 66 == 16706, so
+	    // the resulting string is "16706". The "size" is the number of
+	    // characters of input text to put to work.
+	    if (size > 4){
 		  // We only support standard integers. Ignore other bytes...
 		  size = 4;
 		  fprintf(stderr, "Warning (vpi_const.cc): %%d on constant strings only looks "
 			  "at first 4 bytes!\n");
-	      }
-	      rbuf = (char *) need_result_buf(size + 1, RBUF_VAL);
-	      uint_value = 0;
-	      for(unsigned i=0; i<size; i += 1){
+	    }
+	    static const size_t RBUF_USE_SIZE = 12;
+	    rbuf = (char *) need_result_buf(RBUF_USE_SIZE, RBUF_VAL);
+	    uint_value = 0;
+	    for(unsigned i=0; i<size; i += 1){
 		  uint_value <<=8;
 		  uint_value += (unsigned char)(value_[i]);
-	      }
-	      sprintf(rbuf, "%u", uint_value);
-	      vp->value.str = rbuf;
-	      break;
+	    }
+	    snprintf(rbuf, RBUF_USE_SIZE, "%u", uint_value);
+	    vp->value.str = rbuf;
+	    break;
 
           case vpiBinStrVal:
 	      rbuf = (char *) need_result_buf(8 * size + 1, RBUF_VAL);
@@ -574,7 +581,8 @@ int __vpiDecConst::vpi_get(int code)
 
 void __vpiDecConst::vpi_get_value(p_vpi_value vp)
 {
-      char*rbuf = (char *) need_result_buf(64 + 1, RBUF_VAL);
+      static const size_t RBUF_USE_SIZE = 64 + 1;
+      char*rbuf = (char *) need_result_buf(RBUF_USE_SIZE, RBUF_VAL);
       char*cp = rbuf;
 
       switch (vp->format) {
@@ -586,8 +594,7 @@ void __vpiDecConst::vpi_get_value(p_vpi_value vp)
 	  }
 
           case vpiDecStrVal:
-	      sprintf(rbuf, "%d", value);
-
+	      snprintf(rbuf, RBUF_USE_SIZE, "%d", value);
 	      vp->value.str = rbuf;
 	      break;
 
@@ -601,14 +608,12 @@ void __vpiDecConst::vpi_get_value(p_vpi_value vp)
 	      break;
 
           case vpiHexStrVal:
-	      sprintf(rbuf, "%08x", value);
-
+	      snprintf(rbuf, RBUF_USE_SIZE, "%08x", value);
 	      vp->value.str = rbuf;
 	      break;
 
           case vpiOctStrVal:
-	      sprintf(rbuf, "%011x", value);
-
+	      snprintf(rbuf, RBUF_USE_SIZE, "%011x", value);
 	      vp->value.str = rbuf;
 	      break;
 
@@ -796,7 +801,8 @@ int __vpiNullConst::vpi_get(int code)
 
 void __vpiNullConst::vpi_get_value(p_vpi_value val)
 {
-      char*rbuf = (char *) need_result_buf(64 + 1, RBUF_VAL);
+      static const size_t RBUF_USE_SIZE = 64 + 1;
+      char*rbuf = (char *) need_result_buf(RBUF_USE_SIZE, RBUF_VAL);
 
       switch (val->format) {
 
@@ -808,7 +814,7 @@ void __vpiNullConst::vpi_get_value(p_vpi_value val)
 	  case vpiOctStrVal:
 	  case vpiHexStrVal:
 	  case vpiStringVal:
-	    sprintf(rbuf, "null");
+	    snprintf(rbuf, RBUF_USE_SIZE, "null");
 	    val->value.str = rbuf;
 	    break;
 

--- a/vvp/vpi_priv.cc
+++ b/vvp/vpi_priv.cc
@@ -320,7 +320,7 @@ static const char* vpi_property_str(PLI_INT32 code)
           case vpiSize:
 	    return "vpiSize";
 	  default:
-	    sprintf(buf, "%d", (int)code);
+	    snprintf(buf, sizeof(buf), "%d", (int)code);
       }
       return buf;
 }
@@ -402,7 +402,7 @@ const char* vpi_type_as_string(PLI_INT32 code)
 	  case vpiUserSystf:
 	    return "vpiUserSystf";
 	  default:
-	    sprintf(buf, "%d", (int)code);
+	    snprintf(buf, sizeof(buf), "%d", (int)code);
       }
       return buf;
 }

--- a/vvp/vpi_time.cc
+++ b/vvp/vpi_time.cc
@@ -106,7 +106,8 @@ static void timevar_get_value(vpiHandle ref, s_vpi_value*vp, bool is_int_func,
       vvp_time64_t x, simtime = schedule_simtime();
       int units = rfp->scope? rfp->scope->time_units : vpi_time_precision;
 
-      char*rbuf = (char *) need_result_buf(128, RBUF_VAL);
+      static const size_t RBUF_USE_SIZE = 128;
+      char*rbuf = (char *) need_result_buf(RBUF_USE_SIZE, RBUF_VAL);
 
 	/* Calculate the divisor needed to scale the simulation time
 	   (in time_precision units) to time units of the scope. */
@@ -162,17 +163,17 @@ static void timevar_get_value(vpiHandle ref, s_vpi_value*vp, bool is_int_func,
 	    break;
 
 	  case vpiDecStrVal:
-	    sprintf(rbuf, "%" TIME_FMT_U, simtime);
+	    snprintf(rbuf, RBUF_USE_SIZE, "%" TIME_FMT_U, simtime);
 	    vp->value.str = rbuf;
 	    break;
 
 	  case vpiOctStrVal:
-	    sprintf(rbuf, "%" TIME_FMT_O, simtime);
+	    snprintf(rbuf, RBUF_USE_SIZE, "%" TIME_FMT_O, simtime);
 	    vp->value.str = rbuf;
 	    break;
 
 	  case vpiHexStrVal:
-	    sprintf(rbuf, "%" TIME_FMT_X, simtime);
+	    snprintf(rbuf, RBUF_USE_SIZE, "%" TIME_FMT_X, simtime);
 	    vp->value.str = rbuf;
 	    break;
 

--- a/vvp/vpi_vthr_vector.cc
+++ b/vvp/vpi_vthr_vector.cc
@@ -99,7 +99,8 @@ static double vlg_round(double rval)
 static void vthr_real_get_value(vpiHandle ref, s_vpi_value*vp)
 {
       __vpiVThrWord*obj = dynamic_cast<__vpiVThrWord*>(ref);
-      char *rbuf = (char *) need_result_buf(66, RBUF_VAL);
+      static const size_t RBUF_USE_SIZE = 66;
+      char *rbuf = (char *) need_result_buf(RBUF_USE_SIZE, RBUF_VAL);
 
       double val = 0.0;
 
@@ -133,19 +134,19 @@ static void vthr_real_get_value(vpiHandle ref, s_vpi_value*vp)
 
 	  case vpiDecStrVal:
 	    if (std::isnan(val))
-		  sprintf(rbuf, "%s", "nan");
+		  snprintf(rbuf, RBUF_USE_SIZE, "%s", "nan");
 	    else
-		  sprintf(rbuf, "%0.0f", vlg_round(val));
+		  snprintf(rbuf, RBUF_USE_SIZE, "%0.0f", vlg_round(val));
 	    vp->value.str = rbuf;
 	    break;
 
 	  case vpiOctStrVal:
-	    sprintf(rbuf, "%" PRIo64, (uint64_t)vlg_round(val));
+	    snprintf(rbuf, RBUF_USE_SIZE, "%" PRIo64, (uint64_t)vlg_round(val));
 	    vp->value.str = rbuf;
 	    break;
 
 	  case vpiHexStrVal:
-	    sprintf(rbuf, "%" PRIx64, (uint64_t)vlg_round(val));
+	    snprintf(rbuf, RBUF_USE_SIZE, "%" PRIx64, (uint64_t)vlg_round(val));
 	    vp->value.str = rbuf;
 	    break;
 


### PR DESCRIPTION
Clean up warnings that show up on newer compilers. Many of these warnings are related to obsolete c library features or language features. This does not clear up warnings in code generated by bison or flex.