### PR TITLE
Add support for handling `super` keyword 

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -417,6 +417,7 @@ class PEIdent : public PExpr {
                                    index_component_t::ctype_t,
 				   bool need_const_idx) const;
       NetAssign_*elaborate_lval_net_class_member_(Design*, NetScope*,
+						   const netclass_t *class_type,
 						   NetNet*,
 						   pform_name_t) const;
       bool elaborate_lval_net_packed_member_(Design*, NetScope*,
@@ -511,8 +512,7 @@ class PEIdent : public PExpr {
 					   unsigned flags) const;
 
       NetExpr *elaborate_expr_class_field_(Design*des, NetScope*scope,
-					   NetNet*net,
-					   const name_component_t&comp,
+					   const symbol_search_results &sr,
 					   unsigned expr_wid,
 					   unsigned flags) const;
 

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -285,8 +285,9 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 
 	// If the variable is a class object, then handle it with the
 	// net_class_member_ method.
-      if (reg->class_type() && !member_path.empty() && gn_system_verilog()) {
-	    NetAssign_*lv = elaborate_lval_net_class_member_(des, use_scope, reg, member_path);
+      const netclass_t *class_type = dynamic_cast<const netclass_t *>(sr.type);
+      if (class_type && !member_path.empty() && gn_system_verilog()) {
+	    NetAssign_*lv = elaborate_lval_net_class_member_(des, use_scope, class_type, reg, member_path);
 	    return lv;
       }
 
@@ -475,7 +476,7 @@ NetAssign_* PEIdent::elaborate_lval_method_class_member_(Design*des,
       }
 
       NetAssign_*this_lval = new NetAssign_(this_net);
-      this_lval->set_property(member_name);
+      this_lval->set_property(member_name, pidx);
       if (canon_index) this_lval->set_word(canon_index);
 
       return this_lval;
@@ -1078,7 +1079,8 @@ bool PEIdent::elaborate_lval_net_idx_(Design*des,
  * obj, and member_path=base.x.
  */
 NetAssign_* PEIdent::elaborate_lval_net_class_member_(Design*des, NetScope*scope,
-				    NetNet*sig, pform_name_t member_path) const
+				    const netclass_t *class_type, NetNet*sig,
+				    pform_name_t member_path) const
 {
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PEIdent::elaborate_lval_net_class_member_: "
@@ -1086,7 +1088,6 @@ NetAssign_* PEIdent::elaborate_lval_net_class_member_(Design*des, NetScope*scope
 		 << " of " << sig->name() << "." << endl;
       }
 
-      const netclass_t*class_type = sig->class_type();
       ivl_assert(*this, class_type);
 
 	// Iterate over the member_path. This handles nested class
@@ -1149,7 +1150,7 @@ NetAssign_* PEIdent::elaborate_lval_net_class_member_(Design*des, NetScope*scope
 	    }
 
 	    lv = lv? new NetAssign_(lv) : new NetAssign_(sig);
-	    lv->set_property(method_name);
+	    lv->set_property(method_name, pidx);
 
 	      // Now get the type of the property.
 	    ivl_type_t ptype = class_type->get_prop_type(pidx);

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -159,9 +159,6 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 				    bool is_cassign,
 				    bool is_force) const
 {
-      NetNet*       reg = 0;
-      const NetExpr*par = 0;
-      NetEvent*     eve = 0;
 
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PEIdent::elaborate_lval: "
@@ -182,25 +179,12 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 	    ivl_assert(*this, use_scope);
       }
 
-	/* Try to find the base part of the path that names the
-	   variable. The remainer is the member path. For example, if
-	   the path is a.b.c.d, and a.b is the path to a variable,
-	   then a.b becomes the base_path and c.d becomes the
-	   member_path. If we cannot find the variable with any
-	   prefix, then the base_path will be empty after this loop
-	   and reg will remain nil. */
-      pform_name_t base_path = path_;
-      pform_name_t member_path;
-      while (reg == 0 && !base_path.empty()) {
-	    symbol_search(this, des, use_scope, base_path, reg, par, eve);
-	      // Found it!
-	    if (reg != 0) break;
-	      // Not found. Try to pop another name off the base_path
-	      // and push it to the front of the member_path.
-	    member_path.push_front( base_path.back() );
-	    base_path.pop_back();
-      }
+      symbol_search_results sr;
+      symbol_search(this, des, use_scope, path_, &sr);
 
+      NetNet *reg = sr.net;
+      pform_name_t &base_path = sr.path_head;
+      pform_name_t &member_path = sr.path_tail;
 
 	/* The l-value must be a variable. If not, then give up and
 	   print a useful error message. */

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3906,7 +3906,7 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 		                                "$ivl_queue_method$pop_back");
       }
 
