### PR TITLE
Add support for package export

### DIFF
--- a/PPackage.h
+++ b/PPackage.h
@@ -24,6 +24,7 @@
 # include  "LineInfo.h"
 # include  "StringHeap.h"
 # include  <iostream>
+# include  <vector>
 
 /*
  * SystemVerilog supports class declarations with their own lexical
@@ -42,6 +43,13 @@ class PPackage : public PScopeExtra, public LineInfo {
       bool elaborate(Design*des, NetScope*scope) const;
 
       void pform_dump(std::ostream&out) const;
+
+      struct export_t {
+	    PPackage *pkg;
+	    perm_string name;
+      };
+
+      std::vector<export_t> exports;
 };
 
 #endif /* IVL_PPackage_H */

--- a/PScope.h
+++ b/PScope.h
@@ -25,6 +25,7 @@
 # include  "ivl_target.h"
 # include  <map>
 # include  <set>
+# include  <unordered_set>
 # include  <vector>
 
 class PEvent;
@@ -67,9 +68,14 @@ class LexicalScope {
 	// Symbols that are defined or declared in this scope.
       std::map<perm_string,PNamedItem*>local_symbols;
 
-	// Symbols that are explicitly imported. Bind the imported name
-	// to the package from which the name is imported.
+	// Symbols that are explicitly imported. This contains the package where
+	// the symbol has been decelared. When using exports, this might not be
+	// the same as the package where it has been imported from.
       std::map<perm_string,PPackage*>explicit_imports;
+        // Symbols that are explicitly imported. This contains the set of
+	// packages from which the symbol has been imported. When using exports
+	// the same identifier can be imported via multiple packages.
+      std::map<perm_string,std::unordered_set<PPackage*>> explicit_imports_from;
 
 	// Packages that are wildcard imported. When identifiers from
 	// these packages are referenced, they will be added to the

--- a/ivtest/ivltests/sv_export1.v
+++ b/ivtest/ivltests/sv_export1.v
@@ -1,0 +1,25 @@
+// Check that it is possible to explicitly export an identifier and import it
+// from another scope.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::x;
+  export P1::x;
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    if (x == 123) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export2.v
+++ b/ivtest/ivltests/sv_export2.v
@@ -1,0 +1,25 @@
+// Check that it is possible use package wildcard export an identifier and
+// import it from another scope.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::x;
+  export P1::*;
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    if (x == 123) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export3.v
+++ b/ivtest/ivltests/sv_export3.v
@@ -1,0 +1,25 @@
+// Check that it is possible use full wildcard export an identifier and import
+// it from another scope.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::x;
+  export *::*;
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    if (x == 123) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export4.v
+++ b/ivtest/ivltests/sv_export4.v
@@ -1,0 +1,25 @@
+// Check that it is possible to export an implicitly imported identifier and
+// import it again from another scope.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::*;
+  export P1::x;
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    if (x == 123) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export5.v
+++ b/ivtest/ivltests/sv_export5.v
@@ -1,0 +1,26 @@
+// Check that implicitly imported identifiers can be exported through a package
+// wildcard export.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::*;
+  export P1::*;
+  integer y = x; // Creates an import for P1::x
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    if (x == 123) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export6.v
+++ b/ivtest/ivltests/sv_export6.v
@@ -1,0 +1,28 @@
+// Check that it is possible to implicitly import the same identifier through
+// multiple paths without causing a conflict.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::x;
+  export P1::x;
+endpackage
+
+module test;
+
+  // P1::x is visible through either of the imports below. This should not
+  // create a conflict since it is the same identifier.
+  import P1::*;
+  import P2::*;
+
+  initial begin
+    if (x == 123) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export_fail1.v
+++ b/ivtest/ivltests/sv_export_fail1.v
@@ -1,0 +1,22 @@
+// Check that it is an error to export an identifier from a package from which
+// it has not been imported from.
+
+package P1;
+  integer x;
+endpackage
+
+package P2;
+  import P1::x;
+  export P1::x;
+endpackage
+
+package P3;
+  import P1::x;
+  export P2::x; // This should fail, even though P2::x is the same as P1::x
+endpackage
+
+module test;
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/sv_export_fail2.v
+++ b/ivtest/ivltests/sv_export_fail2.v
@@ -1,0 +1,17 @@
+// Check that it is an error to export an identifier that has not been imported.
+
+package P1;
+  integer x;
+  integer y;
+endpackage
+
+package P2;
+  import P1::x;
+  export P1::y; // Should fail, P1::y has not been imported.
+endpackage
+
+module test;
+  initial begin
+    $display("FAILED");
+  end
+endmodule

--- a/ivtest/ivltests/sv_export_fail3.v
+++ b/ivtest/ivltests/sv_export_fail3.v
@@ -1,0 +1,23 @@
+// Check that an identifier importable through a wildcard import is not exported
+// through a wildcard export if the identifier has not been referenced in
+// package.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::*;
+  export *::*;
+endpackage
+
+module test;
+
+  import P2::x; // This should fail, P1::x is not referenced in P2 and hence not
+                // exportable through P2
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export_fail4.v
+++ b/ivtest/ivltests/sv_export_fail4.v
@@ -1,0 +1,23 @@
+// Check that it is an error to export an identifier that is importable through
+// a wildcard import if it creates a conflict with a local identifier.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::*;
+  integer x = 456;
+  export P1::x; // This should fail, P1::x can not be imported into this scope
+                // since the name already exists.
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export_fail5.v
+++ b/ivtest/ivltests/sv_export_fail5.v
@@ -1,0 +1,25 @@
+// Check that it is an error to export an identifier that is importable through
+// a wildcard import if it creates a conflict with a local identifier, even if
+// the local identifier is declared after the export.
+
+package P1;
+  integer x = 123;
+endpackage
+
+package P2;
+  import P1::*;
+  export P1::x; // This should fail, P1::x can not be imported into this scope
+                // since the there is a local symbol with the same name. Even if
+                // it is declared after the export.
+  integer x = 456;
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_export_fail6.v
+++ b/ivtest/ivltests/sv_export_fail6.v
@@ -1,0 +1,22 @@
+// Check that an error is reported if trying to export an identifier that is
+// declared outside of a package
+
+integer x = 123;
+
+package P1;
+endpackage
+
+package P2;
+  import P1::*;
+  export P1::x; // This should fail. x is visible in P1, but not declared in P1
+endpackage
+
+module test;
+
+  import P2::x;
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -668,6 +668,18 @@ sv_end_labels		normal,-g2009		ivltests
 sv_end_labels_bad	CE,-g2009		ivltests gold=sv_end_labels_bad.gold
 sv_end_labels_unnamed	CE,-g2009		ivltests gold=sv_end_labels_unnamed.gold
 sv_enum1		normal,-g2009		ivltests
+sv_export1		normal,-g2009		ivltests
+sv_export2		normal,-g2009		ivltests
+sv_export3		normal,-g2009		ivltests
+sv_export4		normal,-g2009		ivltests
+sv_export5		normal,-g2009		ivltests
+sv_export6		normal,-g2009		ivltests
+sv_export_fail1		CE,-g2009		ivltests
+sv_export_fail2		CE,-g2009		ivltests
+sv_export_fail3		CE,-g2009		ivltests
+sv_export_fail4		CE,-g2009		ivltests
+sv_export_fail5		CE,-g2009		ivltests
+sv_export_fail6		CE,-g2009		ivltests
 sv_for_variable		normal,-g2009		ivltests
 sv_foreach1		normal,-g2009		ivltests
 sv_foreach2		normal,-g2009		ivltests

--- a/parse.y
+++ b/parse.y
@@ -2053,6 +2053,30 @@ package_import_item_list
   | package_import_item
   ;
 
+package_export_declaration /* IEEE1800-2017 A.2.1.3 */
+  : K_export package_export_item_list ';'
+  | K_export '*' K_SCOPE_RES '*' ';' { pform_package_export(@$, nullptr, nullptr); }
+  ;
+
+package_export_item
+  : PACKAGE_IDENTIFIER K_SCOPE_RES IDENTIFIER
+      { pform_package_export(@2, $1, $3);
+	delete[] $3;
+      }
+  | PACKAGE_IDENTIFIER K_SCOPE_RES TYPE_IDENTIFIER
+      { pform_package_export(@2, $1, $3.text);
+	delete[] $3.text;
+      }
+  | PACKAGE_IDENTIFIER K_SCOPE_RES '*'
+      { pform_package_export(@2, $1, nullptr);
+      }
+  ;
+
+package_export_item_list
+  : package_export_item_list ',' package_export_item
+  | package_export_item
+  ;
+
 package_item /* IEEE1800-2005 A.1.10 */
   : timeunits_declaration
   | parameter_declaration
@@ -2061,6 +2085,7 @@ package_item /* IEEE1800-2005 A.1.10 */
   | task_declaration
   | data_declaration
   | class_declaration
+  | package_export_declaration
   ;
 
 package_item_list

--- a/pform.h
+++ b/pform.h
@@ -203,6 +203,12 @@ extern void pform_start_package_declaration(const struct vlltype&loc,
 extern void pform_end_package_declaration(const struct vlltype&loc);
 extern void pform_package_import(const struct vlltype&loc,
 				 PPackage*pkg, const char*ident);
+extern void pform_package_export(const struct vlltype &loc, PPackage *pkg,
+			         const char *ident);
+PPackage *pform_package_importable(PPackage *pkg, perm_string name);
+PPackage *pform_find_potential_import(const struct vlltype&loc, LexicalScope*scope,
+				      perm_string name, bool tf_call, bool make_explicit);
+
 
 extern PExpr* pform_package_ident(const struct vlltype&loc,
 				  PPackage*pkg, pform_name_t*ident);


### PR DESCRIPTION
By default an identifier that has been imported into a package is not
available for imports by other packages. Only imports that have been
exported can be imported again. E.g.

```SystemVerilog
package P1;
  int x;
endpackage

package P2;
  import P1::x;
  export P1::x;
endpackage

module test;
  import P2::x; // This will only work if x has been exported.
endmodule
```

Exports follow the same syntax as imports and allow both export of specific
identifiers or wildcard export. Export supports the special `*::*` target,
which will export all imported items.

Add support for handling package exports.

There is one special cases that needs to be considered. Usually when using
wildcard imports from multiple packages it is an error if there multiple
import candidates for an identifier. With exports it is possible that there
are multiple candidates through different packets, but they all refer to
the same identifier. In this case it does not create a conflict. E.g.

```SystemVerilog
package P1;
  int x;
endpackage

package P2;
  import P1::x;
  export P1::x;
endpackage

package P3;
   import P1::*;
   import P2::*;
   int y = x; // No import conflict
endpackage
```

Resolves #241.