### PR TITLE
Report error for packed struct default member values

### DIFF
--- a/elab_type.cc
+++ b/elab_type.cc
@@ -242,6 +242,13 @@ ivl_type_t struct_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 		       ; cur_name != curp->names->end() ;  ++ cur_name) {
 		  decl_assignment_t*namep = *cur_name;
 
+		  if (packed_flag && namep->expr) {
+			cerr << namep->expr->get_fileline() << " error: "
+			     << "Packed structs must not have default member values."
+			     << endl;
+			des->errors++;
+		  }
+
 		  netstruct_t::member_t memb;
 		  memb.name = namep->name;
 		  memb.net_type = elaborate_array_type(des, scope, *this,

--- a/ivtest/ivltests/struct_packed_member_def.v
+++ b/ivtest/ivltests/struct_packed_member_def.v
@@ -1,0 +1,13 @@
+// Check that an error is reported when specifing a default member value for a
+// packed struct.
+
+module test;
+  struct packed {
+    // This should fail, default member value is not allowed for packed struct
+    integer x = 10;
+  } s;
+
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -485,6 +485,7 @@ struct_member_signed	normal,-g2009		ivltests
 struct_packed_array	normal,-g2009		ivltests
 struct_packed_array2	normal,-g2009		ivltests
 struct_packed_darray_fail CE,-g2009		ivltests
+struct_packed_member_def	CE,-g2009	ivltests
 struct_packed_queue_fail CE,-g2009		ivltests
 struct_packed_sysfunct	normal,-g2009		ivltests
 struct_packed_sysfunct2	normal,-g2009		ivltests


### PR DESCRIPTION
SystemVerilog allows struct members to have default values specified as
part of the struct declaration. But this is only allowed for unpacked
structs. For packed structs an error should be reported. This is defined in
section 7.2.2 ("Assigning to structures") of the LRM (1800-2017).

Currently default member values are just silently discarded if specified
for a packed struct. Make sure to report an error instead.