### PR TITLE
Handle continuous array assignments from package scoped indentifiers

### DIFF
--- a/elab_net.cc
+++ b/elab_net.cc
@@ -21,6 +21,7 @@
 # include "config.h"
 
 # include  "PExpr.h"
+# include  "PPackage.h"
 # include  "netlist.h"
 # include  "netmisc.h"
 # include  "netstruct.h"
@@ -1101,13 +1102,15 @@ NetNet* PEIdent::elaborate_subport(Design*des, NetScope*scope) const
 
 NetNet*PEIdent::elaborate_unpacked_net(Design*des, NetScope*scope) const
 {
-      NetNet*       sig = 0;
-      const NetExpr*par = 0;
-      NetEvent*     eve = 0;
-      perm_string method_name;
+      NetScope *use_scope = scope;
+      if (package_) {
+	    use_scope = des->find_package(package_->pscope_name());
+	    ivl_assert(*this, use_scope);
+      }
 
-      symbol_search(this, des, scope, path_, sig, par, eve);
-      if (!sig) {
+      symbol_search_results sr;
+      symbol_search(this, des, use_scope, path_, &sr);
+      if (!sr.net) {
 	    cerr << get_fileline() << ": error: Net " << path_
 		 << " is not defined in this context." << endl;
 	    des->errors += 1;
@@ -1122,7 +1125,7 @@ NetNet*PEIdent::elaborate_unpacked_net(Design*des, NetScope*scope) const
 	    return nullptr;
       }
 
-      return sig;
+      return sr.net;
 }
 
 bool PEIdent::is_collapsible_net(Design*des, NetScope*scope,

--- a/ivtest/ivltests/sv_ps_array_cassign.v
+++ b/ivtest/ivltests/sv_ps_array_cassign.v
@@ -1,0 +1,29 @@
+// Check that continuous array assignments from package scoped identifiers are
+// supported.
+
+package P;
+  reg [3:0] y[2];
+  task init;
+    y[0] = 1;
+    y[1] = 2;
+  endtask
+endpackage
+
+module test;
+
+  import P::init;
+
+  wire [3:0] x[2];
+
+  assign x = P::y;
+
+  initial begin
+    init();
+    if (x[0] === 1 && x[1] === 2) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -685,6 +685,7 @@ sv_port_default11	normal,-g2009		ivltests
 sv_port_default12	normal,-g2009		ivltests
 sv_port_default13	CE,-g2009		ivltests
 sv_port_default14	CE,-g2009		ivltests
+sv_ps_array_cassign	normal,-g2005-sv	ivltests
 sv_ps_function1		normal,-g2009		ivltests
 sv_ps_function2		normal,-g2009		ivltests
 sv_ps_function3		normal,-g2009		ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -264,6 +264,7 @@ sv_array_cassign2	CE,-g2005-sv		ivltests
 sv_array_cassign3	CE,-g2005-sv		ivltests
 sv_array_cassign4	CE,-g2005-sv		ivltests
 sv_array_cassign5	CE,-g2005-sv		ivltests
+sv_ps_array_cassign	CE,-g2005-sv		ivltests
 sv_unpacked_port	CE,-g2009		ivltests
 sv_unpacked_port2	CE,-g2009,-pallowsigned=1	ivltests
 sv_unpacked_wire	CE,-g2009		ivltests


### PR DESCRIPTION
Make sure the package scope is considered when elaborating identifiers for
continuous unpacked array assignments.
