### PR TITLE
Allow access to static properties of base classes

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -407,6 +407,11 @@ class PEIdent : public PExpr {
 				     std::list<long>&prefix_indices) const;
 
     private:
+
+      NetAssign_ *elaborate_lval_var_(Design *des, NetScope *scope,
+				      bool is_force, bool is_cassign,
+				      NetNet *reg, ivl_type_t data_type,
+				      pform_name_t tail_path) const;
       NetAssign_*elaborate_lval_method_class_member_(Design*, NetScope*) const;
       NetAssign_*elaborate_lval_net_word_(Design*, NetScope*, NetNet*,
 					  bool need_const_idx) const;

--- a/ivtest/ivltests/sv_class_static_prop4.v
+++ b/ivtest/ivltests/sv_class_static_prop4.v
@@ -1,0 +1,45 @@
+// Check that it is possible to access static properties of a base class
+
+class B;
+  static int x = 0;
+  static int y = 0;
+endclass
+
+class C extends B;
+
+  task t(int a, int b);
+    x = a;
+    this.y = b;
+  endtask
+
+  function int f;
+    return x + this.y;
+  endfunction
+
+endclass
+
+module test;
+  bit failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr !== val) begin \
+      $display("FAILED: `%s`, expected %b, got %b", `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+  C c = new;
+
+  initial begin
+    // Check access inside the class
+    c.t(10, 20);
+    `check(c.f(), 30)
+
+    // Check access outside of the class
+    c.x = 40;
+    `check(c.x, 40)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -590,6 +590,7 @@ sv_class_return		normal,-g2009		ivltests
 sv_class_static_prop1	normal,-g2009		ivltests
 sv_class_static_prop2	normal,-g2009		ivltests
 sv_class_static_prop3	normal,-g2009		ivltests
+sv_class_static_prop4	normal,-g2009		ivltests
 sv_class_super1		normal,-g2009		ivltests
 sv_class_super2		normal,-g2009		ivltests
 sv_class_super3		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -437,6 +437,7 @@ sv_class_return		CE,-g2009		ivltests
 sv_class_static_prop1	CE,-g2009		ivltests
 sv_class_static_prop2	CE,-g2009		ivltests
 sv_class_static_prop3	CE,-g2009		ivltests
+sv_class_static_prop4	CE,-g2009		ivltests
 sv_class_super1		CE,-g2009		ivltests
 sv_class_super2		CE,-g2009		ivltests
 sv_class_super3		CE,-g2009		ivltests

--- a/netclass.cc
+++ b/netclass.cc
@@ -174,8 +174,14 @@ NetScope*netclass_t::method_from_name(perm_string name) const
 
 NetNet* netclass_t::find_static_property(perm_string name) const
 {
-      NetNet*tmp = class_scope_->find_signal(name);
-      return tmp;
+      NetNet *net = class_scope_->find_signal(name);
+      if (net)
+	    return net;
+
+      if (super_)
+	    return super_->find_static_property(name);
+
+      return nullptr;
 }
 
 bool netclass_t::test_scope_is_method(const NetScope*scope) const


### PR DESCRIPTION
Classes are allowed to access properties of the base class. This also
includes static properties. Currently when looking up a static property
only those of the class itself are considered. Extend this to also consider
properties of the base classes.