### PR TITLE
Handle continuous assignment of assignment patterns to array elements

### DIFF
--- a/elab_net.cc
+++ b/elab_net.cc
@@ -890,11 +890,8 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
       if (sig->pin_count() > 1 && widx_flag) {
 	    if (widx < 0 || widx >= (long) sig->pin_count())
 		  return 0;
-
-	    netvector_t*tmp2_vec = new netvector_t(sig->data_type(),
-						   sig->vector_width()-1,0);
 	    NetNet*tmp = new NetNet(scope, scope->local_symbol(),
-				    sig->type(), tmp2_vec);
+				    sig->type(), sig->net_type());
 	    tmp->set_line(*this);
 	    tmp->local_flag(true);
 	    connect(sig->pin(widx), tmp->pin(0));

--- a/ivtest/ivltests/sv_ap_parray3.v
+++ b/ivtest/ivltests/sv_ap_parray3.v
@@ -1,0 +1,21 @@
+// Check that positional assignment patterns are supported for packed arrays
+// when doing continuous assignments.
+
+module test;
+
+  wire [3:0][3:0] x;
+  wire [1:0][3:0][3:0] y;
+
+  assign x = '{1'b1, 32'h2, 3.0, "TEST"};
+  assign y = '{'{1'b1, 1 + 1, 3.0, "TEST"},
+               '{5, 6, '{1'b0, 1 * 1, 3, 1.0}, 8}};
+
+  final begin
+    if (x === 16'h1234 && y == 32'h12345678) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_parray4.v
+++ b/ivtest/ivltests/sv_ap_parray4.v
@@ -1,0 +1,21 @@
+// Check that positional assignment patterns are supported for packed arrays
+// when doing continuous assignments to array elements.
+
+module test;
+
+  wire [3:0][3:0] x[2];
+  wire [1:0][3:0][3:0] y[2];
+
+  assign x[0] = '{1'b1, 32'h2, 3.0, "TEST"};
+  assign y[1] = '{'{1'b1, 1 + 1, 3.0, "TEST"},
+                  '{5, 6, '{1'b0, 1 * 1, 3, 1.0}, 8}};
+
+  final begin
+    if (x[0] === 16'h1234 && y[1] == 32'h12345678) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_struct3.v
+++ b/ivtest/ivltests/sv_ap_struct3.v
@@ -1,0 +1,32 @@
+// Check that positional assigment patterns are supported for structs when using
+// continuous assignments.
+
+module test;
+
+  typedef struct packed {
+    logic [31:0] x;
+    logic [15:0] y;
+    logic [7:0] z;
+  } T;
+
+  T x;
+
+  // Check nested assignment patterns
+  struct packed {
+    T x;
+    logic [2:0][3:0] y;
+  } y;
+
+  assign x = '{1'b1, 2.0, 2 + 1};
+  assign y = '{'{1'b1, 2.0, 2 + 1}, '{4, 5, 6}};
+
+  final begin
+    if (x === 56'h00000001000203 &&
+        y === 68'h00000001000203456) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_struct4.v
+++ b/ivtest/ivltests/sv_ap_struct4.v
@@ -1,0 +1,32 @@
+// Check that positional assigment patterns are supported for structs when using
+// continuous assignments to array elements.
+
+module test;
+
+  typedef struct packed {
+    logic [31:0] x;
+    logic [15:0] y;
+    logic [7:0] z;
+  } T;
+
+  T x[2];
+
+  // Check nested assignment patterns
+  struct packed {
+    T x;
+    logic [2:0][3:0] y;
+  } y[2];
+
+  assign x[0] = '{1'b1, 2.0, 2 + 1};
+  assign y[1] = '{'{1'b1, 2.0, 2 + 1}, '{4, 5, 6}};
+
+  final begin
+    if (x[0] === 56'h00000001000203 &&
+        y[1] === 68'h00000001000203456) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -521,11 +521,15 @@ struct_signed		normal,-g2009		ivltests
 sv-constants		normal,-g2005-sv	ivltests
 sv_ap_parray1		normal,-g2005-sv	ivltests
 sv_ap_parray2		normal,-g2005-sv	ivltests
+sv_ap_parray3		normal,-g2005-sv	ivltests
+sv_ap_parray4		normal,-g2005-sv	ivltests
 sv_ap_parray_fail1	CE,-g2005-sv		ivltests
 sv_ap_parray_fail2	CE,-g2005-sv		ivltests
 sv_ap_parray_fail3	CE,-g2005-sv		ivltests
 sv_ap_struct1		normal,-g2005-sv	ivltests
 sv_ap_struct2		normal,-g2005-sv	ivltests
+sv_ap_struct3		normal,-g2005-sv	ivltests
+sv_ap_struct4		normal,-g2005-sv	ivltests
 sv_ap_struct_fail1	CE,-g2005-sv		ivltests
 sv_ap_struct_fail2	CE,-g2005-sv		ivltests
 sv_assign_pattern_cast	normal,-g2005-sv	ivltests

--- a/ivtest/regress-vlog95.list
+++ b/ivtest/regress-vlog95.list
@@ -260,6 +260,8 @@ scan-invalid		CE			ivltests
 sel_rval_bit_ob		CE			ivltests
 sel_rval_part_ob	CE			ivltests
 signed_net_display	CE,-pallowsigned=1	ivltests
+sv_ap_parray4		CE,-g2005-sv		ivltests
+sv_ap_struct4		CE,-g2005-sv		ivltests
 sv_array_cassign1	CE,-g2005-sv		ivltests
 sv_array_cassign2	CE,-g2005-sv		ivltests
 sv_array_cassign3	CE,-g2005-sv		ivltests


### PR DESCRIPTION
Currently when creating the NetNet for a continuous assignment to an array
element the type of the element is flattened into a canonical 1 dimensional
form. This works for most cases because packed types are compatible if
their total packed with is the same.

But there are some contexts such as if the right-hand-side is an assignment
pattern where the actual type matters and flattening the type will result
in incorrect behavior.

Retain the original type of the array element when creating the NetNet for
the array element assignment.