### PR TITLE
Let void functions in always_comb block contribute to sensitivity list

### DIFF
--- a/ivtest/ivltests/always_comb_void_func.v
+++ b/ivtest/ivltests/always_comb_void_func.v
@@ -1,0 +1,51 @@
+// Check that variables referenced in a void function contribute to the
+// sensitivity list of a always_comb block.
+
+module top;
+  logic passed;
+  logic [7:0] value;
+  integer counter;
+
+  function automatic void count(bit what);
+    counter = 0;
+    for (integer i = 0; i < $bits(value); i++) begin
+      if (value[i] == what)
+        counter += 1;
+    end
+  endfunction
+
+  always_comb begin
+    count(1'b1);
+  end
+
+  initial begin
+    passed = 1'b1;
+
+    value = 8'b0000_0000;
+    #1;
+    if (counter !== 0) begin
+      $display("Expected 0, got %d", counter);
+      passed = 1'b0;
+    end
+
+    value = 8'b0011_1100;
+    #1;
+    if (counter !== 4) begin
+      $display("Expected 4, got %d", counter);
+      passed = 1'b0;
+    end
+
+    value = 8'b1011_1101;
+    #1;
+    if (counter !== 6) begin
+      $display("Expected 6, got %d", counter);
+      passed = 1'b0;
+    end
+
+    if (passed) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -76,6 +76,7 @@ always_comb_fail4	CE,-g2005-sv		ivltests
 always_comb_no_sens	nornal,-g2005-sv	ivltests gold=always_comb_no_sens.gold
 always_comb_rfunc	nornal,-g2005-sv	ivltests
 always_comb_trig	normal,-g2005-sv	ivltests
+always_comb_void_func	normal,-g2005-sv	ivltests
 always_comb_warn	normal,-g2005-sv	ivltests gold=always_comb_warn.gold
 always_ff		normal,-g2005-sv	ivltests
 always_ff_fail		CE,-g2005-sv		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -69,6 +69,7 @@
 
 # Verilog 95 does not support automatic tasks or functions.
 always_comb_rfunc	CE			ivltests
+always_comb_void_func	CE			ivltests
 automatic_error11	CE			ivltests
 automatic_error12	CE			ivltests
 automatic_error13	CE			ivltests


### PR DESCRIPTION
Internally void function calls are modeled as task calls. But unlike task
calls, access to a signal inside a void function is supposed to contribute
to the sensitivity list of an always_comb block.

Make sure that the same logic applied for non-void functions is also
applied for void functions.

Resolves #539