### PR TITLE
Replace assert() with ivl_assert() where line information is available

### DIFF
--- a/Module.cc
+++ b/Module.cc
@@ -22,7 +22,7 @@
 # include  "Module.h"
 # include  "PGate.h"
 # include  "PWire.h"
-# include  <cassert>
+# include  "ivl_assert.h"
 
 using namespace std;
 
@@ -60,7 +60,7 @@ unsigned Module::port_count() const
  */
 const vector<PEIdent*>& Module::get_port(unsigned idx) const
 {
-      assert(idx < ports.size());
+      ivl_assert(*this, idx < ports.size());
       static const vector<PEIdent*> zero;
 
       if (ports[idx])
@@ -71,7 +71,7 @@ const vector<PEIdent*>& Module::get_port(unsigned idx) const
 
 unsigned Module::find_port(const char*name) const
 {
-      assert(name != 0);
+      ivl_assert(*this, name != 0);
       for (unsigned idx = 0 ;  idx < ports.size() ;  idx += 1) {
 	    if (ports[idx] == 0) {
 		    /* It is possible to have undeclared ports. These
@@ -81,7 +81,7 @@ unsigned Module::find_port(const char*name) const
 		       inaccessible to binding by name. */
 		  continue;
 	    }
-	    assert(ports[idx]);
+	    ivl_assert(*this, ports[idx]);
 	    if (ports[idx]->name == name)
 		  return idx;
       }
@@ -92,7 +92,7 @@ unsigned Module::find_port(const char*name) const
 perm_string Module::get_port_name(unsigned idx) const
 {
 
-      assert(idx < ports.size());
+      ivl_assert(*this, idx < ports.size());
       if (ports[idx] == 0 || ports[idx]->name.str() == 0) {
               /* It is possible to have undeclared ports. These
                  are ports that are skipped in the declaration,
@@ -108,7 +108,7 @@ perm_string Module::get_port_name(unsigned idx) const
 
 PExpr* Module::get_port_default_value(unsigned idx) const
 {
-      assert(idx < ports.size());
+      ivl_assert(*this, idx < ports.size());
       return ports[idx] ? ports[idx]->default_value : 0;
 }
 

--- a/PExpr.cc
+++ b/PExpr.cc
@@ -26,6 +26,7 @@
 # include  "PExpr.h"
 # include  "PWire.h"
 # include  "Module.h"
+# include  "ivl_assert.h"
 # include  "netmisc.h"
 # include  "util.h"
 # include  <typeinfo>
@@ -129,7 +130,7 @@ void PEBinary::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 
 bool PEBinary::has_aa_term(Design*des, NetScope*scope) const
 {
-      assert(left_ && right_);
+      ivl_assert(*this, left_ && right_);
       return left_->has_aa_term(des, scope) || right_->has_aa_term(des, scope);
 }
 
@@ -186,7 +187,7 @@ PEBComp::~PEBComp()
 PEBLogic::PEBLogic(char op, PExpr*l, PExpr*r)
 : PEBinary(op, l, r)
 {
-      assert(op == 'a' || op == 'o' || op == 'q' || op == 'Q');
+      ivl_assert(*this, op == 'a' || op == 'o' || op == 'q' || op == 'Q');
 }
 
 PEBLogic::~PEBLogic()
@@ -242,7 +243,7 @@ PECallFunction::PECallFunction(PPackage*pkg, const pform_name_t &n, const list<P
 : path_(pkg, n), parms_(parms.size()), is_overridden_(false)
 {
       int tmp_idx = 0;
-      assert(parms_.size() == parms.size());
+      ivl_assert(*this, parms_.size() == parms.size());
       for (list<PExpr*>::const_iterator idx = parms.begin()
 		 ; idx != parms.end() ; ++idx)
 	    parms_[tmp_idx++] = *idx;
@@ -263,7 +264,7 @@ PECallFunction::PECallFunction(const pform_name_t&n, const list<PExpr *> &parms)
 : path_(n), parms_(parms.size()), is_overridden_(false)
 {
       int tmp_idx = 0;
-      assert(parms_.size() == parms.size());
+      ivl_assert(*this, parms_.size() == parms.size());
       for (list<PExpr*>::const_iterator idx = parms.begin()
 		 ; idx != parms.end() ; ++idx)
 	    parms_[tmp_idx++] = *idx;
@@ -273,7 +274,7 @@ PECallFunction::PECallFunction(perm_string n, const list<PExpr*>&parms)
 : path_(pn_from_ps(n)), parms_(parms.size()), is_overridden_(false)
 {
       int tmp_idx = 0;
-      assert(parms_.size() == parms.size());
+      ivl_assert(*this, parms_.size() == parms.size());
       for (list<PExpr*>::const_iterator idx = parms.begin()
 		 ; idx != parms.end() ; ++idx)
 	    parms_[tmp_idx++] = *idx;
@@ -305,7 +306,7 @@ PEConcat::PEConcat(const list<PExpr*>&p, PExpr*r)
 : parms_(p.size()), width_modes_(SIZED, p.size()), repeat_(r)
 {
       int tmp_idx = 0;
-      assert(parms_.size() == p.size());
+      ivl_assert(*this, parms_.size() == p.size());
       for (list<PExpr*>::const_iterator idx = p.begin()
 		 ; idx != p.end() ; ++idx)
 	    parms_[tmp_idx++] = *idx;
@@ -354,7 +355,7 @@ PEEvent::edge_t PEEvent::type() const
 
 bool PEEvent::has_aa_term(Design*des, NetScope*scope) const
 {
-      assert(expr_);
+      ivl_assert(*this, expr_);
       return expr_->has_aa_term(des, scope);
 }
 
@@ -518,7 +519,7 @@ PENewCopy::~PENewCopy()
 PENumber::PENumber(verinum*vp)
 : value_(vp)
 {
-      assert(vp);
+      ivl_assert(*this, vp);
 }
 
 PENumber::~PENumber()
@@ -557,7 +558,7 @@ PETernary::~PETernary()
 
 void PETernary::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 {
-      assert(expr_ && tru_ && fal_);
+      ivl_assert(*this, expr_ && tru_ && fal_);
       expr_->declare_implicit_nets(scope, type);
       tru_->declare_implicit_nets(scope, type);
       fal_->declare_implicit_nets(scope, type);
@@ -565,7 +566,7 @@ void PETernary::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 
 bool PETernary::has_aa_term(Design*des, NetScope*scope) const
 {
-      assert(expr_ && tru_ && fal_);
+      ivl_assert(*this, expr_ && tru_ && fal_);
       return expr_->has_aa_term(des, scope)
            || tru_->has_aa_term(des, scope)
            || fal_->has_aa_term(des, scope);
@@ -591,13 +592,13 @@ PEUnary::~PEUnary()
 
 void PEUnary::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 {
-      assert(expr_);
+      ivl_assert(*this, expr_);
       expr_->declare_implicit_nets(scope, type);
 }
 
 bool PEUnary::has_aa_term(Design*des, NetScope*scope) const
 {
-      assert(expr_);
+      ivl_assert(*this, expr_);
       return expr_->has_aa_term(des, scope);
 }
 

--- a/PFunction.cc
+++ b/PFunction.cc
@@ -20,7 +20,6 @@
 # include "config.h"
 # include "PTask.h"
 # include "Statement.h"
-# include <cassert>
 # include "ivl_assert.h"
 
 using namespace std;
@@ -38,8 +37,8 @@ PFunction::~PFunction()
 
 void PFunction::set_statement(Statement*s)
 {
-      assert(s != 0);
-      assert(statement_ == 0);
+      ivl_assert(*this, s != 0);
+      ivl_assert(*this, statement_ == 0);
       statement_ = s;
 }
 

--- a/PGate.cc
+++ b/PGate.cc
@@ -22,21 +22,21 @@
 # include  "PGate.h"
 # include  "PExpr.h"
 # include  "verinum.h"
-# include  <cassert>
+# include  "ivl_assert.h"
 
 using namespace std;
 
 void PGate::set_pins_(list<PExpr*>*pins)
 {
-      assert(pins);
-      assert(pins->size() == pins_.size());
+      ivl_assert(*this, pins);
+      ivl_assert(*this, pins->size() == pins_.size());
 
       for (size_t idx = 0 ; idx < pins_.size() ; idx += 1) {
 	    pins_[idx] = pins->front();
 	    pins->pop_front();
       }
 
-      assert(pins->empty());
+      ivl_assert(*this, pins->empty());
       delete pins;
 }
 
@@ -72,7 +72,7 @@ PGate::~PGate()
 
 void PGate::set_ranges(list<pform_range_t>*ranges)
 {
-      assert(ranges_ == 0);
+      ivl_assert(*this, ranges_ == 0);
       ranges_ = ranges;
 }
 
@@ -133,13 +133,13 @@ PNamedItem::SymbolType PGate::symbol_type() const
 PGAssign::PGAssign(list<PExpr*>*pins)
 : PGate(perm_string(), pins)
 {
-      assert(pin_count() == 2);
+      ivl_assert(*this, pin_count() == 2);
 }
 
 PGAssign::PGAssign(list<PExpr*>*pins, list<PExpr*>*dels)
 : PGate(perm_string(), pins, dels)
 {
-      assert(pin_count() == 2);
+      ivl_assert(*this, pin_count() == 2);
 }
 
 PGAssign::~PGAssign()
@@ -288,14 +288,14 @@ PGModule::~PGModule()
 
 void PGModule::set_parameters(list<PExpr*>*o)
 {
-      assert(overrides_ == 0);
+      ivl_assert(*this, overrides_ == 0);
       overrides_ = o;
 }
 
 void PGModule::set_parameters(named<PExpr*>*pa, unsigned npa)
 {
-      assert(parms_ == 0);
-      assert(overrides_ == 0);
+      ivl_assert(*this, parms_ == 0);
+      ivl_assert(*this, overrides_ == 0);
       parms_ = pa;
       nparms_ = npa;
 }

--- a/PTask.cc
+++ b/PTask.cc
@@ -18,8 +18,8 @@
  */
 
 # include "config.h"
-# include  "PTask.h"
-# include  <cassert>
+# include "PTask.h"
+# include "ivl_assert.h"
 
 using namespace std;
 
@@ -39,13 +39,13 @@ bool PTaskFunc::var_init_needs_explicit_lifetime() const
 
 void PTaskFunc::set_ports(vector<pform_tf_port_t>*p)
 {
-      assert(ports_ == 0);
+      ivl_assert(*this, ports_ == 0);
       ports_ = p;
 }
 
 void PTaskFunc::set_this(class_type_t*type, PWire*this_wire)
 {
-      assert(this_type_ == 0);
+      ivl_assert(*this, this_type_ == 0);
       this_type_ = type;
 
 	// Push a synthesis argument that is the "this" value.
@@ -72,7 +72,7 @@ PTask::~PTask()
 
 void PTask::set_statement(Statement*s)
 {
-      assert(statement_ == 0);
+      ivl_assert(*this, statement_ == 0);
       statement_ = s;
 }
 

--- a/PWire.cc
+++ b/PWire.cc
@@ -21,7 +21,6 @@
 # include "ivl_assert.h"
 # include  "PWire.h"
 # include  "PExpr.h"
-# include  <cassert>
 
 using namespace std;
 
@@ -59,7 +58,7 @@ perm_string PWire::basename() const
 
 bool PWire::set_wire_type(NetNet::Type t)
 {
-      assert(t != NetNet::IMPLICIT);
+      ivl_assert(*this, t != NetNet::IMPLICIT);
 
       switch (type_) {
 	  case NetNet::IMPLICIT:
@@ -90,8 +89,8 @@ NetNet::PortType PWire::get_port_type() const
 
 bool PWire::set_port_type(NetNet::PortType pt)
 {
-      assert(pt != NetNet::NOT_A_PORT);
-      assert(pt != NetNet::PIMPLICIT);
+      ivl_assert(*this, pt != NetNet::NOT_A_PORT);
+      ivl_assert(*this, pt != NetNet::PIMPLICIT);
 
       switch (port_type_) {
 	  case NetNet::PIMPLICIT:
@@ -181,13 +180,13 @@ void PWire::set_data_type(data_type_t*type)
       if (set_data_type_.get() == type)
 	    return;
 
-      assert(!set_data_type_.get());
+      ivl_assert(*this, !set_data_type_.get());
       set_data_type_.reset(type);
 }
 
 void PWire::set_discipline(ivl_discipline_t d)
 {
-      assert(discipline_ == 0);
+      ivl_assert(*this, discipline_ == 0);
       discipline_ = d;
 }
 

--- a/Statement.cc
+++ b/Statement.cc
@@ -139,8 +139,8 @@ PChainConstructor* PBlock::extract_chain_constructor()
 
 void PBlock::set_join_type(PBlock::BL_TYPE type)
 {
-      assert(bl_type_ == BL_PAR);
-      assert(type==BL_PAR || type==BL_JOIN_NONE || type==BL_JOIN_ANY);
+      ivl_assert(*this, bl_type_ == BL_PAR);
+      ivl_assert(*this, type==BL_PAR || type==BL_JOIN_NONE || type==BL_JOIN_ANY);
       bl_type_ = type;
 }
 
@@ -173,7 +173,7 @@ PCallTask::PCallTask(const pform_name_t&n, const list<PExpr*>&p)
 	    parms_[idx] = *cur;
 	    ++cur;
       }
-      assert(cur == p.end());
+      ivl_assert(*this, cur == p.end());
 }
 
 PCallTask::PCallTask(PPackage*pkg, const pform_name_t&n, const list<PExpr*>&p)
@@ -184,7 +184,7 @@ PCallTask::PCallTask(PPackage*pkg, const pform_name_t&n, const list<PExpr*>&p)
 	    parms_[idx] = *cur;
 	    ++cur;
       }
-      assert(cur == p.end());
+      ivl_assert(*this, cur == p.end());
 }
 
 PCallTask::PCallTask(perm_string n, const list<PExpr*>&p)
@@ -195,7 +195,7 @@ PCallTask::PCallTask(perm_string n, const list<PExpr*>&p)
 	    parms_[idx] = *cur;
 	    ++cur;
       }
-      assert(cur == p.end());
+      ivl_assert(*this, cur == p.end());
       path_.push_back(name_component_t(n));
 }
 
@@ -241,7 +241,7 @@ PChainConstructor::PChainConstructor(const list<PExpr*>&parms)
 	    parms_[idx] = *cur;
 	    ++cur;
       }
-      assert(cur == parms.end());
+      ivl_assert(*this, cur == parms.end());
 }
 
 PChainConstructor::~PChainConstructor()
