### PR TITLE
 Allow to omit trailing module ports in ordered list connection

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -1317,22 +1317,20 @@ void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
       } else {
 
 	      /* Otherwise, this is a positional list of port
-		 connections. In this case, the port count must be
-		 right. Check that is is, the get the pin list. */
+		 connections. Use as many ports as provided. Trailing
+		 missing ports will be left unconnect or use the default
+		 value if one is available */
 
-	    if (pin_count() != rmod->port_count()) {
+	    if (pin_count() > rmod->port_count()) {
 		  cerr << get_fileline() << ": error: Wrong number "
-			"of ports. Expecting " << rmod->port_count() <<
+			"of ports. Expecting at most " << rmod->port_count() <<
 			", got " << pin_count() << "."
 		       << endl;
 		  des->errors += 1;
 		  return;
 	    }
 
-	      // No named bindings, just use the positional list I
-	      // already have.
-	    assert(pin_count() == rmod->port_count());
-	    pins = get_pins();
+	    std::copy(get_pins().begin(), get_pins().end(), pins.begin());
       }
 
 	// Elaborate these instances of the module. The recursive

--- a/ivtest/ivltests/module_ordered_list1.v
+++ b/ivtest/ivltests/module_ordered_list1.v
@@ -1,0 +1,35 @@
+// Check that it is possible to omit trailing module ports in a ordered list
+// connection if the trailing port has a default value.
+
+module M (
+    output logic a,
+    input  logic b,
+    input  logic c = 1'b0,
+    input  logic d = 1'b1
+);
+    assign a = b ^ c ^ d;
+endmodule
+
+module test;
+
+  logic a, b, c;
+  logic x, y;
+
+  assign b = 1'b0;
+  assign c = 1'b1;
+
+  assign y = 1'b1;
+
+  M i_M1 (a, b, c);
+  M i_M2 (x, y);
+
+  initial begin
+    #1
+    if (a !== 1'b0 || x !== 1'b0) begin
+      $display("FAILED");
+    end else begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/module_ordered_list2.v
+++ b/ivtest/ivltests/module_ordered_list2.v
@@ -1,0 +1,24 @@
+// Check that an error is reported when specifying too many ports in a ordered
+// list connection.
+
+module M (
+    output a,
+    input  b
+);
+    assign a = b;
+endmodule
+
+module test;
+
+  wire a, b, c;
+
+  assign b = 1'b0;
+  assign c = 1'b1;
+
+  M i_M (a, b, c); // Error, too many ports.
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -26,6 +26,8 @@ dumpfile			vvp_tests/dumpfile.json
 final3				vvp_tests/final3.json
 macro_str_esc			vvp_tests/macro_str_esc.json
 memsynth1			vvp_tests/memsynth1.json
+module_ordered_list1		vvp_tests/module_ordered_list1.json
+module_ordered_list2		vvp_tests/module_ordered_list2.json
 module_port_array1		vvp_tests/module_port_array1.json
 param-width			vvp_tests/param-width.json
 param-width-vlog95		vvp_tests/param-width-vlog95.json

--- a/ivtest/vvp_tests/module_ordered_list1.json
+++ b/ivtest/vvp_tests/module_ordered_list1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "module_ordered_list1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/module_ordered_list2.json
+++ b/ivtest/vvp_tests/module_ordered_list2.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "module_ordered_list2.v"
+}


### PR DESCRIPTION
The current implementation expects that for a module instantiation with a
ordered list connection all ports are supplied.

But there doesn't seem to be such a requirement in the LRMs. The Verilog
LRM doesn't mention anything in this regard and the SystemVerilog LRM
mentions in section 23.3.2.1 that a blank or omitted port connection is
either left unconnected or uses the default value of the port.

Update the implementation so that it allows to omit trailing ports and only
generates an error message if too many ports are specified in the ordered
port list.

Resolves #931