### PR TITLE
 ci: Windows: Add gperf to dependency list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
         install: >
           git
           base-devel
+          gperf
           mingw-w64-${{ matrix.arch }}-toolchain
 
     - name: Build and check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       run:
         shell: msys2 {0}
     env:
-      MINGW_INSTALLS: ${{ matrix.msystem }}
+      MINGW_ARCH: ${{ matrix.msystem }}
     steps:
 
     - run: git config --global core.autocrlf input

--- a/ivtest/regress-v13.list
+++ b/ivtest/regress-v13.list
@@ -1,0 +1,84 @@
+# This test list is used to override other test lists when using
+# Icarus Verilog v13.
+
+#
+# Copyright (c) 1999-2015 Guy Hutchison (ghutchis@pacbell.net)
+#
+#    This source code is free software; you can redistribute it
+#    and/or modify it in source code form under the terms of the GNU
+#    General Public License as published by the Free Software
+#    Foundation; either version 2 of the License, or (at your option)
+#    any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+#
+# Format of the file
+#
+# testname		testtype		directory
+#
+# The <testname> is the verilog file name minus an extension.
+#
+# The <testtype> can be one of the following:
+#
+# normal:  Normal results expected, i.e it should compile and execute
+#          producing at least a single line with PASSED.
+#
+# CO:      Compile Only - Compile the file to the default output type.
+#
+# CN:      Compile Null - Compile with the null target. Similar to CO.
+#
+# CE:      Compile with Errors - We EXPECT errors - we're checking
+#                                illegal syntax
+#
+# RE:      Runtime with Errors - We EXPECT errors - we're checking
+#                                illegal syntax
+#
+# EF:      Expected Fail - We EXPECT this test to fail - only use
+#                          with older versions of Icarus.
+#
+# TE:      Translation Error - We EXPECT the translated code to fail -
+#                              only supported in the vlog95 checker.
+#
+# NI:      Not implemented. Only use for version specific tests.
+#
+# <directory> is where the <testname>.v file is located.
+#
+# An optional fourth and fifth argument can be supplied.
+#
+# The fourth argument may be one of the following.
+#
+#   modulename                       - Defines the top level module
+#   gold=filename                    - Compare a gold file against the
+#                                      generated log file.
+#   unordered=filename               - Compare a gold file against the
+#                                      generated log file, allowing for lines
+#                                      to appear in any order
+#   diff=filename1:filename2:skip_ln - Compare the two files for equality.
+#                                      Skip the first <skip_ln> lines or none.
+#
+# If a <modulename> is given you can supply a fifth argument for the
+# gold or diff commands.
+#
+
+# v13 has incomplete synthesis support
+dffsynth		CE,-S			ivltests
+memsynth1		CE,-S			ivltests
+memsynth2		CE,-S			ivltests
+memsynth3		CE,-S			ivltests
+memsynth5		CE,-S			ivltests
+memsynth6		CE,-S			ivltests
+memsynth7		CE,-S			ivltests
+memsynth9		CE,-S			ivltests
+mix_reset		CE,-S			ivltests
+
+# These tests pass, but synthesis is creating unnecessary latches.
+case1			normal			ivltests
+case2			normal			ivltests
+casex_synth		normal			ivltests


### PR DESCRIPTION
msys2 [removed the gperf package from the base-devel](https://github.com/msys2/MSYS2-packages/commit/085698dce3b5e481f0db586173d0157c8e5c8ff9) package collection.

Add gperf explicitly to the dependency list, without this the Windows
CI will fail.

Also fix the following warning `=> WARNING: MINGW_INSTALLS is deprecated, use MINGW_ARCH instead`