-      if (const netclass_t*class_type = net->class_type()) {
+      if (const netclass_t*class_type = dynamic_cast<const netclass_t*>(par_type)) {
 	    NetScope*task = class_type->method_from_name(method_name);
 	    if (task == 0) {
 		    // If an implicit this was added it is not an error if we

--- a/ivtest/ivltests/sv_class_super3.v
+++ b/ivtest/ivltests/sv_class_super3.v
@@ -1,0 +1,39 @@
+// Check that `super` keyword can be used to access members of the base class
+
+class B;
+  int x, y;
+
+  task set_y;
+    y = 2000;
+  endtask
+
+  function bit check_x;
+    return x === 1000;
+  endfunction
+endclass
+
+class C extends B;
+  byte x, y;
+  task set_x;
+    super.x = 1000;
+  endtask
+
+  function bit check_y;
+    return super.y === 2000;
+  endfunction
+endclass
+
+module test;
+  C c;
+
+  initial begin
+    c = new;
+    c.set_x;
+    c.set_y;
+    if (c.check_x() && c.check_y()) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_class_super4.v
+++ b/ivtest/ivltests/sv_class_super4.v
@@ -1,0 +1,26 @@
+// Check that `super` keyword can be used to call tasks of the base class
+
+class B;
+  task t;
+    $display("PASSED");
+  endtask
+endclass
+
+class C extends B;
+  task t;
+    $display("FAILED");
+  endtask
+
+  task check;
+    super.t;
+  endtask
+endclass
+
+module test;
+  C c;
+
+  initial begin
+    c = new;
+    c.check;
+  end
+endmodule

--- a/ivtest/ivltests/sv_class_super5.v
+++ b/ivtest/ivltests/sv_class_super5.v
@@ -1,0 +1,30 @@
+// Check that `super` keyword can be used to call functions of the base class
+
+class B;
+  function int f;
+    return 1;
+  endfunction
+endclass
+
+class C extends B;
+  function int f;
+    return 2;
+  endfunction
+
+  task check;
+    if (super.f() === 1) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+endclass
+
+module test;
+  C c;
+
+  initial begin
+    c = new;
+    c.check;
+  end
+endmodule

--- a/ivtest/ivltests/sv_class_super6.v
+++ b/ivtest/ivltests/sv_class_super6.v
@@ -1,0 +1,39 @@
+// Check that `this.super` is supported
+
+class B;
+  int x, y;
+
+  task set_y;
+    y = 2000;
+  endtask
+
+  function bit check_x;
+    return x === 1000;
+  endfunction
+endclass
+
+class C extends B;
+  byte x, y;
+  task set_x;
+    this.super.x = 1000;
+  endtask
+
+  function bit check_y;
+    return this.super.y === 2000;
+  endfunction
+endclass
+
+module test;
+  C c;
+
+  initial begin
+    c = new;
+    c.set_x;
+    c.set_y;
+    if (c.check_x() && c.check_y()) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -587,6 +587,10 @@ sv_class_static_prop2	normal,-g2009		ivltests
 sv_class_static_prop3	normal,-g2009		ivltests
 sv_class_super1		normal,-g2009		ivltests
 sv_class_super2		normal,-g2009		ivltests
+sv_class_super3		normal,-g2009		ivltests
+sv_class_super4		normal,-g2009		ivltests
+sv_class_super5		normal,-g2009		ivltests
+sv_class_super6		normal,-g2009		ivltests
 sv_class_task1		normal,-g2009		ivltests
 sv_class_virt_new_fail	CE,-g2009		ivltests
 sv_darray1		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -435,6 +435,10 @@ sv_class_static_prop2	CE,-g2009		ivltests
 sv_class_static_prop3	CE,-g2009		ivltests
 sv_class_super1		CE,-g2009		ivltests
 sv_class_super2		CE,-g2009		ivltests
+sv_class_super3		CE,-g2009		ivltests
+sv_class_super4		CE,-g2009		ivltests
+sv_class_super5		CE,-g2009		ivltests
+sv_class_super6		CE,-g2009		ivltests
 sv_class_task1		CE,-g2009		ivltests
 sv_end_label		CE,-g2009		ivltests  # Also generate
 sv_foreach2		CE,-g2009,-pallowsigned=1	ivltests

--- a/net_assign.cc
+++ b/net_assign.cc
@@ -158,10 +158,7 @@ const ivl_type_s* NetAssign_::net_type() const
 		  return ntype;
 
 	    if (const netclass_t*class_type = dynamic_cast<const netclass_t*>(ntype)) {
-		  int pidx = class_type->property_idx_from_name(member_);
-		  ivl_assert(*this, pidx >= 0);
-		  ivl_type_t tmp = class_type->get_prop_type(pidx);
-		  return tmp;
+		  return class_type->get_prop_type(member_idx_);
 	    }
 
 	    if (const netdarray_t*darray = dynamic_cast<const netdarray_t*> (ntype)) {
@@ -178,10 +175,7 @@ const ivl_type_s* NetAssign_::net_type() const
 	    if (member_.nil())
 		  return sig_->net_type();
 
-	    int pidx = class_type->property_idx_from_name(member_);
-	    ivl_assert(*sig_, pidx >= 0);
-	    ivl_type_t tmp = class_type->get_prop_type(pidx);
-	    return tmp;
+	    return class_type->get_prop_type(member_idx_);
       }
 
       if (const netdarray_t*darray = dynamic_cast<const netdarray_t*> (sig_->net_type())) {
@@ -246,10 +240,10 @@ void NetAssign_::set_part(NetExpr*base, unsigned wid,
       sel_type_ = sel_type;
 }
 
-void NetAssign_::set_property(const perm_string&mname)
+void NetAssign_::set_property(const perm_string&mname, unsigned idx)
 {
-	//ivl_assert(*sig_, sig_->class_type());
       member_ = mname;
+      member_idx_ = idx;
 }
 
 /*

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -382,13 +382,12 @@ NetENull::~NetENull()
 {
 }
 
-NetEProperty::NetEProperty(NetNet*net, perm_string pnam, NetExpr*idx)
-: net_(net), index_(idx)
+NetEProperty::NetEProperty(NetNet*net, size_t pidx, NetExpr*idx)
+: net_(net), pidx_(pidx), index_(idx)
 {
       const netclass_t*use_type = dynamic_cast<const netclass_t*>(net->net_type());
       assert(use_type);
 
-      pidx_ = use_type->property_idx_from_name(pnam);
       ivl_type_t prop_type = use_type->get_prop_type(pidx_);
       expr_width(prop_type->packed_width());
       cast_signed(prop_type->get_signed());

--- a/netlist.h
+++ b/netlist.h
@@ -2838,8 +2838,8 @@ class NetAssign_ {
                     ivl_select_type_t = IVL_SEL_OTHER);
 	// Set the member or property name if the signal type is a
 	// class.
-      void set_property(const perm_string&name);
-      inline perm_string get_property(void) const { return member_; }
+      void set_property(const perm_string&name, unsigned int idx);
+      inline int get_property_idx(void) const { return member_idx_; }
 
 	// Determine if the assigned object is signed or unsigned.
 	// This is used when determining the expression type for
@@ -2897,6 +2897,7 @@ class NetAssign_ {
       NetExpr*word_;
 	// member/property if signal is a class.
       perm_string member_;
+      int member_idx_ = -1;
 
       bool signed_;
       bool turn_sig_to_wire_on_release_;
@@ -4579,7 +4580,7 @@ class NetENull : public NetExpr {
  */
 class NetEProperty : public NetExpr {
     public:
-      NetEProperty(NetNet*n, perm_string pname, NetExpr*canon_index =0);
+      NetEProperty(NetNet*n, size_t pidx_, NetExpr*canon_index =0);
       ~NetEProperty();
 
       inline const NetNet* get_sig() const { return net_; }

--- a/netmisc.h
+++ b/netmisc.h
@@ -48,7 +48,7 @@ struct symbol_search_results {
 	    net = 0;
 	    cls_val = 0;
 	    par_val = 0;
-	    par_type = 0;
+	    type = 0;
 	    eve = 0;
       }
 
@@ -80,7 +80,7 @@ struct symbol_search_results {
 	// If this was a parameter, the value expression and the
 	// optional value dimensions.
       const NetExpr*par_val;
-      ivl_type_t par_type;
+      ivl_type_t type;
 	// If this is a named event, ...
       NetEvent*eve;
 

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -87,7 +87,12 @@ ostream& operator<< (ostream&out, const index_component_t&that)
 
 ostream& operator<< (ostream&out, const name_component_t&that)
 {
-      out << that.name.str();
+      if (that.name == THIS_TOKEN)
+	    out << "this";
+      else if (that.name == SUPER_TOKEN)
+	    out << "super";
+      else
+	    out << that.name.str();
 
       typedef std::list<index_component_t>::const_iterator index_it_t;
       for (index_it_t idx = that.index.begin()

--- a/t-dll-proc.cc
+++ b/t-dll-proc.cc
@@ -179,8 +179,6 @@ bool dll_target::make_single_lval_(const LineInfo*li, struct ivl_lval_s*cur, con
 
       cur->width_ = asn->lwidth();
 
-      ivl_type_t nest_type = 0;
-
       if (asn->sig()) {
 	    cur->type_ = IVL_LVAL_REG;
 	    cur->n.sig = find_signal(des_, asn->sig());
@@ -188,7 +186,6 @@ bool dll_target::make_single_lval_(const LineInfo*li, struct ivl_lval_s*cur, con
       } else {
 	    const NetAssign_*asn_nest = asn->nest();
 	    ivl_assert(*li, asn_nest);
-	    nest_type = asn_nest->net_type();
 	    struct ivl_lval_s*cur_nest = new struct ivl_lval_s;
 	    make_single_lval_(li, cur_nest, asn_nest);
 
@@ -209,22 +206,7 @@ bool dll_target::make_single_lval_(const LineInfo*li, struct ivl_lval_s*cur, con
 	    expr_ = 0;
       }
 
-      cur->property_idx = -1;
-      perm_string pname = asn->get_property();
-      if (!pname.nil()) {
-	    const netclass_t*use_type;
-	    switch (cur->type_) {
-		case IVL_LVAL_LVAL:
-		  assert(nest_type);
-		  use_type = dynamic_cast<const netclass_t*> (nest_type);
-		  break;
-		default:
-		  use_type = dynamic_cast<const netclass_t*> (cur->n.sig->net_type);
-		  break;
-	    }
-	    assert(use_type);
-	    cur->property_idx = use_type->property_idx_from_name(pname);
-      }
+      cur->property_idx = asn->get_property_idx();
 
       return flag;
 }


### PR DESCRIPTION
SystemVerilog allows to use the `super` keyword to access properties and
methods of a base class. This is useful if there is for example an
identifier with the same name in the current class as in the base class and
the code wants to access the base class identifier.

To support this a bit of refactoring is required. Currently properties are
internally referenced by name, this does not work if there are multiple
properties of the same. Instead reference properties always by index.

In addition when looking up an identifier that resolves to an object return
both the type and the object itself. This is necessary since both `this`
and `super` resolve to the same object, but each with a different type.

Also support `this.super` which behaves the same as `super`.

Resolves #671