### PR TITLE
Don't allow access to imported identifiers through hierarchical names

### DIFF
--- a/ivtest/ivltests/sv_import_hier_fail1.v
+++ b/ivtest/ivltests/sv_import_hier_fail1.v
@@ -1,0 +1,24 @@
+// Check that imported identifiers can't be accessed through hierarchical names.
+
+package P;
+  integer x;
+endpackage
+
+module M;
+  import P::x;
+  integer y;
+  always_comb y = x;
+endmodule
+
+module test;
+
+  M m ();
+
+  initial begin
+    integer y;
+    y = m.x; // This should fail. Imported identifiers are not visible through
+             // hierarchical names.
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_import_hier_fail2.v
+++ b/ivtest/ivltests/sv_import_hier_fail2.v
@@ -1,0 +1,24 @@
+// Check that imported identifiers can't be accessed through hierarchical names.
+
+package P;
+  integer x;
+endpackage
+
+module M;
+  import P::*;
+  integer y;
+  always_comb y = x;
+endmodule
+
+module test;
+
+  M m ();
+
+  initial begin
+    integer y;
+    y = m.x; // This should fail. Imported identifiers are not visible through
+             // hierarchical names.
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_import_hier_fail3.v
+++ b/ivtest/ivltests/sv_import_hier_fail3.v
@@ -1,0 +1,20 @@
+// Check that imported identifiers can't be accessed through hierarchical names.
+
+package P;
+  integer x;
+endpackage
+
+module test;
+
+  initial begin : outer
+    integer y;
+    begin: inner
+      import P::x;
+      y = x;
+    end
+    y = inner.x; // This should fail. Imported identifiers are not visible
+                 // through hierarchical names.
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -656,6 +656,9 @@ sv_foreach8		normal,-g2009		ivltests gold=sv_foreach8.gold
 sv_foreach_fail1	CE,-g2009		ivltests
 sv_immediate_assert	normal,-g2009		ivltests gold=sv_immediate_assert.gold
 sv_immediate_assume	normal,-g2009		ivltests gold=sv_immediate_assume.gold
+sv_import_hier_fail1	CE,-g2005-sv		ivltests
+sv_import_hier_fail2	CE,-g2005-sv		ivltests
+sv_import_hier_fail3	CE,-g2005-sv		ivltests
 sv_macro		normal,-g2009		ivltests
 sv_macro2		normal,-g2009		ivltests gold=sv_macro2.gold
 sv_macro3a		normal,-g2009		ivltests gold=sv_macro3.gold

--- a/symbol_search.cc
+++ b/symbol_search.cc
@@ -202,11 +202,6 @@ bool symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 		  }
 	    }
 
-	    if (NetScope*import_scope = scope->find_import(des, path_tail.name)) {
-		  scope = import_scope;
-		  continue;
-	    }
-
 	    // Could not find an object. Maybe this is a child scope name? If
 	    // so, evaluate the path components to find the exact scope this
 	    // refers to. This item might be:
@@ -233,6 +228,12 @@ bool symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 	    // Don't scan up if we are searching within a prefixed scope.
 	    if (prefix_scope)
 		  break;
+
+	    // Imports are not visible through hierachical names
+	    if (NetScope*import_scope = scope->find_import(des, path_tail.name)) {
+		  scope = import_scope;
+		  continue;
+	    }
 
 	    // Special case: We can match the module name of a parent
 	    // module. That means if the current scope is a module of type


### PR DESCRIPTION
Imported identifiers should only be visible in the scope they have been
imported too. They should not be accessible through hierarchical names into
that scope. This is defined in section 26.3 ("Referencing data in
packages") of the LRM (1800-2017).

Modify the symbol search to not look at imports if the name is part of a
hierarchical path.