### PR TITLE
Support return in tasks

### DIFF
--- a/ivtest/ivltests/task_return1.v
+++ b/ivtest/ivltests/task_return1.v
@@ -1,0 +1,31 @@
+// Check that it is possible to exit from a task using the return statement with
+// affecting other concurrently running instances of the same task.
+
+module test;
+
+  task automatic t(input integer a, output integer b);
+    if (a == 0) begin
+      b = 1;
+      return;
+    end
+    #10
+    b = 100;
+  endtask
+
+  integer b1;
+  integer b2;
+
+  initial begin
+    fork
+      t(0, b1);
+      t(1, b2);
+    join
+
+    if (b1 == 1 && b2 == 100) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED b1=%0d, b2=%0d", b1, b2);
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/task_return2.v
+++ b/ivtest/ivltests/task_return2.v
@@ -1,0 +1,22 @@
+// Check that it is possible to return from a named sub-block of a task using a
+// `return` statement.
+
+module test;
+
+  task t(input integer a);
+    begin : subblock
+      if (a == 1) begin : condition
+        return;
+      end
+    end
+    $display("FAILED");
+    $finish;
+  endtask
+
+  initial begin
+    t(1);
+    #10
+    $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/task_return_fail1.v
+++ b/ivtest/ivltests/task_return_fail1.v
@@ -1,0 +1,15 @@
+// Check that using a return value when using the return statement in a task
+// results in an error.
+
+module test;
+
+  task t;
+    return 10; // This is an error, tasks can not have return values.
+  endtask
+
+  initial begin
+    t();
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/task_return_fail2.v
+++ b/ivtest/ivltests/task_return_fail2.v
@@ -1,0 +1,18 @@
+// Check that using a return statment inside a parallel block in a task results
+// in an error.
+
+module test;
+
+  task t;
+    fork
+      // This is an error it is not possible to return from inside a parallel block
+      return;
+    join
+  endtask
+
+  initial begin
+    t();
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -36,3 +36,7 @@ struct_packed_write_read2	vvp_tests/struct_packed_write_read2.json
 sv_foreach9			vvp_tests/sv_foreach9.json
 sv_foreach10			vvp_tests/sv_foreach10.json
 sdf_header			vvp_tests/sdf_header.json
+task_return1			vvp_tests/task_return1.json
+task_return2			vvp_tests/task_return2.json
+task_return_fail1		vvp_tests/task_return_fail1.json
+task_return_fail2		vvp_tests/task_return_fail2.json

--- a/ivtest/vvp_tests/task_return1.json
+++ b/ivtest/vvp_tests/task_return1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "task_return1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/task_return2.json
+++ b/ivtest/vvp_tests/task_return2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "task_return2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/task_return_fail1.json
+++ b/ivtest/vvp_tests/task_return_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "task_return_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/task_return_fail2.json
+++ b/ivtest/vvp_tests/task_return_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "task_return_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/netlist.h
+++ b/netlist.h
@@ -5124,6 +5124,12 @@ class Design {
 	// detected. It prevents code being emitted.
       unsigned errors;
 
+      void fork_enter() { in_fork++; };
+      void fork_exit() { in_fork--; };
+      bool is_in_fork() { return in_fork != 0; }
+
+      unsigned int in_fork = 0;
+
     private:
       NetScope* find_scope_(NetScope*, const hname_t&name,
                             NetScope::TYPE type = NetScope::MODULE) const;


### PR DESCRIPTION
SystemVerilog allows to use the `return` statement in a task to exit the
task before it reaches the end of its execution. This is defined in section
13.3 ("Tasks") of the LRM (1800-2017).

This is similar to using `disable` to stop a task from within itself with
the difference that `disable` will affect all concurrently running
executions of a task, while `return` will only affect the task from which
it has been called.

The `%disable/flow` vvp instruction allows to implement the required
behavior for task return.

There is one complication in that it is not allowed to call return from
inside a parallel block (fork-join). If a parallel block is unnamed and has
no variable declarations there won't be a NetScope for it. So it is not
possible to detect whether the return is inside a parallel block by
walking up the scope chain.

To solve this add a design global counter that gets incremented when
entering a fork block and decremented when exiting a parallel block. The
return implementation then checks if the counter is non 0 to determine
whether it is in a parallel block.
