### PR TITLE
Add initial support for packed array and packed struct assignment patterns

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -213,8 +213,15 @@ class PEAssignPattern : public PExpr {
 				     unsigned expr_wid,
                                      unsigned flags) const;
     private:
-      NetExpr* elaborate_expr_darray_(Design*des, NetScope*scope,
-				      ivl_type_t type, unsigned flags) const;
+      NetExpr* elaborate_expr_packed_(Design *des, NetScope *scope,
+				      ivl_variable_type_t base_type,
+				      unsigned int width,
+				      const std::vector<netrange_t> &dims,
+				      unsigned int cur_dim,
+				      bool need_const) const;
+      NetExpr* elaborate_expr_darray_(Design *des, NetScope *scope,
+				      const netdarray_t *array_type,
+				      bool need_const) const;
 
     private:
       std::vector<PExpr*>parms_;

--- a/PExpr.h
+++ b/PExpr.h
@@ -219,6 +219,9 @@ class PEAssignPattern : public PExpr {
 				      const std::vector<netrange_t> &dims,
 				      unsigned int cur_dim,
 				      bool need_const) const;
+      NetExpr* elaborate_expr_struct_(Design *des, NetScope *scope,
+				      const netstruct_t *struct_type,
+				      bool need_const) const;
       NetExpr* elaborate_expr_darray_(Design *des, NetScope *scope,
 				      const netdarray_t *array_type,
 				      bool need_const) const;

--- a/ivtest/ivltests/sv_ap_parray1.v
+++ b/ivtest/ivltests/sv_ap_parray1.v
@@ -1,0 +1,19 @@
+// Check that positional assigment patterns are supported for packed arrays.
+
+module test;
+
+  bit [3:0][3:0] x = '{1'b1, 1 + 1, 3.0, "TEST"};
+
+  // Check nested assignment pattern
+  bit [1:0][3:0][3:0] y = '{'{1'b1, 1 + 1, 3.0, "TEST"},
+                            '{5, 6, '{1'b0, 1 * 1, 3, 1.0}, 8}};
+
+  initial begin
+    if (x === 16'h1234 && y == 32'h12345678) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_parray2.v
+++ b/ivtest/ivltests/sv_ap_parray2.v
@@ -1,0 +1,16 @@
+// Check that positional assigment patterns are supported for packed array
+// parameters.
+
+module test;
+
+  localparam bit [2:0] x = '{1'b1, 2.0, 2 + 1};
+
+  initial begin
+    if (x === 3'b101) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_parray_fail1.v
+++ b/ivtest/ivltests/sv_ap_parray_fail1.v
@@ -1,0 +1,13 @@
+// Check that an error is reported when specifing less elements in a packed
+// array assignment pattern than the array size.
+
+module test;
+
+  bit [2:0][3:0] x = '{1, 2}; // This should fail. Less elements than array
+                              // size.
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_parray_fail2.v
+++ b/ivtest/ivltests/sv_ap_parray_fail2.v
@@ -1,0 +1,13 @@
+// Check that an error is reported when specifing more elements in a packed
+// array assignment pattern than the array size.
+
+module test;
+
+  bit [2:0][3:0] x = '{1, 2, 3, 4}; // This should fail. More elements than
+                                    // array size.
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_parray_fail3.v
+++ b/ivtest/ivltests/sv_ap_parray_fail3.v
@@ -1,0 +1,13 @@
+// Check that an error is reported when using an assignment pattern on a scalar
+// type.
+
+module test;
+
+  bit x = '{1'b1}; // This should fail. Can't use assignment pattern with
+                   // scalar types
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_struct1.v
+++ b/ivtest/ivltests/sv_ap_struct1.v
@@ -1,0 +1,28 @@
+// Check that positional assigment patterns are supported for structs.
+
+module test;
+
+  typedef struct packed {
+    int x;
+    shortint y;
+    byte z;
+  } T;
+
+  T x = '{1'b1, 2.0, 2 + 1};
+
+  // Check nested assignment patterns
+  struct packed {
+    T x;
+    bit [2:0][3:0] y;
+  } y = '{'{1'b1, 2.0, 2 + 1}, '{4, 5, 6}};
+
+  initial begin
+    if (x === 56'h00000001000203 &&
+        y === 68'h00000001000203456) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_struct2.v
+++ b/ivtest/ivltests/sv_ap_struct2.v
@@ -1,0 +1,22 @@
+// Check that positional assigment patterns are supported for structs are
+// supported for parameters.
+
+module test;
+
+  typedef struct packed {
+    int x;
+    shortint y;
+    byte z;
+  } T;
+
+  localparam T x = '{1'b1, 2.0, 2 + 1};
+
+  initial begin
+    if (x === 56'h00000001000203) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_struct_fail1.v
+++ b/ivtest/ivltests/sv_ap_struct_fail1.v
@@ -1,0 +1,16 @@
+// Check that it is an error to provide less elements in a struct assignment
+// pattern than there are members in the struct.
+
+module test;
+
+  struct packed {
+    int x;
+    shortint y;
+    byte z;
+  } x = '{1, 2}; // This should fail. Less elements than required.
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_struct_fail2.v
+++ b/ivtest/ivltests/sv_ap_struct_fail2.v
@@ -1,0 +1,16 @@
+// Check that it is an error to provide more elements in a struct assignment
+// pattern than there are members in the struct.
+
+module test;
+
+  struct packed {
+    int x;
+    shortint y;
+    byte z;
+  } x = '{1, 2, 3, 4}; // This should fail. More elements than required.
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -520,6 +520,11 @@ struct_packed_write_read2	normal,-g2009	ivltests
 struct_invalid_member	CE,-g2009		ivltests gold=struct_invalid_member.gold
 struct_signed		normal,-g2009		ivltests
 sv-constants		normal,-g2005-sv	ivltests
+sv_ap_parray1		normal,-g2005-sv	ivltests
+sv_ap_parray2		normal,-g2005-sv	ivltests
+sv_ap_parray_fail1	CE,-g2005-sv		ivltests
+sv_ap_parray_fail2	CE,-g2005-sv		ivltests
+sv_ap_parray_fail3	CE,-g2005-sv		ivltests
 sv_assign_pattern_cast	normal,-g2005-sv	ivltests
 sv_assign_pattern_const	normal,-g2005-sv	ivltests
 sv_assign_pattern_concat normal,-g2005-sv	ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -525,6 +525,10 @@ sv_ap_parray2		normal,-g2005-sv	ivltests
 sv_ap_parray_fail1	CE,-g2005-sv		ivltests
 sv_ap_parray_fail2	CE,-g2005-sv		ivltests
 sv_ap_parray_fail3	CE,-g2005-sv		ivltests
+sv_ap_struct1		normal,-g2005-sv	ivltests
+sv_ap_struct2		normal,-g2005-sv	ivltests
+sv_ap_struct_fail1	CE,-g2005-sv		ivltests
+sv_ap_struct_fail2	CE,-g2005-sv		ivltests
 sv_assign_pattern_cast	normal,-g2005-sv	ivltests
 sv_assign_pattern_const	normal,-g2005-sv	ivltests
 sv_assign_pattern_concat normal,-g2005-sv	ivltests

--- a/net_design.cc
+++ b/net_design.cc
@@ -550,8 +550,16 @@ void NetScope::evaluate_parameter_logic_(Design*des, param_ref_t cur)
 		 << "use_type = " << use_type << endl;
       }
 
