### PR TITLE
Elaborate member selects in the scope where they are used

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -4369,7 +4369,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 
       if (!sr.path_tail.empty()) {
 	    if (net->struct_type()) {
-		  return check_for_struct_members(this, des, use_scope, net,
+		  return check_for_struct_members(this, des, scope, net,
 						  sr.path_head.back().index,
 						  sr.path_tail);
 	    } else if (dynamic_cast<const netclass_t*>(sr.type)) {
@@ -4710,7 +4710,7 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 			     << endl;
 		  }
 
-		  return check_for_struct_members(this, des, use_scope, sr.net,
+		  return check_for_struct_members(this, des, scope, sr.net,
 						  sr.path_head.back().index,
 						  sr.path_tail);
 	    }
@@ -4890,7 +4890,7 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 	    }
 
 	    if (dynamic_cast<const netclass_t*>(sr.type) && !sr.path_tail.empty()) {
-		  return elaborate_expr_class_field_(des, use_scope, sr,
+		  return elaborate_expr_class_field_(des, scope, sr,
 						     expr_wid, flags);
 	    }
 
@@ -4908,7 +4908,7 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 		  ivl_assert(*this, sr.path_tail.size() == 1);
 		  const name_component_t member_comp = sr.path_tail.front();
 		  ivl_assert(*this, member_comp.index.empty());
-		  return check_for_enum_methods(this, des, use_scope,
+		  return check_for_enum_methods(this, des, scope,
 						netenum, sr.path_head,
 						member_comp.name,
 						expr, NULL, 0);

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -279,7 +279,7 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 	// then we can handled it with the net_packed_member_ method.
       if (reg->struct_type() && !member_path.empty()) {
 	    NetAssign_*lv = new NetAssign_(reg);
-	    elaborate_lval_net_packed_member_(des, use_scope, lv, member_path);
+	    elaborate_lval_net_packed_member_(des, scope, lv, member_path);
 	    return lv;
       }
 
@@ -287,7 +287,7 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 	// net_class_member_ method.
       const netclass_t *class_type = dynamic_cast<const netclass_t *>(sr.type);
       if (class_type && !member_path.empty() && gn_system_verilog()) {
-	    NetAssign_*lv = elaborate_lval_net_class_member_(des, use_scope, class_type, reg, member_path);
+	    NetAssign_*lv = elaborate_lval_net_class_member_(des, scope, class_type, reg, member_path);
 	    return lv;
       }
 

--- a/ivtest/ivltests/sv_ps_member_sel1.v
+++ b/ivtest/ivltests/sv_ps_member_sel1.v
@@ -1,0 +1,18 @@
+// Check that indices to a package scoped identifier get evaluated in the scope
+// where the identifier is used, not where the identifier is declared.
+
+package P;
+  localparam N = 1;
+  logic [3:0] x = 4'b0101;
+endpackage
+
+module test;
+  localparam N = 2;
+  initial begin
+    if (P::x[N] === 1'b1) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_ps_member_sel2.v
+++ b/ivtest/ivltests/sv_ps_member_sel2.v
@@ -1,0 +1,21 @@
+// Check that indices to a struct member for package scoped identifier get
+// evaluated in the scope where the identifier is used, not where the identifier
+// is declared.
+
+package P;
+  localparam N = 1;
+  struct packed {
+      logic [3:0] x;
+  } s = 4'b0101;
+endpackage
+
+module test;
+  localparam N = 2;
+  initial begin
+    if (P::s.x[N] === 1'b1) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_ps_member_sel3.v
+++ b/ivtest/ivltests/sv_ps_member_sel3.v
@@ -1,0 +1,24 @@
+// Check that indices to a property for package scoped identifier get evaluated
+// in the scope where the identifier is used, not where the identifier is
+// declared.
+
+package P;
+  localparam N = 1;
+  class C;
+    localparam X = 4'b0101;
+  endclass
+  C c = new;
+endpackage
+
+module test;
+  localparam N = 2;
+
+  initial begin
+    if (P::c.X[N] === 1'b1) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -692,6 +692,9 @@ sv_ps_function4		normal,-g2009		ivltests
 sv_ps_function5		normal,-g2009		ivltests
 sv_ps_function6		normal,-g2009		ivltests
 sv_ps_function7		normal,-g2009		ivltests
+sv_ps_member_sel1	normal,-g2009		ivltests
+sv_ps_member_sel2	normal,-g2009		ivltests
+sv_ps_member_sel3	normal,-g2009		ivltests
 sv_ps_type1		normal,-g2009		ivltests
 sv_ps_type_cast1	normal,-g2009		ivltests
 sv_ps_type_cast2	normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -458,6 +458,7 @@ sv_port_default6	CE,-g2009,-pallowsigned=1	ivltests
 sv_port_default7	CE,-g2009,-pallowsigned=1	ivltests
 sv_port_default8	CE,-g2009,-pallowsigned=1	ivltests
 sv_port_default9	CE,-g2009		ivltests
+sv_ps_member_sel3	CE,-g2009		ivltests
 sv_ps_type_class1	CE,-g2009		ivltests
 sv_ps_type_class_prop	CE,-g2009		ivltests
 sv_root_class		CE,-g2009		ivltests


### PR DESCRIPTION
There are a few cases where a member select on a package scoped identifier
is evaluated in the scope of the package rather than the scope where the 
identifier is referenced.

This leads to incorrect behavior if a local symbol is used as an index in a
part select of the referenced member select. E.g.

```SystemVerilog
package P;
  localparam N = 1;
  struct packed {
    logic [3:0] x;
  } s = 4'b0101;
endpackage

module test;
  localparam N = 2;
  initial $display(P::s.x[N]); // Will print 0, should print 1
endmodule
```

Use the scope where the member select is used, rather than the scope where
the identifier is defined, to fix this.