### PR TITLE
Fix connecting single element array ports

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -1538,7 +1538,7 @@ void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
 		    // array, then there should be no sub-ports and
 		    // the r-value expression is processed
 		    // differently.
-		  if (prts.size() >= 1 && prts[0]->pin_count()>1) {
+		  if (prts.size() >= 1 && prts[0]->unpacked_dimensions() > 0) {
 			ivl_assert(*this, prts.size()==1);
 			elaborate_unpacked_port(des, scope, prts[0], pins[idx],
 						ptype, rmod, idx);
@@ -1703,7 +1703,7 @@ void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
 		    // differently. Note that we are calling it the
 		    // "r-value" expression, but since this is an
 		    // output port, we assign to it from the internal object.
-		  if (prts[0]->pin_count() > 1) {
+		  if (prts[0]->unpacked_dimensions() > 0) {
 			elaborate_unpacked_port(des, scope, prts[0], pins[idx],
 						ptype, rmod, idx);
 			continue;

--- a/ivtest/ivltests/module_port_array1.v
+++ b/ivtest/ivltests/module_port_array1.v
@@ -1,0 +1,32 @@
+// Check that connecting a module port array with a single element is supported
+
+module M (
+  input [7:0] in[0:0],
+  output [7:0] out[0:0]
+);
+
+  assign out[0] = in[0];
+
+endmodule
+
+module test;
+
+  reg [7:0] A[0:0];
+  wire [7:0] B[0:0];
+
+  M i_m (
+    .in(A),
+    .out(B)
+  );
+
+  initial begin
+    A[0] = 10;
+    #1
+    if (B[0] === 10) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -25,6 +25,7 @@ dffsynth11			vvp_tests/dffsynth11.json
 dumpfile			vvp_tests/dumpfile.json
 macro_str_esc			vvp_tests/macro_str_esc.json
 memsynth1			vvp_tests/memsynth1.json
+module_port_array1		vvp_tests/module_port_array1.json
 param-width			vvp_tests/param-width.json
 param-width-vlog95		vvp_tests/param-width-vlog95.json
 pr1388974			vvp_tests/pr1388974.json

--- a/ivtest/vvp_tests/module_port_array1.json
+++ b/ivtest/vvp_tests/module_port_array1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "module_port_array1.v",
+    "iverilog-args" : [ "-g2009" ]
+}


### PR DESCRIPTION
The current check to decide whether a port is an array or a scalar signal
uses the number of pins on the NetNet. If it is larger than one the code
assumes that it is an array.

But for arrays with on a single element the number of pins will be 1 and
the port is incorrectly treated as a scalar signal which results in an
error.

Instead of using the number of pins check for the number of unpacked
dimensions to decide whether the port is an array.

Resolves #915 