### PR TITLE
 Report an error for size casts with a negative value

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3363,9 +3363,12 @@ unsigned PECastSize::test_width(Design*des, NetScope*scope, width_mode_t&)
       ivl_assert(*this, size_);
       ivl_assert(*this, base_);
 
+      expr_width_ = 0;
+
       NetExpr*size_ex = elab_and_eval(des, scope, size_, -1, true);
       NetEConst*size_ce = dynamic_cast<NetEConst*>(size_ex);
-      expr_width_ = size_ce ? size_ce->value().as_ulong() : 0;
+      if (size_ce && !size_ce->value().is_negative())
+	    expr_width_ = size_ce->value().as_ulong();
       delete size_ex;
       if (expr_width_ == 0) {
 	    cerr << get_fileline() << ": error: Cast size expression "

--- a/ivtest/ivltests/size_cast_fail1.v
+++ b/ivtest/ivltests/size_cast_fail1.v
@@ -1,0 +1,12 @@
+// Check that an error is reported when using a zero value for a size cast.
+
+module test;
+
+  localparam integer N = 0;
+
+  initial begin
+    int x, y;
+    y = N'(x); // This should fail, N is zero
+  end
+
+endmodule

--- a/ivtest/ivltests/size_cast_fail2.v
+++ b/ivtest/ivltests/size_cast_fail2.v
@@ -1,0 +1,12 @@
+// Check that an error is reported when using a negative value for a size cast.
+
+module test;
+
+  localparam integer N = -1;
+
+  initial begin
+    int x, y;
+    y = N'(x); // This should fail, N is negative
+  end
+
+endmodule

--- a/ivtest/ivltests/size_cast_fail3.v
+++ b/ivtest/ivltests/size_cast_fail3.v
@@ -1,0 +1,12 @@
+// Check that an error is reported when using an undefined value for a size cast.
+
+module test;
+
+  localparam integer N = 32'hx;
+
+  initial begin
+    int x, y;
+    y = N'(x); // This should fail, N is undefined
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -465,6 +465,9 @@ size_cast2		normal,-g2005-sv	ivltests
 size_cast3		normal,-g2009		ivltests
 size_cast4		normal,-g2009		ivltests
 size_cast5		normal,-g2009		ivltests
+size_cast_fail1		CE,-g2009		ivltests
+size_cast_fail2		CE,-g2009		ivltests
+size_cast_fail3		CE,-g2009		ivltests
 slongint_test		normal,-g2005-sv	ivltests
 sshortint_test		normal,-g2005-sv	ivltests
 string_events		normal,-g2009		ivltests gold=string_events.gold


### PR DESCRIPTION
Size casts are only allowed if the value is positive. For cases where it is
0 negative or undefined an error should be reported. Currently the negative
case is not handled. Extend the test to also check for negative values.