### PR TITLE
ivlpp: Improve handling of comments in macros

### DIFF
--- a/ivlpp/lexor.lex
+++ b/ivlpp/lexor.lex
@@ -1130,12 +1130,14 @@ void free_macros(void)
  * variables. When the define is over, the def_finish() function
  * executes the define and clears this text. The define_continue_flag
  * is set if do_define detects that the definition is to be continued
- * on the next line.
+ * on the next line. The define_comment_flag is set when a multi-line comment is
+ * active in a define.
  */
 static char*  define_text = 0;
 static size_t define_cnt = 0;
 
 static int define_continue_flag = 0;
+static int define_comment_flag = 0;
 
 /*
  * The do_magic function puts the expansions of magic macros into
@@ -1190,6 +1192,33 @@ static char *find_arg(char*ptr, char*head, char*arg)
 }
 
 /*
+ * Returns 1 if the comment continues on the next line
+ */
+static int do_define_multiline_comment(char *replace_start,
+				       const char *search_start)
+{
+    char *tail = strstr(search_start, "*/");
+
+    if (!tail) {
+        if (search_start[strlen(search_start) - 1] == '\\') {
+            define_continue_flag = 1;
+            define_comment_flag = 1;
+            *replace_start++ = '\\';
+        } else {
+            define_comment_flag = 0;
+            fprintf(stderr, "%s:%u: Unterminated comment in define\n",
+                    istack->path, istack->lineno+1);
+        }
+        *replace_start = '\0';
+        return 1;
+    }
+    define_comment_flag = 0;
+    tail += 2;
+    memmove(replace_start, tail, strlen(tail) + 1);
+    return 0;
+}
+
+/*
  * Collect the definition. Normally, this returns 0. If there is a
  * continuation, then return 1 and this function may be called again
  * to collect another line of the definition.
@@ -1204,6 +1233,12 @@ static void do_define(void)
 
     define_continue_flag = 0;
 
+    /* Are we in an multi-line comment? Look for the end */
+    if (define_comment_flag) {
+        if (do_define_multiline_comment(yytext, yytext))
+            return;
+    }
+
     /* Look for comments in the definition, and remove them. */
     cp = strchr(yytext, '/');
 
@@ -1216,20 +1251,11 @@ static void do_define(void)
             *cp = 0;
             break;
         } else if (cp[1] == '*') {
-            tail = strstr(cp+2, "*/");
-
-            if (tail == 0) {
-                *cp = 0;
-                fprintf(stderr, "%s:%u: Unterminated comment in define\n",
-		        istack->path, istack->lineno+1
-                );
+            if (do_define_multiline_comment(cp, cp + 2))
                 break;
-            }
-
-            memmove(cp, tail+2, strlen(tail+2)+1);
         } else {
 	    cp++;
-        }
+	}
 
         cp = strchr(cp, '/');
     }

--- a/ivlpp/lexor.lex
+++ b/ivlpp/lexor.lex
@@ -1215,9 +1215,7 @@ static void do_define(void)
             }
             *cp = 0;
             break;
-        }
-
-        if (cp[1] == '*') {
+        } else if (cp[1] == '*') {
             tail = strstr(cp+2, "*/");
 
             if (tail == 0) {
@@ -1229,10 +1227,11 @@ static void do_define(void)
             }
 
             memmove(cp, tail+2, strlen(tail+2)+1);
-            continue;
+        } else {
+	    cp++;
         }
 
-        cp = strchr(cp+1, '/');
+        cp = strchr(cp, '/');
     }
 
     /* Trim trailing white space. */

--- a/ivtest/ivltests/macro_comment1.v
+++ b/ivtest/ivltests/macro_comment1.v
@@ -1,0 +1,16 @@
+// Check that a '*' or '/' following a C-style comment is supported in a macro
+
+`define x(a, b) a /* comment */ * b
+`define y(a, b) a /* comment */ / b
+
+ module test;
+
+  initial begin
+    if (`x(2, 3) === 6 && `y(8, 2) === 4) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+ endmodule

--- a/ivtest/ivltests/macro_comment2.v
+++ b/ivtest/ivltests/macro_comment2.v
@@ -1,0 +1,17 @@
+// Check that another comment directly following a C-style comment is
+// supported in a macro.
+
+`define x(a, b) a /* comment */// * b
+`define y(a, b) a /* comment *//*/ b*/
+
+ module test;
+
+  initial begin
+    if (`x(2, 3) === 2 && `y(8, 2) === 8) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+ endmodule

--- a/ivtest/ivltests/macro_comment3.v
+++ b/ivtest/ivltests/macro_comment3.v
@@ -1,0 +1,16 @@
+// Check that a '/' directly after opening a C-style comment gets handled
+// correctly in a macro.
+
+`define x(a, b) a /*/ b */ + b
+
+ module test;
+
+  initial begin
+    if (`x(2, 3) === 5) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+ endmodule

--- a/ivtest/ivltests/macro_comment_multiline.v
+++ b/ivtest/ivltests/macro_comment_multiline.v
@@ -1,0 +1,23 @@
+// Check that multi-line comments in macros are supported. Including some corner
+// cases like another comment start in the comment.
+
+`define test(a, b, c) \
+  (a + /* these is some \
+   multi line */ b /* comment \
+   that goes on \
+   and on */ ) /* and some more \
+\
+   // and even has a comments \
+   /* in the comment */ * c
+
+module test;
+
+  initial begin
+    if (`test(1, 2, 3) === 9) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -638,6 +638,7 @@ macro_args		CO,-yivltests			ivltests
 macro_comment1		normal			ivltests
 macro_comment2		normal			ivltests
 macro_comment3		normal			ivltests
+macro_comment_multiline	normal			ivltests
 macro_redefinition	normal,-Wmacro-redefinition	ivltests gold=macro_redefinition.gold
 macro_replacement	normal,-Wmacro-replacement	ivltests gold=macro_replacement.gold
 macsub			normal			ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -635,6 +635,9 @@ localparam_type		normal			ivltests gold=parameter_type.gold
 long_div		normal			ivltests gold=long_div.gold
 macro2			normal			ivltests
 macro_args		CO,-yivltests			ivltests
+macro_comment1		normal			ivltests
+macro_comment2		normal			ivltests
+macro_comment3		normal			ivltests
 macro_redefinition	normal,-Wmacro-redefinition	ivltests gold=macro_redefinition.gold
 macro_replacement	normal,-Wmacro-replacement	ivltests gold=macro_replacement.gold
 macsub			normal			ivltests


### PR DESCRIPTION
A '*' or '/' directly following a C-style comment in a macro currently
triggers the detection of the start of another comment. Fix this by first
looking for a '/' that should start the comment.

Also add support for handling multi-line comments in macros.