### PR TITLE
regress-sv: Fix expected result for parameter_no_default test

### DIFF
--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -394,7 +394,7 @@ package_vec_part_select	normal,-g2005-sv	ivltests
 packeda			normal,-g2009		ivltests
 packeda2		normal,-g2009		ivltests
 parameter_in_generate2	CE,-g2005-sv		ivltests
-parameter_no_default	CE,-g2005-sv		ivltests
+parameter_no_default	normal,-g2005-sv	ivltests
 parameter_no_default_fail1 CE			ivltests
 parameter_no_default_fail2 CE			ivltests
 parameter_no_default_toplvl normal,-g2005-sv	ivltests


### PR DESCRIPTION
The parameter_no_default test is expected to pass in SystemVerilog mode. Make sure the expected result is correctly annotated in the results file.