@@ -303,7 +303,7 @@ PDoWhile::~PDoWhile()
 PEventStatement::PEventStatement(const std::vector<PEEvent*>&ee)
 : expr_(ee), statement_(0), always_sens_(false)
 {
-      assert(expr_.size() > 0);
+      ivl_assert(*this, expr_.size() > 0);
 }
 
 

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -1426,7 +1426,7 @@ static NetFuncDef* find_function_definition(Design*des, NetScope*,
 	    if (func->elab_stage() < 2) {
 		  func->need_const_func(true);
 		  const PFunction*pfunc = func->func_pform();
-		  assert(pfunc);
+		  ivl_assert(*func, pfunc);
 		  pfunc->elaborate_sig(des, func);
 	    }
 	    return func->func_def();
@@ -1759,7 +1759,7 @@ unsigned PECallFunction::test_width(Design*des, NetScope*scope,
 	    return 0;
 
       NetScope*dscope = def->scope();
-      assert(dscope);
+      ivl_assert(*this, dscope);
 
       if (NetNet*res = dscope->find_signal(dscope->basename())) {
 	    expr_type_   = res->data_type();
@@ -3554,8 +3554,8 @@ NetExpr* PECastType::elaborate_expr(Design*des, NetScope*scope,
         unsigned use_wid = base_->test_width(des, scope, mode);
         NetExpr*base = base_->elaborate_expr(des, scope, use_wid, NO_FLAGS);
 
-        assert(vector->packed_width() > 0);
-        assert(base->expr_width() > 0);
+        ivl_assert(*this, vector->packed_width() > 0);
+        ivl_assert(*this, base->expr_width() > 0);
 
         // Find rounded up length that can fit the whole casted array of vectors
         int len = base->expr_width() + vector->packed_width() - 1;
@@ -3816,7 +3816,7 @@ NetExpr* PEConcat::elaborate_expr(Design*des, NetScope*scope,
 		  continue;
 	    }
 
-	    assert(parms_[idx]);
+	    ivl_assert(*this, parms_[idx]);
             unsigned wid = parms_[idx]->expr_width();
 	    NetExpr*ex = parms_[idx]->elaborate_expr(des, scope, wid, flags);
 	    if (ex == 0) continue;
@@ -5539,7 +5539,7 @@ NetExpr* PEIdent::elaborate_expr_param_(Design*des,
 	    }
 	      /* The numeric parameter value needs to have the file and line
 	       * information for the actual parameter not the expression. */
-	    assert(tmp);
+	    ivl_assert(*this, tmp);
 	    tmp->set_line(found_in->get_parameter_line_info(name));
       }
 
@@ -6406,7 +6406,7 @@ NetExpr* PEIdent::elaborate_expr_net(Design*des, NetScope*scope,
 	// It's not anything else, so this must be a simple identifier
 	// expression with no part or bit select. Return the signal
 	// itself as the expression.
-      assert(use_sel == index_component_t::SEL_NONE);
+      ivl_assert(*this, use_sel == index_component_t::SEL_NONE);
 
       return node;
 }
@@ -6763,7 +6763,7 @@ NetExpr* PENumber::elaborate_expr(Design*, NetScope*, ivl_type_t ntype, unsigned
 NetEConst* PENumber::elaborate_expr(Design*, NetScope*,
 				    unsigned expr_wid, unsigned) const
 {
-      assert(value_);
+      ivl_assert(*this, value_);
       verinum val = *value_;
       if (val.has_len())
             val.has_sign(signed_flag_);

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -807,7 +807,7 @@ bool PEIdent::elaborate_lval_net_idx_(Design*des,
       ivl_assert(*this, index_tail.lsb != 0);
 
       NetNet*reg = lv->sig();
-      assert(reg);
+      ivl_assert(*this, reg);
 
       unsigned long wid;
       calculate_up_do_width_(des, scope, wid);

--- a/elab_net.cc
+++ b/elab_net.cc
@@ -45,7 +45,7 @@ using namespace std;
 NetNet* PEConcat::elaborate_lnet_common_(Design*des, NetScope*scope,
 					 bool bidirectional_flag) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       std::vector<NetNet*> nets(parms_.size());
       unsigned width = 0;
@@ -152,10 +152,10 @@ NetNet* PEConcat::elaborate_lnet_common_(Design*des, NetScope*scope,
 		  connect(ps->pin(1), osig->pin(0));
 		  connect(ps->pin(0), nets[idx]->pin(0));
 
-		  assert(wid <= width);
+		  ivl_assert(*this, wid <= width);
 		  width -= wid;
 	    }
-	    assert(width == 0);
+	    ivl_assert(*this, width == 0);
       }
 
       return osig;
@@ -174,7 +174,7 @@ NetNet* PEConcat::elaborate_bi_net(Design*des, NetScope*scope) const
 bool PEConcat::is_collapsible_net(Design*des, NetScope*scope,
                                   NetNet::PortType port_type) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
         // Repeat concatenations are not currently supported.
       if (repeat_)
@@ -509,7 +509,7 @@ bool PEIdent::eval_part_select_(Design*des, NetScope*scope, NetNet*sig,
 NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
 					bool bidirectional_flag) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetNet*       sig = 0;
       const NetExpr*par = 0;
@@ -1138,7 +1138,7 @@ NetNet*PEIdent::elaborate_unpacked_net(Design*des, NetScope*scope) const
 bool PEIdent::is_collapsible_net(Design*des, NetScope*scope,
                                  NetNet::PortType port_type) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetNet*       sig = 0;
       const NetExpr*par = 0;
@@ -1152,7 +1152,7 @@ bool PEIdent::is_collapsible_net(Design*des, NetScope*scope,
       if (sig == 0)
             return false;
 
-      assert(sig);
+      ivl_assert(*this, sig);
 
 	/* If this is SystemVerilog and the variable is not yet
 	   assigned by anything, then convert it to an unresolved

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -54,7 +54,6 @@
 # include  "parse_api.h"
 # include  "util.h"
 # include  <typeinfo>
-# include  <cassert>
 # include  "ivl_assert.h"
 
 using namespace std;
@@ -176,7 +175,7 @@ static void elaborate_scope_enumeration(Design*des, NetScope*scope,
       size_t name_idx = 0;
 	// Find the enumeration width.
       long raw_width = use_enum->packed_width();
-      assert(raw_width > 0);
+      ivl_assert(*use_enum, raw_width > 0);
       unsigned enum_width = (unsigned)raw_width;
       bool is_signed = use_enum->get_signed();
 	// Define the default start value and the increment value to be the
@@ -599,7 +598,7 @@ static void replace_scope_parameters(Design *des, NetScope*scope, const LineInfo
 		       << "Missing expression in parameter replacement for "
 		       << (*cur).first << endl;;
 	    }
-	    assert(val);
+	    ivl_assert(loc, val);
 	    if (debug_scopes) {
 		  cerr << loc.get_fileline() << ": debug: "
 		       << "Replace " << (*cur).first
@@ -773,7 +772,7 @@ bool Module::elaborate_scope(Design*des, NetScope*scope,
 
       elaborate_scope_enumerations(des, scope, enum_sets);
 
-      assert(classes.size() == classes_lexical.size());
+      ivl_assert(*this, classes.size() == classes_lexical.size());
       elaborate_scope_classes(des, scope, classes_lexical);
 
 	// Run through the defparams for this module and save the result
@@ -1030,7 +1029,7 @@ bool PGenerate::generate_scope_loop_(Design*des, NetScope*container)
 	    delete test_ex;
 	    test_ex = elab_and_eval(des, container, loop_test, -1, true);
 	    test = dynamic_cast<NetEConst*>(test_ex);
-	    assert(test);
+	    ivl_assert(*this, test);
       }
 
 	// Clear the genvar_tmp field in the scope to reflect that the
@@ -1112,7 +1111,7 @@ bool PGenerate::generate_scope_case_(Design*des, NetScope*container)
       generator_it_t cur = generate_schemes.begin();
       while (cur != generate_schemes.end()) {
 	    PGenerate*item = *cur;
-	    assert( item->scheme_type == PGenerate::GS_CASE_ITEM );
+	    ivl_assert(*item, item->scheme_type == PGenerate::GS_CASE_ITEM);
 
 	      // Detect that the item is a default.
 	    if (item->item_test.size() == 0) {
@@ -1334,7 +1333,7 @@ void PGModule::elaborate_scope_mod_(Design*des, Module*mod, NetScope*sc) const
       }
 
 	// Missing module instance names have already been rejected.
-      assert(get_name() != "");
+      ivl_assert(*this, get_name() != "");
 
 	// check for recursive instantiation by scanning the current
 	// scope and its parents. Look for a module instantiation of
@@ -1478,7 +1477,7 @@ void PGModule::elaborate_scope_mod_instances_(Design*des, Module*mod, NetScope*s
 	      // is parameter 0, the second parameter 1, and so on.
 
 	    if (overrides_) {
-		  assert(parms_ == 0);
+		  ivl_assert(*this, parms_ == 0);
 		  list<perm_string>::const_iterator cur
 			= mod->param_names.begin();
 		  list<PExpr*>::const_iterator jdx = overrides_->begin();
@@ -1514,7 +1513,7 @@ void PGModule::elaborate_scope_mod_instances_(Design*des, Module*mod, NetScope*s
 	      // Named parameter overrides carry a name with each override
 	      // so the mapping into the replace list is much easier.
 	    if (parms_) {
-		  assert(overrides_ == 0);
+		  ivl_assert(*this, overrides_ == 0);
 		  for (unsigned jdx = 0 ;  jdx < nparms_ ;  jdx += 1) {
 		          // No expression means that the parameter is not
 		          // replaced.
@@ -1586,7 +1585,7 @@ void PFunction::elaborate_scope(Design*des, NetScope*scope) const
 
 void PTask::elaborate_scope(Design*des, NetScope*scope) const
 {
-      assert(scope->type() == NetScope::TASK);
+      ivl_assert(*this, scope->type() == NetScope::TASK);
 
       scope->add_typedefs(&typedefs);
 
@@ -1658,9 +1657,9 @@ void PBlock::elaborate_scope(Design*des, NetScope*scope) const
  */
 void PCase::elaborate_scope(Design*des, NetScope*scope) const
 {
-      assert(items_);
+      ivl_assert(*this, items_);
       for (unsigned idx = 0 ;  idx < (*items_).size() ;  idx += 1) {
-	    assert( (*items_)[idx] );
+	    ivl_assert(*this, (*items_)[idx]);
 
 	    if (Statement*sp = (*items_)[idx]->stat)
 		  sp -> elaborate_scope(des, scope);

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -70,7 +70,7 @@ static bool get_const_argument(NetExpr*exp, verinum&res)
 	  }
 
 	  default:
-	    assert(0);;
+	    ivl_assert(*exp, 0);;
       }
 
       return true;
@@ -233,7 +233,7 @@ static void elaborate_sig_tasks(Design*des, NetScope*scope,
       for (mtask_it_t cur = tasks.begin()
 		 ; cur != tasks.end() ; ++ cur ) {
 	    NetScope*tscope = scope->child( hname_t((*cur).first) );
-	    assert(tscope);
+	    ivl_assert(*(*cur).second, tscope);
 	    (*cur).second->elaborate_sig(des, tscope);
       }
 }
@@ -460,7 +460,7 @@ bool PGModule::elaborate_sig_mod_(Design*des, NetScope*scope,
 	      // I know a priori that the elaborate_scope created the scope
 	      // already, so just look it up as a child of the current scope.
 	    NetScope*my_scope = instance[idx];
-	    assert(my_scope);
+	    ivl_assert(*this, my_scope);
 
 	    if (my_scope->parent() != scope) {
 		  cerr << get_fileline() << ": internal error: "
@@ -469,7 +469,7 @@ bool PGModule::elaborate_sig_mod_(Design*des, NetScope*scope,
 		       << " instead of " << scope_path(scope)
 		       << endl;
 	    }
-	    assert(my_scope->parent() == scope);
+	    ivl_assert(*this, my_scope->parent() == scope);
 
 	    if (! rmod->elaborate_sig(des, my_scope))
 		  flag = false;
@@ -627,7 +627,7 @@ void PFunction::elaborate_sig(Design*des, NetScope*scope) const
       scope->set_elab_stage(2);
 
       perm_string fname = scope->basename();
-      assert(scope->type() == NetScope::FUNC);
+      ivl_assert(*this, scope->type() == NetScope::FUNC);
 
       elaborate_sig_wires_(des, scope);
 
@@ -716,7 +716,7 @@ void PFunction::elaborate_sig(Design*des, NetScope*scope) const
  */
 void PTask::elaborate_sig(Design*des, NetScope*scope) const
 {
-      assert(scope->type() == NetScope::TASK);
+      ivl_assert(*this, scope->type() == NetScope::TASK);
 
       elaborate_sig_wires_(des, scope);
 
@@ -1055,7 +1055,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 		  }
 		  dimensions_ok &= evaluate_ranges(des, scope, this, plist, port_);
 	    }
-            assert(port_set_ || port_.empty());
+            ivl_assert(*this, port_set_ || port_.empty());
 
 	    /* If they exist get the net/etc. definition MSB and LSB */
 	    if (net_set_ && !net_.empty() && dimensions_ok) {
@@ -1066,7 +1066,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 		  }
 		  dimensions_ok &= evaluate_ranges(des, scope, this, nlist, net_);
 	    }
-            assert(net_set_ || net_.empty());
+            ivl_assert(*this, net_set_ || net_.empty());
 
 	    if (debug_elaborate) {
 		  cerr << get_fileline() << ": PWire::elaborate_sig: "

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -109,7 +109,7 @@ unsigned PGate::calculate_array_size_(Design*des, NetScope*scope,
  */
 void PGAssign::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetExpr* rise_time, *fall_time, *decay_time;
       eval_delays(des, scope, rise_time, fall_time, decay_time, true);
@@ -117,8 +117,8 @@ void PGAssign::elaborate(Design*des, NetScope*scope) const
       ivl_drive_t drive0 = strength0();
       ivl_drive_t drive1 = strength1();
 
-      assert(pin(0));
-      assert(pin(1));
+      ivl_assert(*this, pin(0));
+      ivl_assert(*this, pin(1));
 
 	/* Elaborate the l-value. */
       NetNet*lval = pin(0)->elaborate_lnet(des, scope);
@@ -895,7 +895,7 @@ void PGBuiltin::elaborate(Design*des, NetScope*scope) const
 
 		  if (1 == sig->vector_width() && instance_width != 1) {
 
-			assert(sig->vector_width() == 1);
+			ivl_assert(*this, sig->vector_width() == 1);
 			NetReplicate*rep
 			      = new NetReplicate(scope,
 						 scope->local_symbol(),
@@ -1216,7 +1216,7 @@ void elaborate_unpacked_port(Design *des, NetScope *scope, NetNet *port_net,
 void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
 {
 
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": debug: Instantiate module "
@@ -1403,7 +1403,7 @@ void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
 		    // Handle the error case where there is no internal
 		    // signal connected to the port.
 		  if (!tmp) continue;
-		  assert(tmp);
+		  ivl_assert(*this, tmp);
 
 		  if (tmp->port_type() == NetNet::PINPUT) {
 			  // If we have an unconnected input convert it
@@ -1497,7 +1497,7 @@ void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
 	      // We know by design that each instance has the same
 	      // width port. Therefore, the prts_pin_count must be an
 	      // even multiple of the instance count.
-	    assert(prts_vector_width % instance.size() == 0);
+	    ivl_assert(*this, prts_vector_width % instance.size() == 0);
 
 	    if (!prts.empty() && (prts[0]->port_type() == NetNet::PINPUT)
 	        && prts[0]->pin(0).nexus()->drivers_present()
@@ -1799,12 +1799,12 @@ void PGModule::elaborate_mod_(Design*des, Module*rmod, NetScope*scope) const
 
 	    }
 
-	    assert(sig);
+	    ivl_assert(*this, sig);
 
 #ifndef NDEBUG
 	    if ((! prts.empty())
 		&& (ptype != NetNet::PINPUT)) {
-		  assert(sig->type() != NetNet::REG);
+		  ivl_assert(*this, sig->type() != NetNet::REG);
 	    }
 #endif
 
@@ -2072,7 +2072,7 @@ void PGModule::elaborate_udp_(Design*des, PUdp*udp, NetScope*scope) const
 	    return;
       }
 
-      assert(udp);
+      ivl_assert(*this, udp);
       NetUDP*net = new NetUDP(scope, my_name, udp->ports.size(), udp);
       net->set_line(*this);
       net->rise_time(rise_expr);
@@ -2156,7 +2156,7 @@ void PGModule::elaborate_udp_(Design*des, PUdp*udp, NetScope*scope) const
 
 	      // No named bindings, just use the positional list I
 	      // already have.
-	    assert(pin_count() == udp->ports.size());
+	    ivl_assert(*this, pin_count() == udp->ports.size());
 	    pins = get_pins();
       }
 
@@ -2264,7 +2264,7 @@ void PGModule::elaborate(Design*des, NetScope*scope) const
 	// Try a primitive type
       map<perm_string,PUdp*>::const_iterator udp = pform_primitives.find(type_);
       if (udp != pform_primitives.end()) {
-	    assert((*udp).second);
+	    ivl_assert(*this, (*udp).second);
 	    elaborate_udp_(des, (*udp).second, scope);
 	    return;
       }
@@ -2475,7 +2475,7 @@ static NetExpr*elaborate_delay_expr(PExpr*expr, Design*des, NetScope*scope)
       if (dex->expr_type() == IVL_VT_REAL) {
 	      // Scale the real value.
 	    int shift = scope->time_unit() - scope->time_precision();
-	    assert(shift >= 0);
+	    ivl_assert(*expr, shift >= 0);
 	    double round = 1;
 	    for (int lp = 0; lp < shift; lp += 1) round *= 10.0;
 
@@ -2490,7 +2490,7 @@ static NetExpr*elaborate_delay_expr(PExpr*expr, Design*des, NetScope*scope)
 
 	      // Now scale the integer value.
 	    shift = scope->time_precision() - des->get_precision();
-	    assert(shift >= 0);
+	    ivl_assert(*expr, shift >= 0);
 	    uint64_t scale = 1;
 	    for (int lp = 0; lp < shift; lp += 1) scale *= 10;
 
@@ -2500,7 +2500,7 @@ static NetExpr*elaborate_delay_expr(PExpr*expr, Design*des, NetScope*scope)
 	    dex->set_line(*expr);
       } else {
 	    int shift = scope->time_unit() - des->get_precision();
-	    assert(shift >= 0);
+	    ivl_assert(*expr, shift >= 0);
 	    uint64_t scale = 1;
 	    for (int lp = 0; lp < shift; lp += 1) scale *= 10;
 
@@ -2574,7 +2574,7 @@ static bool lval_not_program_variable(const NetAssign_*lv)
 
 NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
 	/* If this is a compressed assignment, then handle the
 	   elaboration in a specialized function. */
@@ -2657,9 +2657,9 @@ NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
 	    delete lv;
 	    return 0;
       }
-      assert(rv);
+      ivl_assert(*this, rv);
 
-      if (count_) assert(event_);
+      if (count_) ivl_assert(*this, event_);
 
 	/* Rewrite delayed assignments as assignments that are
 	   delayed. For example, a = #<d> b; becomes:
@@ -2787,7 +2787,7 @@ NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
  */
 NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->in_func()) {
 	    cerr << get_fileline() << ": error: functions cannot have non "
@@ -2827,7 +2827,7 @@ NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
 
       NetExpr*delay = 0;
       if (delay_ != 0) {
-	    assert(count_ == 0 && event_ == 0);
+	    ivl_assert(*this, count_ == 0 && event_ == 0);
 	    delay = elaborate_delay_expr(delay_, des, scope);
       }
 
@@ -2844,7 +2844,7 @@ NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
                         return 0;
                   }
 
-		  assert(event_ != 0);
+		  ivl_assert(*this, event_ != 0);
 		  count = elab_and_eval(des, scope, count_, -1);
 		  if (count == 0) {
 			cerr << get_fileline() << ": Unable to elaborate "
@@ -2871,7 +2871,7 @@ NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
 		  return 0;
 	    }
 	    event = dynamic_cast<NetEvWait*>(st) ;
-	    assert(event);
+	    ivl_assert(*this, event);
 
 	      // Some constant values are special.
 	    if (NetEConst*ce = dynamic_cast<NetEConst*>(count)) {
@@ -2906,7 +2906,7 @@ NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
  */
 NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetBlock::Type type;
       switch (bl_type_) {
@@ -2927,7 +2927,7 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
 	    // cases are handled above.
 	  default:
 	    type = NetBlock::SEQU;
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
 
       NetScope*nscope = 0;
@@ -2940,7 +2940,7 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
 		  des->errors += 1;
 		  return 0;
 	    }
-	    assert(nscope);
+	    ivl_assert(*this, nscope);
       }
 
       NetBlock*cur = new NetBlock(type, nscope);
@@ -2970,7 +2970,7 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
 	// referenced elsewhere.
       if ((type == NetBlock::SEQU) && (list_.size() == 1) &&
           (pscope_name() == 0)) {
-	    assert(list_[0]);
+	    ivl_assert(*this, list_[0]);
 	    NetProc*tmp = list_[0]->elaborate(des, nscope);
 	    return tmp;
       }
@@ -2979,7 +2979,7 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
 	    des->fork_enter();
 
       for (unsigned idx = 0 ;  idx < list_.size() ;  idx += 1) {
-	    assert(list_[idx]);
+	    ivl_assert(*this, list_[idx]);
 
 	      // Detect the error that a super.new() statement is in the
 	      // midst of a block. Report the error. Continue on with the
@@ -3253,7 +3253,7 @@ NetProc* PCase::elaborate(Design*des, NetScope*scope) const
 
 NetProc* PChainConstructor::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PChainConstructor::elaborate: "
@@ -3353,7 +3353,7 @@ NetProc* PChainConstructor::elaborate(Design*des, NetScope*scope) const
 
 NetProc* PCondit::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (debug_elaborate)
 	    cerr << get_fileline() << ":  PCondit::elaborate: "
@@ -3476,7 +3476,7 @@ NetProc* PCallTask::elaborate(Design*des, NetScope*scope) const
  */
 NetProc* PCallTask::elaborate_sys(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (path_.size() > 1) {
 	    cerr << get_fileline() << ": error: Hierarchical system task names"
@@ -3548,7 +3548,7 @@ NetProc* PCallTask::elaborate_sys(Design*des, NetScope*scope) const
  */
 NetProc* PCallTask::elaborate_usr(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetScope*pscope = scope;
       if (package_) {
@@ -3577,8 +3577,8 @@ NetProc* PCallTask::elaborate_usr(Design*des, NetScope*scope) const
 	    return 0;
       }
 
-      assert(task);
-      assert(task->type() == NetScope::TASK);
+      ivl_assert(*this, task);
+      ivl_assert(*this, task->type() == NetScope::TASK);
       NetTaskDef*def = task->task_def();
       if (def == 0) {
 	    cerr << get_fileline() << ": internal error: task " << path_
@@ -3587,7 +3587,7 @@ NetProc* PCallTask::elaborate_usr(Design*des, NetScope*scope) const
 	    des->errors += 1;
 	    return 0;
       }
-      assert(def);
+      ivl_assert(*this, def);
 
 	/* In SystemVerilog a method calling another method in the
 	 * current class needs to be elaborated as a method with an
@@ -3596,7 +3596,7 @@ NetProc* PCallTask::elaborate_usr(Design*des, NetScope*scope) const
 	    const NetScope *c_scope = scope->get_class_scope();
 	    if (c_scope && (c_scope == task->get_class_scope())) {
 		  NetProc *tmp = elaborate_method_(des, scope, true);
-		  assert(tmp);
+		  ivl_assert(*this, tmp);
 		  return tmp;
 	    }
       }
@@ -3785,7 +3785,7 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 
 	/* Add the implicit this reference when requested. */
       if (add_this_flag) {
-	    assert(use_path.empty());
+	    ivl_assert(*this, use_path.empty());
 	    use_path.push_front(name_component_t(perm_string::literal(THIS_TOKEN)));
       }
 
@@ -4111,7 +4111,7 @@ NetProc* PCallTask::elaborate_build_call_(Design*des, NetScope*scope,
 	    size_t parms_idx = use_this? idx-1 : idx;
 
 	    NetNet*port = def->port(idx);
-	    assert(port->port_type() != NetNet::NOT_A_PORT);
+	    ivl_assert(*this, port->port_type() != NetNet::NOT_A_PORT);
 	    if (port->port_type() == NetNet::POUTPUT)
 		  continue;
 
@@ -4178,7 +4178,7 @@ NetProc* PCallTask::elaborate_build_call_(Design*des, NetScope*scope,
 	    NetNet*port = def->port(idx);
 
 	      /* Skip input ports. */
-	    assert(port->port_type() != NetNet::NOT_A_PORT);
+	    ivl_assert(*this, port->port_type() != NetNet::NOT_A_PORT);
 	    if (port->port_type() == NetNet::PINPUT)
 		  continue;
 
@@ -4267,7 +4267,7 @@ static bool get_value_as_long(const NetExpr*expr, long&val)
       switch(expr->expr_type()) {
 	  case IVL_VT_REAL: {
 	    const NetECReal*c = dynamic_cast<const NetECReal*> (expr);
-	    assert(c);
+	    ivl_assert(*expr, c);
 	    verireal tmp = c->value();
 	    val = tmp.as_long();
 	    break;
@@ -4276,7 +4276,7 @@ static bool get_value_as_long(const NetExpr*expr, long&val)
 	  case IVL_VT_BOOL:
 	  case IVL_VT_LOGIC: {
 	    const NetEConst*c = dynamic_cast<const NetEConst*>(expr);
-	    assert(c);
+	    ivl_assert(*expr, c);
 	    verinum tmp = c->value();
 	    if (tmp.is_string()) return false;
 	    val = tmp.as_long();
@@ -4300,7 +4300,7 @@ static bool get_value_as_string(const NetExpr*expr, string&str)
 	  case IVL_VT_BOOL:
 	  case IVL_VT_LOGIC: {
 	    const NetEConst*c = dynamic_cast<const NetEConst*>(expr);
-	    assert(c);
+	    ivl_assert(*expr, c);
 	    verinum tmp = c->value();
 	    if (!tmp.is_string()) return false;
 	    str = tmp.as_string();
@@ -4317,8 +4317,8 @@ static bool get_value_as_string(const NetExpr*expr, string&str)
 /* Elaborate an elaboration task. */
 bool PCallTask::elaborate_elab(Design*des, NetScope*scope) const
 {
-      assert(scope);
-      assert(path_.size() == 1);
+      ivl_assert(*this, scope);
+      ivl_assert(*this, path_.size() == 1);
 
       unsigned parm_count = parms_.size();
 
@@ -4433,7 +4433,7 @@ bool PCallTask::elaborate_elab(Design*des, NetScope*scope) const
 NetCAssign* PCAssign::elaborate(Design*des, NetScope*scope) const
 {
       NetCAssign*dev = 0;
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->is_auto() && lval_->has_aa_term(des, scope)) {
 	    cerr << get_fileline() << ": error: automatically allocated "
@@ -4478,7 +4478,7 @@ NetCAssign* PCAssign::elaborate(Design*des, NetScope*scope) const
 
 NetDeassign* PDeassign::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->is_auto() && lval_->has_aa_term(des, scope)) {
 	    cerr << get_fileline() << ": error: automatically allocated "
@@ -4506,7 +4506,7 @@ NetDeassign* PDeassign::elaborate(Design*des, NetScope*scope) const
  */
 NetProc* PDelayStatement::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->in_func()) {
 	    cerr << get_fileline() << ": error: functions cannot have "
@@ -4552,7 +4552,7 @@ NetProc* PDelayStatement::elaborate(Design*des, NetScope*scope) const
  */
 NetProc* PDisable::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
 	/* If the disable scope_ is empty then this is a SystemVerilog
 	 * disable fork statement. */
@@ -4704,7 +4704,7 @@ NetProc* PDoWhile::elaborate(Design*des, NetScope*scope) const
 NetProc* PEventStatement::elaborate_st(Design*des, NetScope*scope,
 				       NetProc*enet) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->in_func()) {
 	    cerr << get_fileline() << ": error: functions cannot have "
@@ -4737,7 +4737,7 @@ NetProc* PEventStatement::elaborate_st(Design*des, NetScope*scope,
 	   @* statement. Generate an expression to use. */
 
       if (expr_.size() == 0) {
-	    assert(enet);
+	    ivl_assert(*this, enet);
 	     /* For synthesis or always_comb/latch we want just the inputs,
 	      * but for the rest we want inputs and outputs that may cause
 	      * a value to change. */
@@ -4793,7 +4793,7 @@ NetProc* PEventStatement::elaborate_st(Design*des, NetScope*scope,
 			unsigned base = nset->at(idx).base;
 cerr << get_fileline() << ": base = " << base << endl;
 // FIXME: make this work with selects that go before the base.
-			assert(base < vwid);
+			ivl_assert(*this, base < vwid);
 			if (base + wid > vwid) wid = vwid - base;
 cerr << get_fileline() << ": base = " << base << ", width = " << wid
      << ", expr width = " << vwid << endl;
@@ -4822,7 +4822,7 @@ cerr << endl;
 
       } else for (unsigned idx = 0 ;  idx < expr_.size() ;  idx += 1) {
 
-	    assert(expr_[idx]->expr());
+	    ivl_assert(*this, expr_[idx]->expr());
 
 	      /* If the expression is an identifier that matches a
 		 named event, then handle this case all at once and
@@ -4847,7 +4847,7 @@ cerr << endl;
 				    break;
 				  default:
 				    cerr << "unknown edge type!";
-				    assert(0);
+				    ivl_assert(*this, 0);
 			      }
 			      cerr << " can not be used with a named event ("
 			           << sr.eve->name() << ")." << endl;
@@ -4888,7 +4888,7 @@ cerr << endl;
 		  des->errors += 1;
 		  continue;
 	    }
-	    assert(expr);
+	    ivl_assert(*this, expr);
 
 	    delete tmp;
 
@@ -4919,7 +4919,7 @@ cerr << endl;
 
 		default:
 		  pr = NULL;
-		  assert(0);
+		  ivl_assert(*this, 0);
 	    }
 
 	    for (unsigned p = 0 ;  p < pr->pin_count() ; p += 1)
@@ -4965,8 +4965,8 @@ cerr << endl;
 NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
 					 NetProc*enet) const
 {
-      assert(scope);
-      assert(expr_.size() == 1);
+      ivl_assert(*this, scope);
+      ivl_assert(*this, expr_.size() == 1);
 
       if (scope->in_func()) {
 	    cerr << get_fileline() << ": error: functions cannot have "
@@ -5009,7 +5009,7 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
       }
 
       if (expr->expr_width() > 1) {
-	    assert(expr->expr_width() > 1);
+	    ivl_assert(*this, expr->expr_width() > 1);
 	    NetEUReduce*cmp = new NetEUReduce('|', expr);
 	    cmp->set_line(*pe);
 	    expr = cmp;
@@ -5021,15 +5021,15 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
 	/* Detect the unusual case that the wait expression is
 	   constant. Constant true is OK (it becomes transparent) but
 	   constant false is almost certainly not what is intended. */
-      assert(expr->expr_width() == 1);
+      ivl_assert(*this, expr->expr_width() == 1);
       if (NetEConst*ce = dynamic_cast<NetEConst*>(expr)) {
 	    verinum val = ce->value();
-	    assert(val.len() == 1);
+	    ivl_assert(*this, val.len() == 1);
 
 	      /* Constant true -- wait(1) <s1> reduces to <s1>. */
 	    if (val[0] == verinum::V1) {
 		  delete expr;
-		  assert(enet);
+		  ivl_assert(*this, enet);
 		  return enet;
 	    }
 
@@ -5059,7 +5059,7 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
 	/* Invert the sense of the test with an exclusive NOR. In
 	   other words, if this adjusted expression returns TRUE, then
 	   wait. */
-      assert(expr->expr_width() == 1);
+      ivl_assert(*this, expr->expr_width() == 1);
       expr = new NetEBComp('N', expr, new NetEConst(verinum(verinum::V1)));
       expr->set_line(*pe);
       eval_expr(expr);
@@ -5127,10 +5127,10 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
  */
 NetProc* PEventStatement::elaborate_wait_fork(Design*des, NetScope*scope) const
 {
-      assert(scope);
-      assert(expr_.size() == 1);
-      assert(expr_[0] == 0);
-      assert(! statement_);
+      ivl_assert(*this, scope);
+      ivl_assert(*this, expr_.size() == 1);
+      ivl_assert(*this, expr_[0] == 0);
+      ivl_assert(*this, ! statement_);
 
       if (scope->in_func()) {
 	    cerr << get_fileline() << ": error: functions cannot have "
@@ -5216,7 +5216,7 @@ NetProc* PForever::elaborate(Design*des, NetScope*scope) const
 NetForce* PForce::elaborate(Design*des, NetScope*scope) const
 {
       NetForce*dev = 0;
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->is_auto() && lval_->has_aa_term(des, scope)) {
 	    cerr << get_fileline() << ": error: automatically allocated "
@@ -5526,7 +5526,7 @@ NetProc* PForStatement::elaborate(Design*des, NetScope*scope) const
       NetExpr*initial_expr;
       NetNet*sig;
       bool error_flag = false;
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (!name1_) {
 	    // If there is no initial assignment expression, then mark that
@@ -5657,7 +5657,7 @@ void PFunction::elaborate(Design*des, NetScope*scope) const
 	    des->errors += 1;
 	    return;
       }
-      assert(def);
+      ivl_assert(*this, def);
 
       NetProc*st;
       if (statement_ == 0) {
@@ -5703,7 +5703,7 @@ void PFunction::elaborate(Design*des, NetScope*scope) const
 
 NetProc* PRelease::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       if (scope->is_auto() && lval_->has_aa_term(des, scope)) {
 	    cerr << get_fileline() << ": error: automatically allocated "
@@ -5724,7 +5724,7 @@ NetProc* PRelease::elaborate(Design*des, NetScope*scope) const
 
 NetProc* PRepeat::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetExpr*expr = elab_and_eval(des, scope, expr_, -1);
       if (expr == 0) {
@@ -5887,7 +5887,7 @@ NetProc* PReturn::elaborate(Design*des, NetScope*scope) const
 void PTask::elaborate(Design*des, NetScope*task) const
 {
       NetTaskDef*def = task->task_def();
-      assert(def);
+      ivl_assert(*this, def);
 
       NetProc*st;
       if (statement_ == 0) {
@@ -5934,7 +5934,7 @@ void PTask::elaborate(Design*des, NetScope*task) const
 
 NetProc* PTrigger::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       symbol_search_results sr;
       if (!symbol_search(this, des, scope, event_, &sr)) {
@@ -5958,7 +5958,7 @@ NetProc* PTrigger::elaborate(Design*des, NetScope*scope) const
 
 NetProc* PNBTrigger::elaborate(Design*des, NetScope*scope) const
 {
-      assert(scope);
+      ivl_assert(*this, scope);
 
       NetNet*       sig = 0;
       const NetExpr*par = 0;
@@ -6312,7 +6312,7 @@ static void elaborate_functions(Design*des, NetScope*scope,
 
 	    hname_t use_name ( (*cur).first );
 	    NetScope*fscope = scope->child(use_name);
-	    assert(fscope);
+	    ivl_assert(*(*cur).second, fscope);
 	    (*cur).second->elaborate(des, fscope);
       }
 }
@@ -6326,7 +6326,7 @@ static void elaborate_tasks(Design*des, NetScope*scope,
 
 	    hname_t use_name ( (*cur).first );
 	    NetScope*tscope = scope->child(use_name);
-	    assert(tscope);
+	    ivl_assert(*(*cur).second, tscope);
 	    (*cur).second->elaborate(des, tscope);
       }
 }
@@ -6862,7 +6862,7 @@ bool Design::check_proc_delay() const
 		  if (! wait) {
 			  // The always_comb/latch processes have an event
 			  // control added automatically by the compiler.
-			assert(pr->type() == IVL_PR_ALWAYS_FF);
+			ivl_assert(*pr, pr->type() == IVL_PR_ALWAYS_FF);
 			cerr << pr->get_fileline() << ": error: the first "
 			        "statement of an always_ff process must be "
 			        "an event control statement." << endl;
@@ -6891,7 +6891,7 @@ bool Design::check_proc_delay() const
 			              "control." << endl;
 			      result = true;
 			} else {
-			      assert(pr->type() == IVL_PR_ALWAYS_COMB);
+			      ivl_assert(*pr, pr->type() == IVL_PR_ALWAYS_COMB);
 			      cerr << pr->get_fileline() << ": warning: "
 			              "always_comb process has no "
 			              "sensitivities." << endl;
@@ -6928,17 +6928,17 @@ static void print_nexus_name(const Nexus*nex)
 		  return;
 	      // For a NetPartSelect calculate the name.
 	    } else if (const NetPartSelect*ps = dynamic_cast<const NetPartSelect*>(obj)) {
-		  assert(ps->pin_count() >= 2);
-		  assert(ps->pin(1).get_dir() == Link::INPUT);
-		  assert(ps->pin(1).is_linked());
+		  ivl_assert(*ps, ps->pin_count() >= 2);
+		  ivl_assert(*ps, ps->pin(1).get_dir() == Link::INPUT);
+		  ivl_assert(*ps, ps->pin(1).is_linked());
 		  print_nexus_name(ps->pin(1).nexus());
 		  cerr << "[]";
 		  return;
 	      // For a NetUReduce calculate the name.
 	    } else if (const NetUReduce*reduce = dynamic_cast<const NetUReduce*>(obj)) {
-		  assert(reduce->pin_count() == 2);
-		  assert(reduce->pin(1).get_dir() == Link::INPUT);
-		  assert(reduce->pin(1).is_linked());
+		  ivl_assert(*reduce, reduce->pin_count() == 2);
+		  ivl_assert(*reduce, reduce->pin(1).get_dir() == Link::INPUT);
+		  ivl_assert(*reduce, reduce->pin(1).is_linked());
 		  switch (reduce->type()) {
 		    case NetUReduce::AND:
 			cerr << "&";
@@ -6959,14 +6959,14 @@ static void print_nexus_name(const Nexus*nex)
 			cerr << "~^";
 			break;
 		    case NetUReduce::NONE:
-			assert(0);
+			ivl_assert(*reduce, 0);
 		  }
 		  print_nexus_name(reduce->pin(1).nexus());
 		  return;
 	    } else if (const NetLogic*logic = dynamic_cast<const NetLogic*>(obj)) {
-		  assert(logic->pin_count() >= 2);
-		  assert(logic->pin(1).get_dir() == Link::INPUT);
-		  assert(logic->pin(1).is_linked());
+		  ivl_assert(*logic, logic->pin_count() >= 2);
+		  ivl_assert(*logic, logic->pin(1).get_dir() == Link::INPUT);
+		  ivl_assert(*logic, logic->pin(1).is_linked());
 		  switch (logic->type()) {
 		    case NetLogic::NOT:
 			cerr << "~";
@@ -6989,17 +6989,17 @@ static void print_nexus_name(const Nexus*nex)
 
 static void print_event_probe_name(const NetEvProbe *prb)
 {
-      assert(prb->pin_count() == 1);
-      assert(prb->pin(0).get_dir() == Link::INPUT);
-      assert(prb->pin(0).is_linked());
+      ivl_assert(*prb, prb->pin_count() == 1);
+      ivl_assert(*prb, prb->pin(0).get_dir() == Link::INPUT);
+      ivl_assert(*prb, prb->pin(0).is_linked());
       print_nexus_name(prb->pin(0).nexus());
 }
 
 static void check_event_probe_width(const LineInfo *info, const NetEvProbe *prb)
 {
-      assert(prb->pin_count() == 1);
-      assert(prb->pin(0).get_dir() == Link::INPUT);
-      assert(prb->pin(0).is_linked());
+      ivl_assert(*prb, prb->pin_count() == 1);
+      ivl_assert(*prb, prb->pin(0).get_dir() == Link::INPUT);
+      ivl_assert(*prb, prb->pin(0).is_linked());
       if (prb->edge() == NetEvProbe::ANYEDGE) return;
       if (prb->pin(0).nexus()->vector_width() > 1) {
 	    cerr << info->get_fileline() << " warning: Synthesis wants "

--- a/expr_synth.cc
+++ b/expr_synth.cc
@@ -116,7 +116,7 @@ NetNet* NetEBAdd::synthesize(Design*des, NetScope*scope, NetExpr*root)
 	    lsig = pad_to_width(des, lsig, expr_width(), *this);
 	    rsig = pad_to_width(des, rsig, expr_width(), *this);
 
-	    assert(lsig->vector_width() == rsig->vector_width());
+	    ivl_assert(*this, lsig->vector_width() == rsig->vector_width());
 	    width=lsig->vector_width();
       }
 
@@ -175,7 +175,7 @@ NetNet* NetEBBits::synthesize(Design*des, NetScope*scope, NetExpr*root)
       lsig = pad_to_width(des, lsig, width, *this);
       rsig = pad_to_width(des, rsig, width, *this);
 
-      assert(lsig->vector_width() == rsig->vector_width());
+      ivl_assert(*this, lsig->vector_width() == rsig->vector_width());
       netvector_t*osig_vec = new netvector_t(expr_type(), width-1, 0);
       NetNet*osig = new NetNet(scope, scope->local_symbol(),
 			       NetNet::IMPLICIT, osig_vec);
@@ -206,7 +206,7 @@ NetNet* NetEBBits::synthesize(Design*des, NetScope*scope, NetExpr*root)
 	    break;
 	  default:
 	    gate = NULL;
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
 
       connect(osig->pin(0), gate->pin(0));
@@ -585,10 +585,10 @@ NetNet* NetEBLogic::synthesize(Design*des, NetScope*scope, NetExpr*root)
 
 	/* The left and right operands have already been reduced to a
 	 * single bit value, so just connect then to the logic gate. */
-      assert(lsig->pin_count() == 1);
+      ivl_assert(*this, lsig->pin_count() == 1);
       connect(lsig->pin(0), olog->pin(1));
 
-      assert(rsig->pin_count() == 1);
+      ivl_assert(*this, rsig->pin_count() == 1);
       connect(rsig->pin(0), olog->pin(2));
 
       return osig;
@@ -723,7 +723,7 @@ NetNet* NetEBShift::synthesize(Design*des, NetScope*scope, NetExpr*root)
 
       connect(dev->pin_Result(), osig->pin(0));
 
-      assert(lsig->vector_width() == dev->width());
+      ivl_assert(*this, lsig->vector_width() == dev->width());
       connect(dev->pin_Data(), lsig->pin(0));
 
       connect(dev->pin_Distance(), rsig->pin(0));
@@ -742,7 +742,7 @@ NetNet* NetEConcat::synthesize(Design*des, NetScope*scope, NetExpr*root)
 	    if (parms_[idx]->expr_width() == 0) {
 		    /* We need to synthesize a replication of zero. */
 		  tmp[idx] = parms_[idx]->synthesize(des, scope, root);
-		  assert(tmp[idx] == 0);
+		  ivl_assert(*this, tmp[idx] == 0);
 		  num_parms -= 1;
 	    } else {
 		  tmp[idx] = parms_[idx]->synthesize(des, scope, root);
@@ -893,7 +893,7 @@ NetNet* NetEUBits::synthesize(Design*des, NetScope*scope, NetExpr*root)
 	    break;
 	  default:
 	    gate = NULL;
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
 
       connect(osig->pin(0), gate->pin(0));

--- a/net_assign.cc
+++ b/net_assign.cc
@@ -69,7 +69,7 @@ NetAssign_::~NetAssign_()
 		  sig_->type(NetNet::WIRE);
       }
 
-      assert( more == 0 );
+      ivl_assert(*this, more == 0 );
       delete word_;
 }
 
@@ -87,7 +87,7 @@ NetScope*NetAssign_::scope() const
 
 void NetAssign_::set_word(NetExpr*r)
 {
-      assert(word_ == 0);
+      ivl_assert(*this, word_ == 0);
       word_ = r;
 }
 
@@ -183,7 +183,7 @@ perm_string NetAssign_::name() const
 
 NetNet* NetAssign_::sig() const
 {
-      assert(sig_? nest_==0 : nest_!=0);
+      ivl_assert(*this, sig_ ? nest_ == 0 : nest_ != 0);
       return sig_;
 }
 
@@ -257,7 +257,7 @@ NetAssign_* NetAssignBase::l_val(unsigned idx)
 	    idx -= 1;
       }
 
-      assert(idx == 0);
+      ivl_assert(*this, idx == 0);
       return cur;
 }
 
@@ -272,7 +272,7 @@ const NetAssign_* NetAssignBase::l_val(unsigned idx) const
 	    idx -= 1;
       }
 
-      assert(idx == 0);
+      ivl_assert(*this, idx == 0);
       return cur;
 }
 

--- a/net_event.cc
+++ b/net_event.cc
@@ -43,7 +43,7 @@ NetEvent::NetEvent(perm_string n)
 
 NetEvent::~NetEvent()
 {
-      assert(waitref_ == 0);
+      ivl_assert(*this, waitref_ == 0);
       if (scope_) scope_->rem_event(this);
       while (probes_) {
 	    NetEvProbe*tmp = probes_->enext_;
@@ -60,13 +60,13 @@ perm_string NetEvent::name() const
 
 NetScope* NetEvent::scope()
 {
-      assert(scope_);
+      ivl_assert(*this, scope_);
       return scope_;
 }
 
 const NetScope* NetEvent::scope() const
 {
-      assert(scope_);
+      ivl_assert(*this, scope_);
       return scope_;
 }
 
@@ -254,7 +254,7 @@ NetEvTrig::~NetEvTrig()
       } else {
 	    NetEvTrig*cur = event_->trig_;
 	    while (cur->enext_ != this) {
-		  assert(cur->enext_);
+		  ivl_assert(*this, cur->enext_);
 		  cur = cur->enext_;
 	    }
 
@@ -282,7 +282,7 @@ NetEvNBTrig::~NetEvNBTrig()
       } else {
 	    NetEvNBTrig*cur = event_->nb_trig_;
 	    while (cur->enext_ != this) {
-		  assert(cur->enext_);
+		  ivl_assert(*this, cur->enext_);
 		  cur = cur->enext_;
 	    }
 
@@ -320,7 +320,7 @@ NetEvProbe::~NetEvProbe()
       } else {
 	    NetEvProbe*cur = event_->probes_;
 	    while (cur->enext_ != this) {
-		  assert(cur->enext_);
+		  ivl_assert(*this, cur->enext_);
 		  cur = cur->enext_;
 	    }
 
@@ -398,10 +398,10 @@ NetEvWait::~NetEvWait()
 			tgt->wlist_ = tmp->next;
 			delete tmp;
 		  } else {
-			assert(tmp->next);
+			ivl_assert(*this, tmp->next);
 			while (tmp->next->obj != this) {
 			      tmp = tmp->next;
-			      assert(tmp->next);
+			      ivl_assert(*this, tmp->next);
 			}
 			tmp->next = tmp->next->next;
 			delete tmp;
@@ -417,7 +417,7 @@ void NetEvWait::add_event(NetEvent*tgt)
 {
 	/* A wait fork is an empty event. */
       if (! tgt) {
-	    assert(events_.empty());
+	    ivl_assert(*this, events_.empty());
 	    events_.push_back(0);
 	    return;
       }
@@ -442,20 +442,20 @@ void NetEvWait::replace_event(NetEvent*src, NetEvent*repl)
 		  break;
       }
 
-      assert(idx < events_.size());
+      ivl_assert(*this, idx < events_.size());
 
 	// First, remove me from the list held by the src NetEvent.
-      assert(src->waitref_ > 0);
+      ivl_assert(*this, src->waitref_ > 0);
       src->waitref_ -= 1;
       struct NetEvent::wcell_*tmp = src->wlist_;
       if (tmp->obj == this) {
 	    src->wlist_ = tmp->next;
 	    delete tmp;
       } else {
-	    assert(tmp->next);
+	    ivl_assert(*this, tmp->next);
 	    while (tmp->next->obj != this) {
 		  tmp = tmp->next;
-		  assert(tmp->next);
+		  ivl_assert(*this, tmp->next);
 	    }
 	    tmp->next = tmp->next->next;
 	    delete tmp;

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -265,8 +265,8 @@ ivl_variable_type_t NetEConcat::expr_type() const
 
 void NetEConcat::set(unsigned idx, NetExpr*e)
 {
-      assert(idx < parms_.size());
-      assert(parms_[idx] == 0);
+      ivl_assert(*this, idx < parms_.size());
+      ivl_assert(*this, parms_[idx] == 0);
       parms_[idx] = e;
       expr_width( expr_width() + repeat_ * e->expr_width() );
 }
@@ -275,7 +275,7 @@ NetEConstEnum::NetEConstEnum(perm_string n, const netenum_t *enum_set,
 			     const verinum &val)
 : NetEConst(enum_set, val), name_(n)
 {
-      assert(has_width());
+      ivl_assert(*this, has_width());
 }
 
 NetEConstEnum::~NetEConstEnum()
@@ -395,7 +395,7 @@ NetEProperty::NetEProperty(NetNet*net, size_t pidx, NetExpr*idx)
 : net_(net), pidx_(pidx), index_(idx)
 {
       const netclass_t*use_type = dynamic_cast<const netclass_t*>(net->net_type());
-      assert(use_type);
+      ivl_assert(*this, use_type);
 
       ivl_type_t prop_type = use_type->get_prop_type(pidx_);
       set_net_type(prop_type);
@@ -491,7 +491,7 @@ unsigned NetESFunc::nparms() const
 
 void NetESFunc::parm(unsigned idx, NetExpr*v)
 {
-      assert(idx < parms_.size());
+      ivl_assert(*this, idx < parms_.size());
       if (parms_[idx])
 	    delete parms_[idx];
       parms_[idx] = v;
@@ -499,13 +499,13 @@ void NetESFunc::parm(unsigned idx, NetExpr*v)
 
 const NetExpr* NetESFunc::parm(unsigned idx) const
 {
-      assert(idx < parms_.size());
+      ivl_assert(*this, idx < parms_.size());
       return parms_[idx];
 }
 
 NetExpr* NetESFunc::parm(unsigned idx)
 {
-      assert(idx < parms_.size());
+      ivl_assert(*this, idx < parms_.size());
       return parms_[idx];
 }
 

--- a/net_func_eval.cc
+++ b/net_func_eval.cc
@@ -316,7 +316,7 @@ bool NetAssign::eval_func_lval_(const LineInfo&loc,
 
       LocalVar*var = & ptr->second;
       while (var->nwords == -1) {
-	    assert(var->ref);
+	    ivl_assert(*this, var->ref);
 	    var = var->ref;
       }
 
@@ -342,7 +342,7 @@ bool NetAssign::eval_func_lval_(const LineInfo&loc,
 
 	    old_lval = var->array[word];
       } else {
-	    assert(var->nwords == 0);
+	    ivl_assert(*this, var->nwords == 0);
 	    old_lval = var->value;
       }
 
@@ -429,7 +429,7 @@ bool NetAssign::eval_func_lval_(const LineInfo&loc,
       if (var->nwords > 0) {
 	    var->array[word] = rval_result;
       } else {
-	    assert(var->nwords == 0);
+	    ivl_assert(*this, var->nwords == 0);
 	    var->value = rval_result;
       }
 
@@ -1088,7 +1088,7 @@ NetExpr* NetESignal::evaluate_function(const LineInfo&loc,
 	// Follow indirect references to the actual variable.
       LocalVar*var = & ptr->second;
       while (var->nwords == -1) {
-	    assert(var->ref);
+	    ivl_assert(*this, var->ref);
 	    var = var->ref;
       }
 

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -240,7 +240,7 @@ void NetScope::add_typedefs(const map<perm_string,typedef_t*>*typedefs)
 
 NetScope*NetScope::find_typedef_scope(const Design*des, const typedef_t*type)
 {
-      assert(type);
+      ivl_assert(*this, type);
 
       NetScope *cur_scope = this;
       while (cur_scope) {
@@ -310,8 +310,8 @@ bool NetScope::auto_name(const char*prefix, char pad, const char* suffix)
 {
 	// Find the current reference to myself in the parent scope.
       map<hname_t,NetScope*>::iterator self = up_->children_.find(name_);
-      assert(self != up_->children_.end());
-      assert(self->second == this);
+      ivl_assert(*this, self != up_->children_.end());
+      ivl_assert(*this, self->second == this);
 
 	// This is to keep the pad attempts from being stuck in some
 	// sort of infinite loop. This should not be a practical
@@ -481,33 +481,33 @@ void NetScope::print_type(ostream&stream) const
 
 void NetScope::set_task_def(NetTaskDef*def)
 {
-      assert( type_ == TASK );
-      assert( task_ == 0 );
+      ivl_assert(*this, type_ == TASK);
+      ivl_assert(*this, task_ == nullptr);
       task_ = def;
 }
 
 NetTaskDef* NetScope::task_def()
 {
-      assert( type_ == TASK );
+      ivl_assert(*this, type_ == TASK);
       return task_;
 }
 
 const NetTaskDef* NetScope::task_def() const
 {
-      assert( type_ == TASK );
+      ivl_assert(*this, type_ == TASK);
       return task_;
 }
 
 void NetScope::set_func_def(NetFuncDef*def)
 {
-      assert( type_ == FUNC );
-      assert( func_ == 0 );
+      ivl_assert(*this, type_ == FUNC);
+      ivl_assert(*this, func_ == nullptr);
       func_ = def;
 }
 
 NetFuncDef* NetScope::func_def()
 {
-      assert( type_ == FUNC );
+      ivl_assert(*this, type_ == FUNC);
       return func_;
 }
 
@@ -518,14 +518,14 @@ bool NetScope::in_func() const
 
 const NetFuncDef* NetScope::func_def() const
 {
-      assert( type_ == FUNC );
+      ivl_assert(*this, type_ == FUNC);
       return func_;
 }
 
 void NetScope::set_class_def(netclass_t*def)
 {
-      assert( type_ == CLASS );
-      assert( class_def_==0  );
+      ivl_assert(*this, type_ == CLASS);
+      ivl_assert(*this, class_def_ == nullptr);
       class_def_ = def;
 }
 
@@ -539,26 +539,26 @@ const netclass_t* NetScope::class_def(void) const
 
 void NetScope::set_module_name(perm_string n)
 {
-      assert(type_==MODULE || type_==PACKAGE);
+      ivl_assert(*this, type_==MODULE || type_==PACKAGE);
       module_name_ = n;
 }
 
 perm_string NetScope::module_name() const
 {
-      assert(type_==MODULE || type_==PACKAGE);
+      ivl_assert(*this, type_==MODULE || type_==PACKAGE);
       return module_name_;
 }
 
 void NetScope::set_num_ports(unsigned int num_ports)
 {
-    assert(type_ == MODULE);
-    assert(ports_.empty());
+    ivl_assert(*this, type_ == MODULE);
+    ivl_assert(*this, ports_.empty());
     ports_.resize( num_ports );
 }
 
 void NetScope::add_module_port_net(NetNet*subport)
 {
-      assert(type_ == MODULE);
+      ivl_assert(*this, type_ == MODULE);
       port_nets.push_back(subport);
 }
 
@@ -566,8 +566,8 @@ void NetScope::add_module_port_net(NetNet*subport)
 void NetScope::add_module_port_info( unsigned idx, perm_string name, PortType::Enum ptype,
                                 unsigned long width )
 {
-      assert(type_ == MODULE);
-      assert(ports_.size() > idx);
+      ivl_assert(*this, type_ == MODULE);
+      ivl_assert(*this, ports_.size() > idx);
       PortInfo &info = ports_[idx];
       info.name = name;
       info.type = ptype;
@@ -577,14 +577,14 @@ void NetScope::add_module_port_info( unsigned idx, perm_string name, PortType::E
 
 unsigned NetScope::module_port_nets() const
 {
-      assert(type_ == MODULE);
+      ivl_assert(*this, type_ == MODULE);
       return port_nets.size();
 }
 
 
 const std::vector<PortInfo> & NetScope::module_port_info() const
 {
-      assert(type_ == MODULE);
+      ivl_assert(*this, type_ == MODULE);
       return ports_;
 }
 
@@ -592,8 +592,8 @@ const std::vector<PortInfo> & NetScope::module_port_info() const
 
 NetNet* NetScope::module_port_net(unsigned idx) const
 {
-      assert(type_ == MODULE);
-      assert(idx < port_nets.size());
+      ivl_assert(*this, type_ == MODULE);
+      ivl_assert(*this, idx < port_nets.size());
       return port_nets[idx];
 }
 
@@ -634,7 +634,7 @@ perm_string NetScope::basename() const
 
 void NetScope::add_event(NetEvent*ev)
 {
-      assert(ev->scope_ == 0);
+      ivl_assert(*this, ev->scope_ == nullptr);
       ev->scope_ = this;
       ev->snext_ = events_;
       events_ = ev;
@@ -642,7 +642,7 @@ void NetScope::add_event(NetEvent*ev)
 
 void NetScope::rem_event(NetEvent*ev)
 {
-      assert(ev->scope_ == this);
+      ivl_assert(*this, ev->scope_ == this);
       ev->scope_ = 0;
       if (events_ == ev) {
 	    events_ = ev->snext_;
@@ -650,7 +650,7 @@ void NetScope::rem_event(NetEvent*ev)
       } else {
 	    NetEvent*cur = events_;
 	    while (cur->snext_ != ev) {
-		  assert(cur->snext_);
+		  ivl_assert(*this, cur->snext_);
 		  cur = cur->snext_;
 	    }
 	    cur->snext_ = ev->snext_;
@@ -671,7 +671,7 @@ NetEvent* NetScope::find_event(perm_string name)
 
 void NetScope::add_genvar(perm_string name, LineInfo *li)
 {
-      assert((type_ == MODULE) || (type_ == GENBLOCK));
+      ivl_assert(*li, (type_ == MODULE) || (type_ == GENBLOCK));
       genvars_[name] = li;
 }
 
@@ -690,7 +690,7 @@ void NetScope::add_signal(NetNet*net)
 
 void NetScope::rem_signal(NetNet*net)
 {
-      assert(net->scope() == this);
+      ivl_assert(*this, net->scope() == this);
       signals_map_.erase(net->name());
 }
 
@@ -726,7 +726,7 @@ netclass_t*NetScope::find_class(const Design*des, perm_string name)
             return import_scope->find_class(des, name);
 
       if (up_==0 && type_==CLASS) {
-	    assert(class_def_);
+	    ivl_assert(*this, class_def_);
 
 	    NetScope*def_parent = class_def_->definition_scope();
 	    return def_parent->find_class(des, name);
@@ -785,7 +785,7 @@ const NetScope* NetScope::get_class_scope() const
 		case NetScope::PACKAGE:
 		  return 0;
 		default:
-		  assert(0);
+		  ivl_assert(*this, 0);
 	    }
 	    scope = scope->parent();
       }

--- a/netlist.cc
+++ b/netlist.cc
@@ -151,7 +151,7 @@ void NetPins::devirtualize_pins(void)
 	    cerr << get_fileline() << ": error: pin count " << npins_ <<
 		" exceeds " << array_size_limit <<
 		" (set by -pARRAY_SIZE_LIMIT)" << endl;
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
       if (debug_optimizer && npins_ > 1000) cerr << "debug: devirtualizing " << npins_ << " pins." << endl;
 
@@ -183,8 +183,8 @@ NetPins::NetPins(unsigned npins)
 NetPins::~NetPins()
 {
       if (pins_) {
-	    assert(pins_[0].node_ == this);
-	    assert(pins_[0].pin_zero_);
+	    ivl_assert(*this, pins_[0].node_ == this);
+	    ivl_assert(*this, pins_[0].pin_zero_);
 	    delete[] pins_;
       }
 }
@@ -199,8 +199,8 @@ Link& NetPins::pin(unsigned idx)
 		 << typeid(*this).name() << endl;
       }
 
-      assert(idx < npins_);
-      assert(idx == 0? (pins_[0].pin_zero_ && pins_[0].node_==this) : pins_[idx].pin_==idx);
+      ivl_assert(*this, idx < npins_);
+      ivl_assert(*this, idx == 0? (pins_[0].pin_zero_ && pins_[0].node_==this) : pins_[idx].pin_==idx);
 
       return pins_[idx];
 }
@@ -210,11 +210,11 @@ const Link& NetPins::pin(unsigned idx) const
       if (!pins_ && !disable_virtual_pins) {
 	    cerr << get_fileline() << ": internal error: pin is unexpectedly"
 	      " virtual, try again with -pDISABLE_VIRTUAL_PINS=true" << endl;
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
-      assert(pins_);
-      assert(idx < npins_);
-      assert(idx == 0? (pins_[0].pin_zero_ && pins_[0].node_==this) : pins_[idx].pin_==idx);
+      ivl_assert(*this, pins_);
+      ivl_assert(*this, idx < npins_);
+      ivl_assert(*this, idx == 0? (pins_[0].pin_zero_ && pins_[0].node_==this) : pins_[idx].pin_==idx);
       return pins_[idx];
 }
 
@@ -406,7 +406,7 @@ void NetDelaySrc::set_delays(uint64_t t01, uint64_t t10, uint64_t t0z,
 
 uint64_t NetDelaySrc::get_delay(unsigned idx) const
 {
-      assert(idx < 12);
+      ivl_assert(*this, idx < 12);
       return transition_delays_[idx];
 }
 
@@ -588,7 +588,7 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
 		 ; cur != unpacked.end() ; ++cur, idx += 1) {
 	    unpacked_dims_[idx] = *cur;
       }
-      assert(idx == unpacked_dims_.size());
+      ivl_assert(*this, idx == unpacked_dims_.size());
 
       ivl_assert(*this, s);
       if (pin_count() == 0) {
@@ -623,14 +623,14 @@ NetNet::~NetNet()
 		 << "expression references." << endl;
 	    dump_net(cerr, 4);
       }
-      assert(eref_count_ == 0);
+      ivl_assert(*this, eref_count_ == 0);
       if (lref_count_ > 0) {
 	    cerr << get_fileline() << ": internal error: attempt to delete "
 		 << "signal ``" << name() << "'' which has "
 		 << "assign references." << endl;
 	    dump_net(cerr, 4);
       }
-      assert(lref_count_ == 0);
+      ivl_assert(*this, lref_count_ == 0);
       if (scope())
 	    scope()->rem_signal(this);
 
@@ -670,7 +670,7 @@ int NetNet::get_module_port_index() const
 void NetNet::set_module_port_index(unsigned idx)
 {
     port_index_ = idx;
-    assert( port_index_ >= 0 );
+    ivl_assert(*this, port_index_ >= 0);
 }
 
 ivl_variable_type_t NetNet::data_type() const
@@ -714,7 +714,7 @@ const netstruct_t*NetNet::struct_type(void) const
 		  return 0;
       }
 
-      assert(0);
+      ivl_assert(*this, 0);
       return 0;
 }
 
@@ -769,7 +769,7 @@ void NetNet::set_discipline(ivl_discipline_t dis)
 bool NetNet::sb_is_valid(const list<long>&indices, long sb) const
 {
       ivl_assert(*this, indices.size()+1 == packed_dims().size());
-      assert(packed_dims().size() == 1);
+      ivl_assert(*this, packed_dims().size() == 1);
       const netrange_t&rng = packed_dims().back();
       if (rng.get_msb() >= rng.get_lsb())
 	    return (sb <= rng.get_msb()) && (sb >= rng.get_lsb());
@@ -838,7 +838,7 @@ void NetNet::incr_eref()
 
 void NetNet::decr_eref()
 {
-      assert(eref_count_ > 0);
+      ivl_assert(*this, eref_count_ > 0);
       eref_count_ -= 1;
 }
 
@@ -882,7 +882,7 @@ void NetNet::incr_lref()
 
 void NetNet::decr_lref()
 {
-      assert(lref_count_ > 0);
+      ivl_assert(*this, lref_count_ > 0);
       lref_count_ -= 1;
 }
 
@@ -903,7 +903,7 @@ unsigned NetNet::delay_paths(void)const
 
 const NetDelaySrc* NetNet::delay_path(unsigned idx) const
 {
-      assert(idx < delay_paths_.size());
+      ivl_assert(*this, idx < delay_paths_.size());
       return delay_paths_[idx];
 }
 
@@ -941,7 +941,7 @@ NetPartSelect::NetPartSelect(NetNet*sig, NetNet*sel,
 	    break;
 	  case NetPartSelect::PV:
 	      /* Only a vector to part can be a variable select. */
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
       pin(2).set_dir(Link::INPUT);
 
@@ -1935,13 +1935,13 @@ const Link& NetMux::pin_Sel() const
 
 Link& NetMux::pin_Data(unsigned s)
 {
-      assert(s < size_);
+      ivl_assert(*this, s < size_);
       return pin(2+s);
 }
 
 const Link& NetMux::pin_Data(unsigned s) const
 {
-      assert(s < size_);
+      ivl_assert(*this, s < size_);
       return pin(2+s);
 }
 
@@ -2050,7 +2050,7 @@ NetConst::~NetConst()
 
 verinum::V NetConst::value(unsigned idx) const
 {
-      assert(idx < width());
+      ivl_assert(*this, idx < width());
       return value_[idx];
 }
 
@@ -2123,7 +2123,7 @@ NetSTask::NetSTask(const char*na, ivl_sfunc_as_task_t sfat,
 : name_(0), sfunc_as_task_(sfat), parms_(pa)
 {
       name_ = lex_strings.add(na);
-      assert(name_[0] == '$');
+      ivl_assert(*this, name_[0] == '$');
 }
 
 NetSTask::~NetSTask()
@@ -2183,7 +2183,7 @@ unsigned NetEUFunc::parm_count() const
 
 const NetExpr* NetEUFunc::parm(unsigned idx) const
 {
-      assert(idx < parms_.size());
+      ivl_assert(*this, idx < parms_.size());
       return parms_[idx];
 }
 
@@ -2610,7 +2610,7 @@ ivl_variable_type_t NetECast::expr_type() const
 	    ret = IVL_VT_BOOL;
 	    break;
 	  default:
-	    assert(0);
+	    ivl_assert(*this, 0);
       }
 
       return ret;
@@ -2776,7 +2776,7 @@ static DelayType get_loop_delay_type(const NetExpr*expr, const NetProc*proc, boo
 	     * returns three different values. */
 	  default:
 	    result = NO_DELAY;
-	    assert(0);
+	    ivl_assert(*expr, 0);
       }
 
       return result;
@@ -3123,7 +3123,7 @@ bool NetBlock::check_synth(ivl_process_type_t pr_type,
 		  cerr << "join_none";
 		  break;
 	      default:
-		  assert(0);
+		  ivl_assert(*this, 0);
 	    }
 	    cerr << " statement cannot be synthesized "
                  << get_process_type_as_string(pr_type) << endl;

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1400,12 +1400,12 @@ uint64_t get_scaled_time_from_real(Design*des, NetScope*scope, NetECReal*val)
       verireal fn = val->value();
 
       int shift = scope->time_unit() - scope->time_precision();
-      assert(shift >= 0);
+      ivl_assert(*scope, shift >= 0);
       int64_t delay = fn.as_long64(shift);
 
 
       shift = scope->time_precision() - des->get_precision();
-      assert(shift >= 0);
+      ivl_assert(*scope, shift >= 0);
       for (int lp = 0; lp < shift; lp += 1) delay *= 10;
 
       return delay;

--- a/pform.cc
+++ b/pform.cc
@@ -501,7 +501,7 @@ static void check_potential_imports(const struct vlltype&loc, perm_string name, 
 void pform_set_scope_timescale(const struct vlltype&loc)
 {
       PScopeExtra*scope = dynamic_cast<PScopeExtra*>(lexical_scope);
-      assert(scope);
+      ivl_assert(loc, scope);
 
       PScopeExtra*parent = find_nearest_scopex(scope->parent_scope());
 
@@ -542,7 +542,7 @@ void pform_set_scope_timescale(const struct vlltype&loc)
 		  VLerror("error: A timeprecision is missing or is too large!");
 	    }
       } else {
-            assert(scope->time_unit >= scope->time_precision);
+            ivl_assert(loc, scope->time_unit >= scope->time_precision);
       }
 
       if (warn_timescale && used_global_timescale
@@ -579,8 +579,8 @@ PClass* pform_push_class_scope(const struct vlltype&loc, perm_string name)
       FILE_NAME(class_scope, loc);
 
       PScopeExtra*scopex = find_nearest_scopex(lexical_scope);
-      assert(scopex);
-      assert(!pform_cur_generate);
+      ivl_assert(loc, scopex);
+      ivl_assert(loc, !pform_cur_generate);
 
       pform_set_scope_timescale(class_scope, scopex);
 
@@ -618,7 +618,7 @@ PTask* pform_push_task_scope(const struct vlltype&loc, char*name,
       FILE_NAME(task, loc);
 
       PScopeExtra*scopex = find_nearest_scopex(lexical_scope);
-      assert(scopex);
+      ivl_assert(loc, scopex);
       if (is_compilation_unit(scopex) && !gn_system_verilog()) {
 	    cerr << task->get_fileline() << ": error: task declarations "
 		  "must be contained within a module." << endl;
@@ -653,7 +653,7 @@ PFunction* pform_push_function_scope(const struct vlltype&loc, const char*name,
       FILE_NAME(func, loc);
 
       PScopeExtra*scopex = find_nearest_scopex(lexical_scope);
-      assert(scopex);
+      ivl_assert(loc, scopex);
       if (is_compilation_unit(scopex) && !gn_system_verilog()) {
 	    cerr << func->get_fileline() << ": error: function declarations "
 		  "must be contained within a module." << endl;
@@ -730,7 +730,7 @@ PNBTrigger* pform_new_nb_trigger(const struct vlltype&loc,
 
       PExpr*tmp_dly = 0;
       if (dly) {
-	    assert(dly->size() == 1);
+	    ivl_assert(loc, dly->size() == 1);
 	    tmp_dly = dly->front();
       }
 
@@ -1559,8 +1559,8 @@ void pform_start_generate_if(const struct vlltype&li, PExpr*test)
 
 void pform_start_generate_else(const struct vlltype&li)
 {
-      assert(pform_cur_generate);
-      assert(pform_cur_generate->scheme_type == PGenerate::GS_CONDIT);
+      ivl_assert(li, pform_cur_generate);
+      ivl_assert(li, pform_cur_generate->scheme_type == PGenerate::GS_CONDIT);
 
       PGenerate*cur = pform_cur_generate;
       pform_endgenerate(false);
@@ -1637,8 +1637,8 @@ void pform_start_generate_nblock(const struct vlltype&li, char*name)
  */
 void pform_generate_case_item(const struct vlltype&li, list<PExpr*>*expr_list)
 {
-      assert(pform_cur_generate);
-      assert(pform_cur_generate->scheme_type == PGenerate::GS_CASE);
+      ivl_assert(li, pform_cur_generate);
+      ivl_assert(li, pform_cur_generate->scheme_type == PGenerate::GS_CASE);
 
       PGenerate*gen = new PGenerate(lexical_scope, pform_cur_generate->id_number);
       lexical_scope = gen;
@@ -1662,7 +1662,7 @@ void pform_generate_case_item(const struct vlltype&li, list<PExpr*>*expr_list)
 		  pform_cur_generate->item_test[idx] = *expr_cur;
 		  ++ expr_cur;
 	    }
-	    assert(expr_cur == expr_list->end());
+	    ivl_assert(li, expr_cur == expr_list->end());
       }
 }
 
@@ -1856,9 +1856,9 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 		    list<string>*table, Statement*init_expr)
 {
       unsigned local_errors = 0;
-      assert(!parms->empty());
+      ivl_assert(loc, !parms->empty());
 
-      assert(decl);
+      ivl_assert(loc, decl);
 
 	/* Put the declarations into a map, so that I can check them
 	   off with the parameters in the list. If the port is already
@@ -1870,14 +1870,14 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	    perm_string port_name = (*decl)[idx]->basename();
 
 	    if (PWire*cur = defs[port_name]) {
-		  assert((*decl)[idx]);
+		  ivl_assert(loc, (*decl)[idx]);
 		  if ((*decl)[idx]->get_port_type() != NetNet::PIMPLICIT) {
 			bool rc = cur->set_port_type((*decl)[idx]->get_port_type());
-			assert(rc);
+			ivl_assert(loc, rc);
 		  }
 		  if ((*decl)[idx]->get_wire_type() != NetNet::IMPLICIT) {
 			bool rc = cur->set_wire_type((*decl)[idx]->get_wire_type());
-			assert(rc);
+			ivl_assert(loc, rc);
 		  }
 
 	    } else {
@@ -1913,7 +1913,7 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	      -- An input port is declared output.
 
 	*/
-      assert(pins.size() > 0);
+      ivl_assert(loc, pins.size() > 0);
       do {
 	    if (pins[0] == 0) {
 		  cerr << loc << ": error: "
@@ -1997,19 +1997,19 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
       verinum::V init = verinum::Vx;
       if (init_expr) {
 	      // XXXX
-	    assert(pins[0]->get_wire_type() == NetNet::REG);
+	    ivl_assert(loc, pins[0]->get_wire_type() == NetNet::REG);
 
 	    PAssign*pa = dynamic_cast<PAssign*>(init_expr);
-	    assert(pa);
+	    ivl_assert(*init_expr, pa);
 
 	    const PEIdent*id = dynamic_cast<const PEIdent*>(pa->lval());
-	    assert(id);
+	    ivl_assert(*init_expr, id);
 
 	      // XXXX
-	      //assert(id->name() == pins[0]->name());
+	      //ivl_assert(*init_expr, id->name() == pins[0]->name());
 
 	    const PENumber*np = dynamic_cast<const PENumber*>(pa->rval());
-	    assert(np);
+	    ivl_assert(*init_expr, np);
 
 	    init = np->value()[0];
       }
@@ -2064,12 +2064,12 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
         for (cur = parms->begin(), idx = 1
 		   ;  cur != parms->end()
 		   ;  idx += 1, ++ cur) {
-	      assert(idx < pins.size());
+	      ivl_assert(loc, idx < pins.size());
 	      pins[idx] = new PWire(*cur, NetNet::WIRE,
 				    NetNet::PINPUT);
 	      FILE_NAME(pins[idx], loc);
 	}
-	assert(idx == pins.size());
+	ivl_assert(loc, idx == pins.size());
       }
 
 	/* Verify the initial expression, if present, to be sure that
@@ -2078,19 +2078,19 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
       verinum::V init = verinum::Vx;
       if (init_expr) {
 	      // XXXX
-	    assert(pins[0]->get_wire_type() == NetNet::REG);
+	    ivl_assert(*init_expr, pins[0]->get_wire_type() == NetNet::REG);
 
 	    PAssign*pa = dynamic_cast<PAssign*>(init_expr);
-	    assert(pa);
+	    ivl_assert(*init_expr, pa);
 
 	    const PEIdent*id = dynamic_cast<const PEIdent*>(pa->lval());
-	    assert(id);
+	    ivl_assert(*init_expr, id);
 
 	      // XXXX
-	      //assert(id->name() == pins[0]->name());
+	      //ivl_assert(*init_expr, id->name() == pins[0]->name());
 
 	    const PENumber*np = dynamic_cast<const PENumber*>(pa->rval());
-	    assert(np);
+	    ivl_assert(*init_expr, np);
 
 	    init = np->value()[0];
       }
@@ -2110,8 +2110,8 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	    for (unsigned idx = 0 ;  idx < pins.size() ;  idx += 1)
 		  udp->ports[idx] = pins[idx]->basename();
 
-	    assert(udp);
-	    assert(table);
+	    ivl_assert(loc, udp);
+	    ivl_assert(loc, table);
 	    process_udp_table(udp, table, loc);
 	    udp->initial  = init;
 
@@ -2222,7 +2222,7 @@ void pform_makegates(const struct vlltype&loc,
 		     std::vector<lgate>*gates,
 		     list<named_pexpr_t>*attr)
 {
-      assert(! pform_cur_module.empty());
+      ivl_assert(loc, !pform_cur_module.empty());
       if (pform_cur_module.front()->program_block) {
 	    cerr << loc << ": error: Gates and switches may not be instantiated in "
 		 << "program blocks." << endl;
@@ -2365,7 +2365,7 @@ void pform_make_modgates(const struct vlltype&loc,
 	    delete gates;
 	    return;
       }
-      assert(! pform_cur_module.empty());
+      ivl_assert(loc, !pform_cur_module.empty());
 
 	// Detect some more realistic errors.
 
@@ -2449,7 +2449,7 @@ void pform_make_pgassign_list(const struct vlltype&loc,
 			      list<PExpr*>*del,
 			      struct str_pair_t str)
 {
-      assert(alist->size() % 2 == 0);
+      ivl_assert(loc, alist->size() % 2 == 0);
       while (! alist->empty()) {
 	    PExpr*lval = alist->front(); alist->pop_front();
 	    PExpr*rval = alist->front(); alist->pop_front();
@@ -2631,7 +2631,7 @@ PWire *pform_makewire(const vlltype&li, perm_string name, NetNet::Type type,
 {
       PWire*cur = pform_get_or_make_wire(li, name, type, NetNet::NOT_A_PORT,
 				         SR_NET);
-      assert(cur);
+      ivl_assert(li, cur);
 
       if (indices && !indices->empty())
 	    cur->set_unpacked_idx(*indices);
@@ -2725,8 +2725,8 @@ vector<pform_tf_port_t>*pform_make_task_ports(const struct vlltype&loc,
 				      list<pform_port_t>*ports,
 				      bool allow_implicit)
 {
-      assert(pt != NetNet::PIMPLICIT && pt != NetNet::NOT_A_PORT);
-      assert(ports);
+      ivl_assert(loc, pt != NetNet::PIMPLICIT && pt != NetNet::NOT_A_PORT);
+      ivl_assert(loc, ports);
 
       vector<pform_tf_port_t>*res = new vector<pform_tf_port_t>(0);
       PWSRType rt = SR_BOTH;
@@ -2969,7 +2969,7 @@ void pform_set_parameter(const struct vlltype&loc,
 void pform_set_specparam(const struct vlltype&loc, perm_string name,
 			 list<pform_range_t>*range, PExpr*expr)
 {
-      assert(! pform_cur_module.empty());
+      ivl_assert(loc, !pform_cur_module.empty());
       Module*scope = pform_cur_module.front();
       if (scope != lexical_scope) {
 	    delete range;
@@ -2977,7 +2977,7 @@ void pform_set_specparam(const struct vlltype&loc, perm_string name,
 	    return;
       }
 
-      assert(expr);
+      ivl_assert(loc, expr);
       Module::param_expr_t*parm = new Module::param_expr_t();
       FILE_NAME(parm, loc);
 
@@ -2988,7 +2988,7 @@ void pform_set_specparam(const struct vlltype&loc, perm_string name,
       parm->range = 0;
 
       if (range) {
-	    assert(range->size() == 1);
+	    ivl_assert(loc, range->size() == 1);
 	    parm->data_type = new vector_type_t(IVL_VT_LOGIC, false, range);
 	    parm->range = 0;
       }
@@ -3059,13 +3059,13 @@ extern PSpecPath* pform_make_specify_path(const struct vlltype&li,
       for (idx = 0, cur = src->begin() ;  cur != src->end() ;  ++ idx, ++ cur) {
 	    path->src[idx] = *cur;
       }
-      assert(idx == path->src.size());
+      ivl_assert(li, idx == path->src.size());
       delete src;
 
       for (idx = 0, cur = dst->begin() ;  cur != dst->end() ;  ++ idx, ++ cur) {
 	    path->dst[idx] = *cur;
       }
-      assert(idx == path->dst.size());
+      ivl_assert(li, idx == path->dst.size());
       delete dst;
 
       return path;
@@ -3088,7 +3088,7 @@ extern PSpecPath* pform_assign_path_delay(PSpecPath*path, list<PExpr*>*del)
       if (path == 0)
 	    return 0;
 
-      assert(path->delays.empty());
+      ivl_assert(*path, path->delays.empty());
 
       path->delays.resize(del->size());
       for (unsigned idx = 0 ;  idx < path->delays.size() ;  idx += 1) {
@@ -3116,7 +3116,7 @@ void pform_set_port_type(const struct vlltype&li,
 			 data_type_t*dt,
 			 list<named_pexpr_t>*attr)
 {
-      assert(pt != NetNet::PIMPLICIT && pt != NetNet::NOT_A_PORT);
+      ivl_assert(li, pt != NetNet::PIMPLICIT && pt != NetNet::NOT_A_PORT);
 
       vector_type_t *vt = dynamic_cast<vector_type_t*> (dt);
 
@@ -3165,7 +3165,7 @@ void pform_set_data_type(const struct vlltype&li, data_type_t*data_type,
 {
       if (data_type == 0) {
 	    VLerror(li, "internal error: data_type==0.");
-	    assert(0);
+	    ivl_assert(li, 0);
       }
 
       vector_type_t*vec_type = dynamic_cast<vector_type_t*> (data_type);

--- a/pform_disciplines.cc
+++ b/pform_disciplines.cc
@@ -23,6 +23,7 @@
 # include  "pform.h"
 # include  "parse_misc.h"
 # include  "discipline.h"
+# include  "ivl_assert.h"
 
 using namespace std;
 
@@ -103,7 +104,7 @@ void pform_start_discipline(const char*name)
 
 void pform_discipline_domain(const struct vlltype&loc, ivl_dis_domain_t use_domain)
 {
-      assert(use_domain != IVL_DIS_NONE);
+      ivl_assert(loc, use_domain != IVL_DIS_NONE);
 
       if (discipline_domain != IVL_DIS_NONE) {
 	    cerr << loc.text << ":" << loc.first_line << ": error: "
@@ -197,7 +198,7 @@ void pform_attach_discipline(const struct vlltype&loc,
 	    if (cur_net == 0) {
 		    /* Not declared yet, declare it now. */
 		  cur_net = pform_makewire(loc, *cur, NetNet::WIRE, 0);
-		  assert(cur_net);
+		  ivl_assert(loc, cur_net);
 	    }
 
 	    if (ivl_discipline_t tmp = cur_net->get_discipline()) {

--- a/pform_package.cc
+++ b/pform_package.cc
@@ -75,7 +75,7 @@ void pform_end_package_declaration(const struct vlltype&loc)
 PPackage *pform_find_potential_import(const struct vlltype&loc, LexicalScope*scope,
 				      perm_string name, bool tf_call, bool make_explicit)
 {
-      assert(scope);
+      ivl_assert(loc, scope);
 
       PPackage *found_pkg = nullptr;
       for (auto search_pkg : scope->potential_imports) {
@@ -217,7 +217,7 @@ static bool pform_package_exportable(const struct vlltype &loc, PPackage *pkg,
 
 void pform_package_export(const struct vlltype &loc, PPackage *pkg, const char *ident)
 {
-      assert(pform_cur_package);
+      ivl_assert(loc, pform_cur_package);
 
       perm_string use_ident;
       if (ident) {
@@ -231,7 +231,7 @@ void pform_package_export(const struct vlltype &loc, PPackage *pkg, const char *
 PExpr* pform_package_ident(const struct vlltype&loc,
 			   PPackage*pkg, pform_name_t*ident_name)
 {
-      assert(ident_name);
+      ivl_assert(loc, ident_name);
       PEIdent*tmp = new PEIdent(pkg, *ident_name);
       FILE_NAME(tmp, loc);
       return tmp;

--- a/pform_pclass.cc
+++ b/pform_pclass.cc
@@ -21,6 +21,7 @@
 # include  "pform.h"
 # include  "PClass.h"
 # include  "parse_misc.h"
+# include  "ivl_assert.h"
 
 using namespace std;
 
@@ -47,14 +48,14 @@ void pform_start_class_declaration(const struct vlltype&loc,
 {
       PClass*class_scope = pform_push_class_scope(loc, type->name);
       class_scope->type = type;
-      assert(pform_cur_class == 0);
+      ivl_assert(loc, pform_cur_class == 0);
       pform_cur_class = class_scope;
 
-      assert(type->base_type == 0);
+      ivl_assert(loc, type->base_type == 0);
       type->base_type.reset(base_type);
       type->virtual_class = virtual_class;
 
-      assert(type->base_args.empty());
+      ivl_assert(loc, type->base_args.empty());
       if (base_exprs) {
 	    for (list<PExpr*>::iterator cur = base_exprs->begin()
 		       ; cur != base_exprs->end() ; ++ cur) {
@@ -69,7 +70,7 @@ void pform_class_property(const struct vlltype&loc,
 			  data_type_t*data_type,
 			  list<decl_assignment_t*>*decls)
 {
-      assert(pform_cur_class);
+      ivl_assert(loc, pform_cur_class);
 
 	// Add the non-static properties to the class type
 	// object. Unwind the list of names to make a map of name to
@@ -118,7 +119,7 @@ void pform_set_this_class(const struct vlltype&loc, PTaskFunc*net)
 	// The pform_make_task_ports() function deletes the this_name
 	// object.
 
-      assert(this_port->at(0).defe == 0);
+      ivl_assert(loc, this_port->at(0).defe == 0);
       PWire*this_wire = this_port->at(0).port;
       delete this_port;
 
@@ -127,7 +128,7 @@ void pform_set_this_class(const struct vlltype&loc, PTaskFunc*net)
 
 void pform_set_constructor_return(PFunction*net)
 {
-      assert(pform_cur_class);
+      ivl_assert(*net, pform_cur_class);
       net->set_return(pform_cur_class->type);
 }
 
@@ -136,14 +137,14 @@ void pform_set_constructor_return(PFunction*net)
  */
 PFunction*pform_push_constructor_scope(const struct vlltype&loc)
 {
-      assert(pform_cur_class);
+      ivl_assert(loc, pform_cur_class);
       PFunction*func = pform_push_function_scope(loc, "new", LexicalScope::AUTOMATIC);
       return func;
 }
 
 void pform_end_class_declaration(const struct vlltype&loc)
 {
-      assert(pform_cur_class);
+      ivl_assert(loc, pform_cur_class);
 
 	// If there were initializer statements, then collect them
 	// into an implicit constructor function.

--- a/symbol_search.cc
+++ b/symbol_search.cc
@@ -107,7 +107,7 @@ bool symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 		  // Prefix is present, but is NOT a scope. Fail! Actually, this
 		  // should not happen, since this is the "not found" case, and we
 		  // should have returned already.
-		  assert(0);
+		  ivl_assert(*li, 0);
 		  return false;
 	    }
       }


### PR DESCRIPTION
`ivl_assert()` is similar to `assert()` except that it will also include source file and line information about the expression for which the assert was triggered.

Use `ivl_assert()` instead of `assert()` where the line information is available. This will generate better bug reports and make it easier to diagnose why an assert is triggered.