### PR TITLE
ci: Use parallel build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         export PATH="/usr/local/opt/bison/bin:$PATH"
         autoconf
         ./configure
-        make check
+        make -j$(nproc) check
         sudo make install
 
     - name: Test
@@ -58,7 +58,7 @@ jobs:
       run: |
         autoconf
         ./configure
-        make check
+        make -j$(nproc) check
         sudo make install
 
     - name: Test


### PR DESCRIPTION
The github CI VM has multiple CPUs. 2 for Linux and Windows, 3 for macOS. Make use of parallel build to speed up the CI tests a bit.

For Windows the `makepkg-mingw` command already schedules a parallel build, so no changes are made to the Windows build.

This speeds up the build part of the Linux and MacOS steps, which allows them to finish earlier. Unfortunately the bottleneck for the CI execution time is running the regression test suite on the Windows VM, which is almost 10x slower than on the Linux VM.