### PR TITLE
Added support for labels in immediate assert/assume

### DIFF
--- a/ivtest/gold/sv_immediate_assert.gold
+++ b/ivtest/gold/sv_immediate_assert.gold
@@ -6,3 +6,6 @@ ERROR: ./ivltests/sv_immediate_assert.v:11:
        Time: 0  Scope: test
 Check 7 : this should be displayed
 Check 8 : this should be displayed
+ERROR: ./ivltests/sv_immediate_assert.v:19: Check 9 : this should be displayed
+       Time: 0  Scope: test
+Check 10 : this should be displayed

--- a/ivtest/gold/sv_immediate_assume.gold
+++ b/ivtest/gold/sv_immediate_assume.gold
@@ -6,3 +6,6 @@ ERROR: ./ivltests/sv_immediate_assume.v:11:
        Time: 0  Scope: test
 Check 7 : this should be displayed
 Check 8 : this should be displayed
+ERROR: ./ivltests/sv_immediate_assume.v:19: Check 9 : this should be displayed
+       Time: 0  Scope: test
+Check 10 : this should be displayed

--- a/ivtest/ivltests/sv_immediate_assert.v
+++ b/ivtest/ivltests/sv_immediate_assert.v
@@ -13,6 +13,15 @@ initial begin
     else $display("Check 7 : this shouldn't be displayed");
   assert(i == 0) $display("Check 8 : this shouldn't be displayed");
     else $display("Check 8 : this should be displayed");
+
+  a_i_is_non_0 : assert(i == 0) 
+    $display("Check 9 : this shouldn't be displayed");
+    else $error("Check 9 : this should be displayed");
+
+  a_i_is_1 : assert(i == 1) 
+    $display("Check 10 : this should be displayed");
+    else $error("Check 10 : this shouldn't be displayed i: %0d", i);
+
 end
 
 endmodule

--- a/ivtest/ivltests/sv_immediate_assume.v
+++ b/ivtest/ivltests/sv_immediate_assume.v
@@ -13,6 +13,15 @@ initial begin
     else $display("Check 7 : this shouldn't be displayed");
   assume(i == 0) $display("Check 8 : this shouldn't be displayed");
     else $display("Check 8 : this should be displayed");
+
+  a_i_is_non_0 : assume(i == 0) 
+    $display("Check 9 : this shouldn't be displayed");
+    else $error("Check 9 : this should be displayed");
+
+  a_i_is_1 : assume(i == 1) 
+    $display("Check 10 : this should be displayed");
+    else $error("Check 10 : this shouldn't be displayed i: %0d", i);
+
 end
 
 endmodule

--- a/parse.y
+++ b/parse.y
@@ -2118,12 +2118,12 @@ port_direction_opt
   ;
 
 procedural_assertion_statement /* IEEE1800-2012 A.6.10 */
-  : concurrent_assertion_statement
-      { $$ = $1; }
-  | simple_immediate_assertion_statement
-      { $$ = $1; }
-  | deferred_immediate_assertion_statement
-      { $$ = $1; }
+  : block_identifier_opt concurrent_assertion_statement
+      { $$ = $2; }
+  | block_identifier_opt simple_immediate_assertion_statement
+      { $$ = $2; }
+  | block_identifier_opt deferred_immediate_assertion_statement
+      { $$ = $2; }
   ;
 
 property_expr /* IEEE1800-2012 A.2.10 */


### PR DESCRIPTION
Updated parse.y to add labels. Also added labelled assert/assume in existing tests. Updated GOLD files accordingly. Fixes #897 