### PR TITLE
vvp: Handle `%fork` in `final` procedures

### DIFF
--- a/ivtest/ivltests/final3.v
+++ b/ivtest/ivltests/final3.v
@@ -1,0 +1,20 @@
+// Check that sub-blocks with variable declarations inside final procedures get
+// executed
+
+
+module test;
+
+  final begin
+    static int x = -1;
+    for (int i = 0; i < 1; i++) begin
+      x = i;
+    end
+
+    if (x === 0) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -23,6 +23,7 @@ dffsynth9			vvp_tests/dffsynth9.json
 dffsynth10			vvp_tests/dffsynth10.json
 dffsynth11			vvp_tests/dffsynth11.json
 dumpfile			vvp_tests/dumpfile.json
+final3				vvp_tests/final3.json
 macro_str_esc			vvp_tests/macro_str_esc.json
 memsynth1			vvp_tests/memsynth1.json
 param-width			vvp_tests/param-width.json

--- a/ivtest/vvp_tests/final3.json
+++ b/ivtest/vvp_tests/final3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "final3.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/vvp/schedule.cc
+++ b/vvp/schedule.cc
@@ -855,6 +855,7 @@ void schedule_final_vthread(vthread_t thr)
       struct vthread_event_s*cur = new vthread_event_s;
 
       cur->thr = thr;
+      vthread_mark_final(thr);
       vthread_mark_scheduled(thr);
 
       schedule_final_event(cur);

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -833,6 +833,19 @@ void vthread_mark_scheduled(vthread_t thr)
       }
 }
 
+void vthread_mark_final(vthread_t thr)
+{
+      /*
+       * The behavior in a final thread is the same as in a function. Any
+       * child thread will be executed immediately rather than being
+       * scheduled.
+       */
+      while (thr != 0) {
+	    thr->i_am_in_function = 1;
+	    thr = thr->wait_next;
+      }
+}
+
 void vthread_delay_delete()
 {
       if (running_thread)

--- a/vvp/vthread.h
+++ b/vvp/vthread.h
@@ -52,6 +52,11 @@ extern vthread_t vthread_new(vvp_code_t sa, __vpiScope*scope);
 extern void vthread_mark_scheduled(vthread_t thr);
 
 /*
+ * This function marks the thread as being a final procedure.
+ */
+extern void vthread_mark_final(vthread_t thr);
+
+/*
  * This function causes deletion of the currently running thread to
  * be delayed until after all sync events have been processed for the
  * time step in which the thread terminates. It is only used by the


### PR DESCRIPTION
In the current implementation a `%fork` instruction in a final block will
get scheduled, but never executed.

And while SystemVerilog requires a `final` procedure to execute in 0 time
and so no SystemVerilog `fork` is allowed inside of it, there are some
other scenarios where iverilog generates `%fork` statements.

For example when declaring variables in a sub-block a sub-scope with its
own thread is is used to allocate the storage for those variables and
`%fork` is used to execute the child thread.

E.g. the following, while being valid SystemVerilog, will never execute the
loop because the generated code will implement the loop as a child thread
being executed by a `%fork` statement.
```SystemVerilog
  final for (int i = 0; i < 10; i++) $display(i);
```

To mitigate this treat final statements the same as functions and rather
than scheduling a child thread, execute it immediately when using the `%fork`
statement.