### PR TITLE
Fix line location and require SystemVerilog mode for implicit named port connections

### DIFF
--- a/ivtest/gold/br_gh939-iverilog-stderr.gold
+++ b/ivtest/gold/br_gh939-iverilog-stderr.gold
@@ -1,0 +1,4 @@
+ivltests/br_gh939.v:10: error: Net o is not defined in this context.
+ivltests/br_gh939.v:10: error: Output port expression must support continuous assignment.
+ivltests/br_gh939.v:10:      : Port 1 (o) of M is connected to o
+2 error(s) during elaboration.

--- a/ivtest/ivltests/br_gh939.v
+++ b/ivtest/ivltests/br_gh939.v
@@ -1,0 +1,11 @@
+// Check the line and file information for errors related to implicit named port
+// connections are correct.
+
+module M(
+  output o
+);
+endmodule
+
+module test;
+  M i_m(.o); // Error, no net named o
+endmodule

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -325,7 +325,7 @@ br_gh283a		normal			ivltests
 br_gh283b		normal			ivltests
 br_gh283c		normal			ivltests
 br_gh309		normal			ivltests
-br_gh315		normal,-gspecify	ivltests
+br_gh315		normal,-g2005-sv,-gspecify	ivltests
 br_gh316a		normal,-gspecify	ivltests
 br_gh316b		normal,-gspecify	ivltests
 br_gh316c		normal,-gspecify	ivltests

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -5,6 +5,7 @@
 array_packed_write_read		vvp_tests/array_packed_write_read.json
 br_gh13a			vvp_tests/br_gh13a.json
 br_gh13a-vlog95			vvp_tests/br_gh13a-vlog95.json
+br_gh939			vvp_tests/br_gh939.json
 case1				vvp_tests/case1.json
 case2				vvp_tests/case2.json
 case2-S				vvp_tests/case2-S.json

--- a/ivtest/vvp_tests/br_gh939.json
+++ b/ivtest/vvp_tests/br_gh939.json
@@ -1,0 +1,6 @@
+{
+    "type"   : "CE",
+    "source" : "br_gh939.v",
+    "gold"   : "br_gh939",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/parse.y
+++ b/parse.y
@@ -5728,7 +5728,8 @@ port_name
 	$$ = tmp;
       }
   | attribute_list_opt '.' IDENTIFIER
-      { named_pexpr_t*tmp = new named_pexpr_t;
+      { pform_requires_sv(@3, "Implicit named port connections");
+	named_pexpr_t*tmp = new named_pexpr_t;
 	tmp->name = lex_strings.make($3);
 	tmp->parm = new PEIdent(lex_strings.make($3), true);
 	FILE_NAME(tmp->parm, @3);

--- a/parse.y
+++ b/parse.y
@@ -5731,7 +5731,7 @@ port_name
       { named_pexpr_t*tmp = new named_pexpr_t;
 	tmp->name = lex_strings.make($3);
 	tmp->parm = new PEIdent(lex_strings.make($3), true);
-	FILE_NAME(tmp->parm, @1);
+	FILE_NAME(tmp->parm, @3);
 	delete[]$3;
 	delete $1;
 	$$ = tmp;


### PR DESCRIPTION
Two small fixes/changes for implicit named port connections.

- Use the correct line location
- Require SystemVerilog mode
  -  Regression test `br_gh315` is modified to run in SystemVerilog mode since it
makes use of implicit named port connections.


In order to regression test for the line information also add support for gold files for CE type tests  to vvp_reg.py.

Resolves #939