### PR TITLE
Handle implicit task/function imports in the unit scope 

### DIFF
--- a/ivtest/ivltests/sv_wildcard_import8.v
+++ b/ivtest/ivltests/sv_wildcard_import8.v
@@ -1,0 +1,28 @@
+// Check that implicit imports of functions and tasks works if the wildcard
+// import statement is in the unit scope.
+
+package P;
+
+  function integer f(integer x);
+    return x * 2;
+  endfunction
+
+  task t(bit failed);
+    if (failed) begin
+      $display("FAILED");
+    end else begin
+      $display("PASSED");
+    end
+  endtask
+
+endpackage
+
+import P::*;
+
+module test;
+
+  initial begin
+    t(f(10) !== 20);
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -41,6 +41,7 @@ sv_array_cassign6		vvp_tests/sv_array_cassign6.json
 sv_array_cassign7		vvp_tests/sv_array_cassign7.json
 sv_foreach9			vvp_tests/sv_foreach9.json
 sv_foreach10			vvp_tests/sv_foreach10.json
+sv_wildcard_import8		vvp_tests/sv_wildcard_import8.json
 sdf_header			vvp_tests/sdf_header.json
 task_return1			vvp_tests/task_return1.json
 task_return2			vvp_tests/task_return2.json

--- a/ivtest/vvp_tests/sv_wildcard_import8.json
+++ b/ivtest/vvp_tests/sv_wildcard_import8.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_wildcard_import8.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/main.cc
+++ b/main.cc
@@ -1126,6 +1126,8 @@ int main(int argc, char*argv[])
 	    rc += pform_parse(source_files[idx]);
       }
 
+      pform_finish();
+
       if (pf_path) {
 	    ofstream out (pf_path);
 	    out << "PFORM DUMP NATURES:" << endl;

--- a/parse_api.h
+++ b/parse_api.h
@@ -58,6 +58,8 @@ extern void pform_dump(std::ostream&out, const PTaskFunc*tf);
  */
 extern int pform_parse(const char*path);
 
+extern void pform_finish();
+
 extern std::string vl_file;
 
 extern void pform_set_timescale(int units, int prec, const char*file,


### PR DESCRIPTION
SystemVerilog requires that functions and tasks are not implicitly imported
if a symbol with the same name appears in the scope, even if it the symbol
is declared after its usage.

To support this a list of potential imports is collected while parsing a
scope and only when the end of the scope is reached it is evaluated whether
the symbol should be imported or not based on whether it already exists in
the scope.

This currently works fine for all scopes except for the unit scope. Since
the unit scope might span multiple files it is never explicitly closed and
the potential imports are never checked.

Make sure that after parsing all files is done the potential imports for
the unit scope are checked.

Resolves #928