### PR TITLE
Initialize NetNet::port_index_

### DIFF
--- a/netlist.h
+++ b/netlist.h
@@ -825,7 +825,7 @@ class NetNet  : public NetObj, public PortType {
       std::vector<bool> lref_mask_;
 
       std::vector<class NetDelaySrc*> delay_paths_;
-      int       port_index_;
+      int       port_index_ = -1;
 };
 
 /*


### PR DESCRIPTION
The port_index_ member of the NetNet is not initialized which can lead to undefined behavior. Make sure to initialize to -1 to indicate that the net is not associated with any port.

Resolves #890