### PR TITLE
Improve error handling for package scoped function calls

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -928,9 +928,6 @@ class PECallFunction : public PExpr {
       NetExpr* elaborate_expr_(Design *des, NetScope *scope,
 			       unsigned flags) const;
 
-      NetExpr*elaborate_expr_pkg_(Design*des, NetScope*scope,
-				  unsigned flags)const;
-
       NetExpr* elaborate_expr_method_(Design*des, NetScope*scope,
 				      symbol_search_results&search_results)
 				      const;

--- a/ivtest/ivltests/sv_ps_function_fail1.v
+++ b/ivtest/ivltests/sv_ps_function_fail1.v
@@ -1,0 +1,15 @@
+// Check that an error is reported when trying to call a package scoped function
+// that does not exist.
+
+package P;
+endpackage
+
+module test;
+
+  initial begin
+    int y;
+    y = P::f(10); // This should fail, f does not exist
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ps_function_fail2.v
+++ b/ivtest/ivltests/sv_ps_function_fail2.v
@@ -1,0 +1,16 @@
+// Check that trying to call a package scoped variable as a function results in
+// an error.
+
+package P;
+  int x;
+endpackage
+
+module test;
+
+  initial begin
+    int y;
+    y = P::x(10); // This should fail, x is not a function
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ps_function_fail3.v
+++ b/ivtest/ivltests/sv_ps_function_fail3.v
@@ -1,0 +1,17 @@
+// Check that an error is reported when trying to call a package scoped task as
+// a function.
+
+package P;
+  task t(int x);
+  endtask
+endpackage
+
+module test;
+
+  initial begin
+    int y;
+    y = P::t(10); // This should fail, t is a task
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -692,6 +692,9 @@ sv_ps_function4		normal,-g2009		ivltests
 sv_ps_function5		normal,-g2009		ivltests
 sv_ps_function6		normal,-g2009		ivltests
 sv_ps_function7		normal,-g2009		ivltests
+sv_ps_function_fail1	CE,-g2009		ivltests
+sv_ps_function_fail2	CE,-g2009		ivltests
+sv_ps_function_fail3	CE,-g2009		ivltests
 sv_ps_member_sel1	normal,-g2009		ivltests
 sv_ps_member_sel2	normal,-g2009		ivltests
 sv_ps_member_sel3	normal,-g2009		ivltests


### PR DESCRIPTION
Currently a package scoped function call will result in an assert if the
function does not exist in the package scope.

For non-package scoped function calls instead a proper error is reported.

Refactor the code to share the same code paths between package scoped and
non-package scoped function calls. This makes sure that errors are reported
in both cases. It also makes the code slightly smaller.