-      NetExpr*expr = elab_and_eval(des, val_scope, val_expr, lv_width, true,
-                                   cur->second.is_annotatable, use_type);
+      NetExpr *expr;
+
+      // Handle assignment patterns as a special case as they need the type to
+      // be evaluated correctly.
+      if (param_type && dynamic_cast<PEAssignPattern*>(val_expr)) {
+	    expr = elab_and_eval(des, val_scope, val_expr, param_type, true);
+      } else {
+	    expr = elab_and_eval(des, val_scope, val_expr, lv_width, true,
+				 cur->second.is_annotatable, use_type);
+      }
       if (! expr)
             return;
 

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1019,6 +1019,11 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 	    return 0;
       }
 
+      if (lv_net_type->packed())
+	    eval_expr(tmp, lv_net_type->packed_width());
+      else
+	    eval_expr(tmp, -1);
+
       return tmp;
 }
 

--- a/netstruct.h
+++ b/netstruct.h
@@ -65,6 +65,7 @@ class netstruct_t : public LineInfo, public ivl_type_s {
 	// description, and set the off value to be the offset into
 	// the packed value where the member begins.
       const struct member_t* packed_member(perm_string name, unsigned long&off) const;
+      const std::vector<member_t>& members() const { return members_; }
 
 	// Return the width (in bits) of the packed record, or -1 if
 	// the record is not packed.


### PR DESCRIPTION
SystemVerilog allows to use assignment patterns to assign a value to a
packed array or packed struct typed variable.

This is similar to using a concatenation, with the difference that for
concatenations the values are evaluated in a self-determined context and
for assignment patterns they are evaluated in a context defined by the
element type of the packed array or the member type of the struct.
This means that the value is for example automatically width expanded or
truncated if it does not have the same size as the element type. Automatic
type conversion is also done when allowed. E.g.

```SystemVerilog
bit [3:0][3:0] x = '{1'b1, 32'h2, 3.0, "TEST"};
$display("%x", x); // -> 1234
```

Nested assignment patterns are also supported. E.g.

```SystemVerilog
struct packed {
  byte x;
  bit [2:0][3:0] y;
} x = '{1, '{2, 3, 4}};
$display("%x", x); // -> 1234
```

Add support for using assignment patterns as the right hand side value.
Since the complete type of the target variable is required to correctly
evaluate the assignment pattern it is handled as a special case in
`elab_rval_expression()`. For other types of expressions for packed values
only the total width of the target value is provided to the rvalue
elaboration function.

SystemVerilog also supports assignment patterns for the left hand side in
assignments. This is not yet supported.

Also not yet supported is specifying array elements by index, struct members by
name as well as the `default` keyword. Such as
```SystemVerilog
bit [3:0][3:0] x = '{1:1, default: 0};
```

