### PR TITLE
Support continue/break in constant functions

### DIFF
--- a/ivtest/ivltests/constfunc16.v
+++ b/ivtest/ivltests/constfunc16.v
@@ -1,0 +1,39 @@
+// Check that break and continue are supported in constant functions in for
+// loops
+
+module test;
+
+  function automatic integer f1(integer x);
+    integer j = 0;
+    for (integer i = 0; i < 10; i++) begin
+      if (i >= x) begin
+        break;
+      end
+      j++;
+    end
+    return j;
+  endfunction
+
+  function automatic integer f2(integer x);
+    integer j = 0;
+    for (integer i = 0; i < x; i++) begin
+      if (i % 2 == 0) begin
+        continue;
+      end
+      j++;
+    end
+    return j;
+  endfunction
+
+  reg [f1(3):0] x;
+  reg [f2(6):0] y;
+
+  initial begin
+    if ($bits(x) === 4 && $bits(y) === 4) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/constfunc17.v
+++ b/ivtest/ivltests/constfunc17.v
@@ -1,0 +1,43 @@
+// Check that break and continue are supported in constant functions in while
+// loops
+
+module test;
+
+  function automatic integer f1(integer x);
+    integer j = 0;
+    integer i = 0;
+    while (i < 10) begin
+      if (i >= x) begin
+        break;
+      end
+      j++;
+      i++;
+    end
+    return j;
+  endfunction
+
+  function automatic integer f2(integer x);
+    integer j = 0;
+    integer i = 0;
+    while (i < x) begin
+      i++;
+      if (i % 2 == 0) begin
+        continue;
+      end
+      j++;
+    end
+    return j;
+  endfunction
+
+  reg [f1(3):0] x;
+  reg [f2(6):0] y;
+
+  initial begin
+    if ($bits(x) === 4 && $bits(y) === 4) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/constfunc18.v
+++ b/ivtest/ivltests/constfunc18.v
@@ -1,0 +1,41 @@
+// Check that break and continue are supported in constant functions in repeat
+// loops
+
+module test;
+
+  function automatic integer f1(integer x);
+    integer j = 0;
+    repeat(10) begin
+      if (j >= x) begin
+        break;
+      end
+      j++;
+    end
+    return j;
+  endfunction
+
+  function automatic integer f2(integer x);
+    integer j = 0;
+    integer i = 0;
+    repeat(x) begin
+      i++;
+      if (i % 2 == 0) begin
+        continue;
+      end
+      j++;
+    end
+    return j;
+  endfunction
+
+  reg [f1(3):0] x;
+  reg [f2(6):0] y;
+
+  initial begin
+    if ($bits(x) === 4 && $bits(y) === 4) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/constfunc19.v
+++ b/ivtest/ivltests/constfunc19.v
@@ -1,0 +1,43 @@
+// Check that break and continue are supported in constant functions in do-while
+// loops
+
+module test;
+
+  function automatic integer f1(integer x);
+    integer j = 0;
+    integer i = 0;
+    do begin
+      if (i >= x) begin
+        break;
+      end
+      j++;
+      i++;
+    end while (i < 10);
+    return j;
+  endfunction
+
+  function automatic integer f2(integer x);
+    integer j = 0;
+    integer i = 0;
+    do begin
+      i++;
+      if (i % 2 == 0) begin
+        continue;
+      end
+      j++;
+    end while (i < x);
+    return j;
+  endfunction
+
+  reg [f1(3):0] x;
+  reg [f2(6):0] y;
+
+  initial begin
+    if ($bits(x) === 4 && $bits(y) === 4) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/constfunc20.v
+++ b/ivtest/ivltests/constfunc20.v
@@ -1,0 +1,32 @@
+// Check that break and continue are supported in constant functions in forever
+// loops
+
+module test;
+
+  function automatic integer f(integer x);
+    integer j = 0;
+    integer i = 0;
+    forever begin
+      i++;
+      if (i == x) begin
+        break;
+      end
+      if (i % 2 == 0) begin
+        continue;
+      end
+      j++;
+    end
+    return j;
+  endfunction
+
+  reg [f(10):0] x;
+
+  initial begin
+    if ($bits(x) === 6) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -10,6 +10,11 @@ case2				vvp_tests/case2.json
 case2-S				vvp_tests/case2-S.json
 case3				vvp_tests/case3.json
 casex_synth			vvp_tests/casex_synth.json
+constfunc16			vvp_tests/constfunc16.json
+constfunc17			vvp_tests/constfunc17.json
+constfunc18			vvp_tests/constfunc18.json
+constfunc19			vvp_tests/constfunc19.json
+constfunc20			vvp_tests/constfunc20.json
 dffsynth			vvp_tests/dffsynth.json
 dffsynth-S			vvp_tests/dffsynth-S.json
 dffsynth2			vvp_tests/dffsynth2.json

--- a/ivtest/vvp_tests/constfunc16.json
+++ b/ivtest/vvp_tests/constfunc16.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "constfunc16.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/constfunc17.json
+++ b/ivtest/vvp_tests/constfunc17.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "constfunc17.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/constfunc18.json
+++ b/ivtest/vvp_tests/constfunc18.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "constfunc18.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/constfunc19.json
+++ b/ivtest/vvp_tests/constfunc19.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "constfunc19.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/constfunc20.json
+++ b/ivtest/vvp_tests/constfunc20.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "constfunc20.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/netlist.h
+++ b/netlist.h
@@ -3068,6 +3068,8 @@ class NetBreak : public NetProc {
     public:
       virtual void dump(std::ostream&, unsigned ind) const;
       virtual bool emit_proc(struct target_t*) const;
+      bool evaluate_function(const LineInfo &loc,
+			     std::map<perm_string,LocalVar> &ctx) const final;
 };
 
 /*
@@ -3222,6 +3224,8 @@ class NetContinue : public NetProc {
     public:
       virtual void dump(std::ostream&, unsigned ind) const;
       virtual bool emit_proc(struct target_t*) const;
+      bool evaluate_function(const LineInfo &loc,
+			     std::map<perm_string,LocalVar> &ctx) const final;
 };
 
 /*


### PR DESCRIPTION
Add support for `continue` and `break` in constant functions. This is done
in a similar way to how `disable` is implemented for constant functions.

Two new global flags are introduced `loop_break` and `loop_continue` that
get set when evaluating the corresponding statement. If either of these
flags are set all other statements are ignored until the end of a loop is
reached. At the end of the loop both `loop_break` and `loop_continue` get
cleared. If `loop_break` was set before clearing it the loop is exited.