### PR TITLE
Modifications to give error messages rather than assertions

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -6226,7 +6226,14 @@ NetExpr* PEIdent::elaborate_expr_net_bit_(Design*des, NetScope*scope,
 		  unsigned long lwid;
 		  long idx;
 		  rc = net->sig()->sb_to_slice(prefix_indices, msv, idx, lwid);
-		  ivl_assert(*this, rc);
+
+                  if(!rc) {
+                    cerr << get_fileline() << ": error: Index " << net->sig()->name()
+                         << "[" << msv << "] is out of range."
+                         << endl;
+                    des->errors += 1;
+                    return 0;
+                  }
 
 		    // Make an expression out of the index
 		  NetEConst*idx_c = new NetEConst(verinum(idx));

--- a/elab_net.cc
+++ b/elab_net.cc
@@ -464,9 +464,17 @@ bool PEIdent::eval_part_select_(Design*des, NetScope*scope, NetNet*sig,
 			unsigned long tmp_lwid;
 			bool rcl = sig->sb_to_slice(prefix_indices, msb,
 						    tmp_loff, tmp_lwid);
-			ivl_assert(*this, rcl);
-			midx = tmp_loff + tmp_lwid - 1;
-			lidx = tmp_loff;
+                        if(rcl) {
+                          midx = tmp_loff + tmp_lwid - 1;
+                          lidx = tmp_loff;
+                        } else {
+                          cerr << get_fileline() << ": error: Index " << sig->name()
+                               << "[" << msb << "] is out of range."
+                               << endl;
+                          des->errors += 1;
+                          midx = 0;
+                          lidx = 0;
+                        }
 		  } else {
 			midx = sig->sb_to_idx(prefix_indices, msb);
 			if (midx >= (long)sig->vector_width()) {


### PR DESCRIPTION
Fix for assertions in issue #840.

First, for an overflow on the LHS of the assignment:
```
wlye@AMR-BU-L02782:~/issues/issue-836$ cat test1.sv
module test1;
  logic [1:0][1:0] a;
  logic [1:0][1:0] b;
  generate
    for(genvar i=0;i<3;i++)
      assign b[i] = a[i];
  endgenerate
endmodule
wlye@AMR-BU-L02782:~/issues/issue-836$ iverilog -g2012 test1.sv
test1.sv:6: assert: elab_net.cc:467: failed assertion rcl
Aborted
wlye@AMR-BU-L02782:~/issues/issue-836$ iverilog-x -g2012 test1.sv
test1.sv:6: error: Index b[2] is out of range.
test1.sv:6: error: Unresolved net/uwire b cannot have multiple drivers.
2 error(s) during elaboration.
wlye@AMR-BU-L02782:~/issues/issue-836$
```
Second, for an overflow on the RHS of the asignment:
```
wlye@AMR-BU-L02782:~/issues/issue-836$ cat test2.sv
module test2;
  logic [1:0][1:0] a;
  logic [2:0][1:0] b;
  generate
    for(genvar i=0;i<3;i++)
      assign b[i] = a[i];
  endgenerate
endmodule
wlye@AMR-BU-L02782:~/issues/issue-836$ iverilog -g2012 test1.sv
test1.sv:6: assert: elab_net.cc:467: failed assertion rcl
Aborted
wlye@AMR-BU-L02782:~/issues/issue-836$ iverilog-x -g2012 test1.sv
test1.sv:6: error: Index b[2] is out of range.
test1.sv:6: error: Unresolved net/uwire b cannot have multiple drivers.
2 error(s) during elaboration.
wlye@AMR-BU-L02782:~/issues/issue-836$
```