### PR TITLE
Consolidate class property handling

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -412,7 +412,6 @@ class PEIdent : public PExpr {
 				      bool is_force, bool is_cassign,
 				      NetNet *reg, ivl_type_t data_type,
 				      pform_name_t tail_path) const;
-      NetAssign_*elaborate_lval_method_class_member_(Design*, NetScope*) const;
       NetAssign_*elaborate_lval_net_word_(Design*, NetScope*, NetNet*,
 					  bool need_const_idx) const;
       bool elaborate_lval_net_bit_(Design*, NetScope*, NetAssign_*,
@@ -510,11 +509,6 @@ class PEIdent : public PExpr {
 					   NetESignal*net,
 					   NetScope*found,
 					   bool need_const) const;
-
-      NetExpr*elaborate_expr_class_member_(Design*des,
-					   NetScope*scope,
-					   unsigned expr_wid,
-					   unsigned flags) const;
 
       NetExpr *elaborate_expr_class_field_(Design*des, NetScope*scope,
 					   const symbol_search_results &sr,

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3812,7 +3812,6 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
       use_path.pop_back();
 
       NetNet *net;
-      ivl_type_t cls_val = 0;
       const NetExpr *par;
       ivl_type_t par_type = 0;
       NetEvent *eve;
@@ -3838,7 +3837,7 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 	// resolve to a class object. Note that the "this" symbol
 	// (internally represented as "@") is handled by there being a
 	// "this" object in the instance scope.
-      symbol_search(this, des, scope, use_path, net, par, eve, par_type, cls_val);
+      symbol_search(this, des, scope, use_path, net, par, eve, par_type);
 
       if (net == 0)
 	    return 0;

--- a/ivtest/ivltests/sv_class_prop_shadow1.v
+++ b/ivtest/ivltests/sv_class_prop_shadow1.v
@@ -1,0 +1,25 @@
+// Check that class properties can be shadowed by a local symbol
+
+module test;
+
+  class C;
+    int x = 0;
+
+    task check;
+      int x; // This should shadow the class property
+      x = 10;
+      if (this.x == 0 && x === 10) begin
+        $display("PASSED");
+      end else begin
+        $display("FAILED");
+      end
+    endtask
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    c.check;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_prop_shadow2.v
+++ b/ivtest/ivltests/sv_class_prop_shadow2.v
@@ -1,0 +1,28 @@
+// Check that it is possible to access a package scoped identifier of the same
+// name of a class property inside a class method
+
+package P;
+  int x = 10;
+endpackage
+
+module test;
+
+  class C;
+    int x = 0;
+
+    task check;
+      if (P::x === 10) begin
+        $display("PASSED");
+      end else begin
+        $display("FAILED");
+      end
+    endtask
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    c.check;
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -584,6 +584,8 @@ sv_class_method_lt_static2	CE,-g2009	ivltests
 sv_class_method_signed1	normal,-g2009		ivltests
 sv_class_method_signed2	normal,-g2009		ivltests
 sv_class_method_var_init	normal,-g2009	ivltests
+sv_class_prop_shadow1		normal,-g2009	ivltests
+sv_class_prop_shadow2		normal,-g2009	ivltests
 sv_class_property_signed1	normal,-g2009	ivltests
 sv_class_property_signed2	normal,-g2009	ivltests
 sv_class_property_signed3	normal,-g2009	ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -432,6 +432,8 @@ sv_class_method_default2 CE,-g2009		ivltests
 sv_class_method_signed1	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_method_signed2	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_method_var_init	CE,-g2009,-pallowsigned=1	ivltests
+sv_class_prop_shadow1		CE,-g2009	ivltests
+sv_class_prop_shadow2		CE,-g2009	ivltests
 sv_class_property_signed1	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_property_signed2	CE,-g2009,-pallowsigned=1	ivltests
 sv_class_property_signed3	CE,-g2009,-pallowsigned=1	ivltests

--- a/netmisc.h
+++ b/netmisc.h
@@ -46,7 +46,6 @@ struct symbol_search_results {
       inline symbol_search_results() {
 	    scope = 0;
 	    net = 0;
-	    cls_val = 0;
 	    par_val = 0;
 	    type = 0;
 	    eve = 0;
@@ -55,7 +54,6 @@ struct symbol_search_results {
       inline bool is_scope() const {
 	    if (net) return false;
 	    if (eve) return false;
-	    if (cls_val) return false;
 	    if (par_val) return false;
 	    if (scope) return true;
 	    return false;
@@ -64,7 +62,6 @@ struct symbol_search_results {
       inline bool is_found() const {
 	    if (net) return true;
 	    if (eve) return true;
-	    if (cls_val) return true;
 	    if (par_val) return true;
 	    if (scope) return true;
 	    return false;
@@ -75,8 +72,6 @@ struct symbol_search_results {
       NetScope*scope;
 	// If this was a net, the signal itself.
       NetNet*net;
-	// For a class property we only have type information.
-      ivl_type_t cls_val;
 	// If this was a parameter, the value expression and the
 	// optional value dimensions.
       const NetExpr*par_val;

--- a/netmisc.h
+++ b/netmisc.h
@@ -136,8 +136,7 @@ extern NetScope* symbol_search(const LineInfo*li,
 			       NetNet*&net,       /* net/reg */
 			       const NetExpr*&par,/* parameter/expr */
 			       NetEvent*&eve,     /* named event */
-			       ivl_type_t&par_type,
-			       ivl_type_t&cls_val);
+			       ivl_type_t&par_type);
 
 inline NetScope* symbol_search(const LineInfo*li,
                                Design*des,
@@ -148,9 +147,8 @@ inline NetScope* symbol_search(const LineInfo*li,
 			       NetEvent*&eve      /* named event */)
 {
       ivl_type_t par_type;
-      ivl_type_t cls_val;
       return symbol_search(li, des, start, path, net, par, eve,
-                           par_type, cls_val);
+                           par_type);
 }
 
 /*

--- a/symbol_search.cc
+++ b/symbol_search.cc
@@ -311,14 +311,12 @@ NetScope*symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 		       NetNet*&net,
 		       const NetExpr*&par,
 		       NetEvent*&eve,
-		       ivl_type_t&par_type,
-		       ivl_type_t&cls_val)
+		       ivl_type_t&par_type)
 {
       symbol_search_results recurse;
       bool flag = symbol_search(li, des, scope, path, &recurse);
 
       net = 0;
-      cls_val = 0;
       par = 0;
       par_type = 0;
       eve = 0;
@@ -335,7 +333,6 @@ NetScope*symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 
       // Convert the extended results to the compatible results.
       net = recurse.net;
-      cls_val = recurse.cls_val;
       par = recurse.par_val;
       par_type = recurse.type;
       eve = recurse.eve;

--- a/symbol_search.cc
+++ b/symbol_search.cc
@@ -187,16 +187,21 @@ bool symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 
 		    // Static items are just normal signals and are found above.
 		  if (scope->type() == NetScope::CLASS) {
-			netclass_t*clsnet = scope->find_class(des, scope->basename());
+			const netclass_t *clsnet = scope->class_def();
 			int pidx = clsnet->property_idx_from_name(path_tail.name);
 			if (pidx >= 0) {
-			      ivl_type_t prop_type = clsnet->get_prop_type(pidx);
-			      const netuarray_t*tmp_ua = dynamic_cast<const netuarray_t*>(prop_type);
-			      if (tmp_ua) prop_type = tmp_ua->element_type();
-			      path.push_back(path_tail);
+			      // This is a class property being accessed in a
+			      // class method. Return `this` for the net and the
+			      // property name for the path tail.
+			      NetScope *scope_method = find_method_containing_scope(*li, start_scope);
+			      ivl_assert(*li, scope_method);
+			      res->net = scope_method->find_signal(perm_string::literal(THIS_TOKEN));
+			      ivl_assert(*li, res->net);
 			      res->scope = scope;
-			      res->cls_val = prop_type;
-			      res->path_head = path;
+			      ivl_assert(*li, path.empty());
+			      res->path_head.push_back(name_component_t(perm_string::literal(THIS_TOKEN)));
+			      res->path_tail.push_front(path_tail);
+			      res->type = clsnet;
 			      return true;
 			}
 		  }


### PR DESCRIPTION
There are currently two mechanisms for handling class properties. One that
is used when a class property is accessed through an object and other when
a class property is used freestanding in a class method.

Both are very similar, but there are some small differences. E.g. one
supports arrays, the other supports nested properties.

```SystemVerilog
class B;
  int x;
endclass

class C;
  B b;
  B ba[2];
  task t;
    ba[0] = new; // Does work
    this.ba[0] = new; // Does not work
    b.x = 10; // Does not work
    this.b.x = 10; // Does work
  endtask
```

There is another problem where free standing properties take precedence
over local variables. E.g.

```SystemVerilog
class C;
  int x = 1;
  task t();
    int x = 2;
    $display(x); // Should print 2, will print 1
  endtask
endclass
```

The class property elaboration also ignores the package scope of the
identifier resulting in access to a class property being elaborated if
there is a property of the same name as the scoped identifier. E.g.

```SystemVerilog
package P;
  int x = 2;
endpackage

class C;
  int x = 1;
  task t;
    $display(P::x); // Should print 2, will print 1
  endtask
endclass
```

Consolidate the two implementation to use the same code path. This is
mainly done by letting the symbol search return a result for free standing
properties as if the property had been specified on the `this` object. I.e.
`prop` and `this.prop` will return the same result from the symbol search.

The main motivation behind this PR is fixing the shadowing problem. There
are still a few other problems around nested and array class properties
which makes it difficult to write meaningful regressions tests yet.