### PR TITLE
Make result of binary operations 2-state if inputs are 2-state

### DIFF
--- a/eval_tree.cc
+++ b/eval_tree.cc
@@ -807,7 +807,7 @@ NetEConst* NetEBLogic::eval_arguments_(const NetExpr*l, const NetExpr*r) const
 {
 	// NetEBLogic arguments should have already been reduced so real is not possible.
       ivl_assert(*this, (l->expr_type() != IVL_VT_REAL) && (r->expr_type() != IVL_VT_REAL));
-      ivl_assert(*this, expr_type() == IVL_VT_LOGIC);
+      ivl_assert(*this, expr_type() == IVL_VT_LOGIC || expr_type() == IVL_VT_BOOL);
 
       const NetEConst*lc = dynamic_cast<const NetEConst*>(l);
       const NetEConst*rc = dynamic_cast<const NetEConst*>(r);
@@ -943,7 +943,7 @@ NetExpr* NetEBMinMax::eval_tree_real_(const NetExpr*l, const NetExpr*r) const
 NetExpr* NetEBMinMax::eval_arguments_(const NetExpr*l, const NetExpr*r) const
 {
       if (expr_type() == IVL_VT_REAL) return eval_tree_real_(l,r);
-      ivl_assert(*this, expr_type() == IVL_VT_LOGIC);
+      ivl_assert(*this, expr_type() == IVL_VT_LOGIC || expr_type() == IVL_VT_BOOL);
 
       const NetEConst*lc = dynamic_cast<const NetEConst*>(l);
       const NetEConst*rc = dynamic_cast<const NetEConst*>(r);
@@ -996,7 +996,7 @@ NetExpr* NetEBMult::eval_tree_real_(const NetExpr*l, const NetExpr*r) const
 NetExpr* NetEBMult::eval_arguments_(const NetExpr*l, const NetExpr*r) const
 {
       if (expr_type() == IVL_VT_REAL) return eval_tree_real_(l,r);
-      ivl_assert(*this, expr_type() == IVL_VT_LOGIC);
+      ivl_assert(*this, expr_type() == IVL_VT_LOGIC || expr_type() == IVL_VT_BOOL);
 
       const NetEConst*lc = dynamic_cast<const NetEConst*>(l);
       const NetEConst*rc = dynamic_cast<const NetEConst*>(r);
@@ -1034,7 +1034,7 @@ NetExpr* NetEBPow::eval_tree_real_(const NetExpr*l, const NetExpr*r) const
 NetExpr* NetEBPow::eval_arguments_(const NetExpr*l, const NetExpr*r) const
 {
       if (expr_type() == IVL_VT_REAL) return eval_tree_real_(l,r);
-      ivl_assert(*this, expr_type() == IVL_VT_LOGIC);
+      ivl_assert(*this, expr_type() == IVL_VT_LOGIC || expr_type() == IVL_VT_BOOL);
 
       const NetEConst*lc = dynamic_cast<const NetEConst*>(l);
       const NetEConst*rc = dynamic_cast<const NetEConst*>(r);

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -111,15 +111,23 @@ NetEBAdd::~NetEBAdd()
 {
 }
 
+
+static ivl_variable_type_t arith_expr_type(const NetExpr *l, const NetExpr *r)
+{
+      if (l->expr_type() == IVL_VT_REAL ||
+          r->expr_type() == IVL_VT_REAL)
+	    return IVL_VT_REAL;
+
+      if (l->expr_type() == IVL_VT_LOGIC ||
+          r->expr_type() == IVL_VT_LOGIC)
+	    return IVL_VT_LOGIC;
+
+      return IVL_VT_BOOL;
+}
+
 ivl_variable_type_t NetEBAdd::expr_type() const
 {
-      if (left_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-
-      if (right_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-
-      return IVL_VT_LOGIC;
+      return arith_expr_type(left_, right_);
 }
 
 /*
@@ -171,6 +179,8 @@ ivl_variable_type_t NetEBDiv::expr_type() const
       if (right_->expr_type() == IVL_VT_REAL)
 	    return IVL_VT_REAL;
 
+      // div is always 4-state, even if both inputs are 2-state because division
+      // by 0 can yield 'x
       return IVL_VT_LOGIC;
 }
 
@@ -185,12 +195,7 @@ NetEBMinMax::~NetEBMinMax()
 
 ivl_variable_type_t NetEBMinMax::expr_type() const
 {
-      if (left_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-      if (right_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-
-      return IVL_VT_LOGIC;
+      return arith_expr_type(left_, right_);
 }
 
 NetEBMult::NetEBMult(char op__, NetExpr*l, NetExpr*r, unsigned wid, bool signed_flag)
@@ -204,13 +209,7 @@ NetEBMult::~NetEBMult()
 
 ivl_variable_type_t NetEBMult::expr_type() const
 {
-      if (left_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-
-      if (right_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-
-      return IVL_VT_LOGIC;
+      return arith_expr_type(left_, right_);
 }
 
 NetEBPow::NetEBPow(char op__, NetExpr*l, NetExpr*r, unsigned wid, bool signed_flag)
@@ -224,12 +223,7 @@ NetEBPow::~NetEBPow()
 
 ivl_variable_type_t NetEBPow::expr_type() const
 {
-      if (right_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-      if (left_->expr_type() == IVL_VT_REAL)
-	    return IVL_VT_REAL;
-
-      return IVL_VT_LOGIC;
+      return arith_expr_type(left_, right_);
 }
 
 NetEBShift::NetEBShift(char op__, NetExpr*l, NetExpr*r, unsigned wid, bool signed_flag)
@@ -244,6 +238,15 @@ NetEBShift::~NetEBShift()
 bool NetEBShift::has_width() const
 {
       return left_->has_width();
+}
+
+ivl_variable_type_t NetEBShift::expr_type() const
+{
+      if (left_->expr_type() == IVL_VT_LOGIC ||
+          right_->expr_type() == IVL_VT_LOGIC)
+	    return IVL_VT_LOGIC;
+
+      return IVL_VT_BOOL;
 }
 
 NetEConcat::NetEConcat(unsigned cnt, unsigned r, ivl_variable_type_t vt)

--- a/netlist.cc
+++ b/netlist.cc
@@ -2257,6 +2257,15 @@ NetEBBits::~NetEBBits()
 {
 }
 
+ivl_variable_type_t NetEBBits::expr_type() const
+{
+      if (left_->expr_type() == IVL_VT_LOGIC ||
+          right_->expr_type() == IVL_VT_LOGIC)
+	    return IVL_VT_LOGIC;
+
+      return IVL_VT_BOOL;
+}
+
 NetEBinary::NetEBinary(char op__, NetExpr*l, NetExpr*r, unsigned wid, bool signed_flag)
 : op_(op__), left_(l), right_(r)
 {
@@ -2282,6 +2291,15 @@ NetEBLogic::NetEBLogic(char op__, NetExpr*l, NetExpr*r)
 
 NetEBLogic::~NetEBLogic()
 {
+}
+
+ivl_variable_type_t NetEBLogic::expr_type() const
+{
+      if (left_->expr_type() == IVL_VT_LOGIC ||
+          right_->expr_type() == IVL_VT_LOGIC)
+	    return IVL_VT_LOGIC;
+
+      return IVL_VT_BOOL;
 }
 
 NetEConst::NetEConst(const verinum&val)

--- a/netlist.h
+++ b/netlist.h
@@ -4248,6 +4248,8 @@ class NetEBBits : public NetEBinary {
       virtual NetEBBits* dup_expr() const;
       virtual NetNet* synthesize(Design*, NetScope*scope, NetExpr*root);
 
+      ivl_variable_type_t expr_type() const override;
+
     private:
       NetEConst* eval_arguments_(const NetExpr*l, const NetExpr*r) const;
 };
@@ -4308,6 +4310,8 @@ class NetEBLogic : public NetEBinary {
 
       virtual NetEBLogic* dup_expr() const;
       virtual NetNet* synthesize(Design*, NetScope*scope, NetExpr*root);
+
+      ivl_variable_type_t expr_type() const override;
 
     private:
       NetEConst* eval_arguments_(const NetExpr*l, const NetExpr*r) const;
@@ -4391,6 +4395,8 @@ class NetEBShift : public NetEBinary {
 
       virtual NetEBShift* dup_expr() const;
       virtual NetNet* synthesize(Design*, NetScope*scope, NetExpr*root);
+
+      ivl_variable_type_t expr_type() const override;
 
     private:
       NetEConst* eval_arguments_(const NetExpr*l, const NetExpr*r) const;

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -884,8 +884,8 @@ static int show_stmt_assign_sig_string(ivl_statement_t net)
 	    return 0;
       }
 
-      assert(ivl_expr_width(rval)==8);
       draw_eval_vec4(rval);
+      resize_vec4_wid(rval, 8);
 
 	/* Calculate the character select for the word. */
       int mux_word = allocate_word();


### PR DESCRIPTION
The are many binary operations where if the two operands are 2-state the result is guaranteed to be 2-state.

This is true for all arithmetic operation with the exception of division where division by 0 will always result in 'x even if the inputs are both 2-state.

The same is true for all binary bitwise operators as well as the binary logical operators.

Having the expression type be 2-state avoids some unnecessary %cast2 instructions that would otherwise get inserted when assigning the result to a 2-state variable.

E.g without this change the following will result in

```
  int a, b, c;
  b = a + b;
```

will result in

```
  %load/vec4 ...;
  %load/vec4 ...;
  %add;
  %cast2;
  %store/vec4 ...;
```

For binary comparison operators this is already handled.