### PR TITLE
Add initial support for array assignment patterns

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -222,8 +222,13 @@ class PEAssignPattern : public PExpr {
       NetExpr* elaborate_expr_struct_(Design *des, NetScope *scope,
 				      const netstruct_t *struct_type,
 				      bool need_const) const;
-      NetExpr* elaborate_expr_darray_(Design *des, NetScope *scope,
-				      const netdarray_t *array_type,
+      NetExpr* elaborate_expr_array_(Design *des, NetScope *scope,
+				     const netarray_t *array_type,
+				     bool need_const, bool up) const;
+      NetExpr* elaborate_expr_uarray_(Design *des, NetScope *scope,
+				      const netuarray_t *uarray_type,
+				      const std::vector<netrange_t> &dims,
+				      unsigned int cur_dim,
 				      bool need_const) const;
 
     private:

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -242,8 +242,12 @@ NetAssign_*PEIdent::elaborate_lval_var_(Design *des, NetScope *scope,
 	// is less than the array dimensions (unpacked).
       if (reg->unpacked_dimensions() > name_tail.index.size()) {
 	    if (gn_system_verilog()) {
-		  cerr << get_fileline() << ": sorry: Assignment to an entire"
-		        " array or to an array slice is not yet supported."
+		  if (name_tail.index.empty()) {
+			NetAssign_*lv = new NetAssign_(reg);
+			return lv;
+		  }
+		  cerr << get_fileline() << ": sorry: Assignment to an "
+		        " array slice is not yet supported."
 		       << endl;
 	    } else {
 		  cerr << get_fileline() << ": error: Assignment to an entire"

--- a/ivtest/ivltests/sv_ap_uarray1.v
+++ b/ivtest/ivltests/sv_ap_uarray1.v
@@ -1,0 +1,44 @@
+// Check that procedural assignment of unpacked array assignment patterns is
+// supported and a entries are assigned in the right order.
+
+module test;
+
+  bit failed;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  int x[3:0];
+  int y[0:3];
+  int z[4];
+
+  initial begin
+    x = '{1'b1, 1 + 1, 3.3, "TEST"};
+    y = '{1'b1, 1 + 1, 3.3, "TEST"};
+    z = '{1'b1, 1 + 1, 3.3, "TEST"};
+
+    `check(x[0], 1413829460);
+    `check(x[1], 3);
+    `check(x[2], 2);
+    `check(x[3], 1);
+
+    `check(y[0], 1);
+    `check(y[1], 2);
+    `check(y[2], 3);
+    `check(y[3], 1413829460);
+
+    `check(z[0], 1);
+    `check(z[1], 2);
+    `check(z[2], 3);
+    `check(z[3], 1413829460);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray2.v
+++ b/ivtest/ivltests/sv_ap_uarray2.v
@@ -1,0 +1,45 @@
+// Check that procedural assignment of unpacked array assignment patterns to
+// multi-dimensional arrays is supported and entries are assigned in the right
+// order.
+
+module test;
+
+  bit failed;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  int x[1:0][1:0];
+  int y[1:0][0:1];
+  int z[2][2];
+
+  initial begin
+    x = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+    y = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+    z = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+
+    `check(x[0][0], 1413829460);
+    `check(x[0][1], 3);
+    `check(x[1][0], 2);
+    `check(x[1][1], 1);
+
+    `check(y[0][0], 3);
+    `check(y[0][1], 1413829460);
+    `check(y[1][0], 1);
+    `check(y[1][1], 2);
+
+    `check(z[0][0], 1);
+    `check(z[0][1], 2);
+    `check(z[1][0], 3);
+    `check(z[1][1], 1413829460);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray3.v
+++ b/ivtest/ivltests/sv_ap_uarray3.v
@@ -1,0 +1,44 @@
+// Check that continuous assignment of unpacked array assignment patterns is
+// supported and entries are assigned in the right order.
+
+module test;
+
+  bit failed;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  int x[3:0];
+  int y[0:3];
+  int z[4];
+
+  assign x = '{1'b1, 1 + 1, 3.3, "TEST"};
+  assign y = '{1'b1, 1 + 1, 3.3, "TEST"};
+  assign z = '{1'b1, 1 + 1, 3.3, "TEST"};
+
+  initial begin
+    `check(x[0], 1413829460);
+    `check(x[1], 3);
+    `check(x[2], 2);
+    `check(x[3], 1);
+
+    `check(y[0], 1);
+    `check(y[1], 2);
+    `check(y[2], 3);
+    `check(y[3], 1413829460);
+
+    `check(z[0], 1);
+    `check(z[1], 2);
+    `check(z[2], 3);
+    `check(z[3], 1413829460);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray4.v
+++ b/ivtest/ivltests/sv_ap_uarray4.v
@@ -1,0 +1,45 @@
+// Check that continuous assignment of unpacked array assignment patterns to
+// multi-dimensional arrays is supported and entries are assigned in the right
+// order.
+
+module test;
+
+  bit failed;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  int x[1:0][1:0];
+  int y[1:0][0:1];
+  int z[2][2];
+
+  assign x = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+  assign y = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+  assign z = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+
+  initial begin
+    `check(x[0][0], 1413829460);
+    `check(x[0][1], 3);
+    `check(x[1][0], 2);
+    `check(x[1][1], 1);
+
+    `check(y[0][0], 3);
+    `check(y[0][1], 1413829460);
+    `check(y[1][0], 1);
+    `check(y[1][1], 2);
+
+    `check(z[0][0], 1);
+    `check(z[0][1], 2);
+    `check(z[1][0], 3);
+    `check(z[1][1], 1413829460);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray5.v
+++ b/ivtest/ivltests/sv_ap_uarray5.v
@@ -1,0 +1,45 @@
+// Check that procedural assignment of unpacked real array assignment patterns
+// to multi-dimensional arrays is supported and entries are assigned in the
+// right order.
+
+module test;
+
+  bit failed;
+
+  `define check(val, exp) do \
+    if (val != exp) begin \
+      $display("FAILED(%0d). '%s' expected %0f, got %0f", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  real x[1:0][1:0];
+  real y[1:0][0:1];
+  real z[2][2];
+
+  initial begin
+    x = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+    y = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+    z = '{'{1'b1, 1 + 1}, '{3.3, "TEST"}};
+
+    `check(x[0][0], 1413829460.0);
+    `check(x[0][1], 3.3);
+    `check(x[1][0], 2.0);
+    `check(x[1][1], 1.0);
+
+    `check(y[0][1], 1413829460.0);
+    `check(y[0][0], 3.3);
+    `check(y[1][1], 2.0);
+    `check(y[1][0], 1.0);
+
+    `check(z[0][0], 1.0);
+    `check(z[0][1], 2.0);
+    `check(z[1][0], 3.3);
+    `check(z[1][1], 1413829460.0);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray6.v
+++ b/ivtest/ivltests/sv_ap_uarray6.v
@@ -1,0 +1,45 @@
+// Check that procedural assignment of unpacked string array assignment patterns
+// to multi-dimensional arrays is supported and entries are assigned in the
+// right order.
+
+module test;
+
+  bit failed;
+
+  `define check(val, exp) do \
+    if (val != exp) begin \
+      $display("FAILED(%0d). '%s' expected %s, got %s", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  string x[1:0][1:0];
+  string y[1:0][0:1];
+  string z[2][2];
+
+  initial begin
+    x = '{'{"Hello", "World"}, '{"Array", "Pattern"}};
+    y = '{'{"Hello", "World"}, '{"Array", "Pattern"}};
+    z = '{'{"Hello", "World"}, '{"Array", "Pattern"}};
+
+    `check(x[0][0], "Pattern");
+    `check(x[0][1], "Array");
+    `check(x[1][0], "World");
+    `check(x[1][1], "Hello");
+
+    `check(y[0][0], "Array");
+    `check(y[0][1], "Pattern");
+    `check(y[1][0], "Hello");
+    `check(y[1][1], "World");
+
+    `check(z[0][0], "Hello");
+    `check(z[0][1], "World");
+    `check(z[1][0], "Array");
+    `check(z[1][1], "Pattern");
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray_fail1.v
+++ b/ivtest/ivltests/sv_ap_uarray_fail1.v
@@ -1,0 +1,13 @@
+// Check that an unpacked array assignment pattern with too many elements
+// results in an error.
+
+module test;
+
+  int x[1:0];
+
+  initial begin
+    x = '{1, 2, 3}; // Should fail, more elements in assignment pattern than
+                    // array size.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray_fail2.v
+++ b/ivtest/ivltests/sv_ap_uarray_fail2.v
@@ -1,0 +1,13 @@
+// Check that an unpacked array assignment pattern with not enough elements
+// results in an error.
+
+module test;
+
+  int x[1:0];
+
+  initial begin
+    x = '{1}; // Should fail, less elements in assignment pattern than array
+              // size.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_array_assign_fail1.v
+++ b/ivtest/ivltests/sv_array_assign_fail1.v
@@ -1,0 +1,13 @@
+// Check that trying to do a procedural assign of a scalar to an array results
+// in an error.
+
+module test;
+
+  integer x[1:0];
+
+  initial begin
+    x = 10; // Error, scalar assigned to array
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_array_assign_fail2.v
+++ b/ivtest/ivltests/sv_array_assign_fail2.v
@@ -1,0 +1,14 @@
+// Check that trying to do a continuous assign of a scalar to an array results
+// in an error.
+
+module test;
+
+  integer x[1:0];
+
+  assign x = 10; // Error, scalar assigned to array
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -45,6 +45,14 @@ pv_wr_fn_vec2			vvp_tests/pv_wr_fn_vec2.json
 pv_wr_fn_vec4			vvp_tests/pv_wr_fn_vec4.json
 struct_packed_write_read	vvp_tests/struct_packed_write_read.json
 struct_packed_write_read2	vvp_tests/struct_packed_write_read2.json
+sv_ap_uarray1			vvp_tests/sv_ap_uarray1.json
+sv_ap_uarray2			vvp_tests/sv_ap_uarray2.json
+sv_ap_uarray3			vvp_tests/sv_ap_uarray3.json
+sv_ap_uarray4			vvp_tests/sv_ap_uarray4.json
+sv_ap_uarray5			vvp_tests/sv_ap_uarray5.json
+sv_ap_uarray6			vvp_tests/sv_ap_uarray6.json
+sv_ap_uarray_fail1		vvp_tests/sv_ap_uarray_fail1.json
+sv_ap_uarray_fail2		vvp_tests/sv_ap_uarray_fail2.json
 sv_array_cassign6		vvp_tests/sv_array_cassign6.json
 sv_array_cassign7		vvp_tests/sv_array_cassign7.json
 sv_foreach9			vvp_tests/sv_foreach9.json

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -53,6 +53,8 @@ sv_ap_uarray5			vvp_tests/sv_ap_uarray5.json
 sv_ap_uarray6			vvp_tests/sv_ap_uarray6.json
 sv_ap_uarray_fail1		vvp_tests/sv_ap_uarray_fail1.json
 sv_ap_uarray_fail2		vvp_tests/sv_ap_uarray_fail2.json
+sv_array_assign_fail1	vvp_tests/sv_array_assign_fail1.json
+sv_array_assign_fail2	vvp_tests/sv_array_assign_fail2.json
 sv_array_cassign6		vvp_tests/sv_array_cassign6.json
 sv_array_cassign7		vvp_tests/sv_array_cassign7.json
 sv_foreach9			vvp_tests/sv_foreach9.json

--- a/ivtest/vvp_tests/sv_ap_uarray1.json
+++ b/ivtest/vvp_tests/sv_ap_uarray1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray2.json
+++ b/ivtest/vvp_tests/sv_ap_uarray2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray3.json
+++ b/ivtest/vvp_tests/sv_ap_uarray3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray4.json
+++ b/ivtest/vvp_tests/sv_ap_uarray4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray5.json
+++ b/ivtest/vvp_tests/sv_ap_uarray5.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray5.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray6.json
+++ b/ivtest/vvp_tests/sv_ap_uarray6.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray6.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray_fail1.json
+++ b/ivtest/vvp_tests/sv_ap_uarray_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_ap_uarray_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_ap_uarray_fail2.json
+++ b/ivtest/vvp_tests/sv_ap_uarray_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_ap_uarray_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_array_assign_fail1.json
+++ b/ivtest/vvp_tests/sv_array_assign_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_array_assign_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_array_assign_fail2.json
+++ b/ivtest/vvp_tests/sv_array_assign_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_array_assign_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/net_assign.cc
+++ b/net_assign.cc
@@ -149,11 +149,10 @@ ivl_type_t NetAssign_::net_type() const
       } else {
 	    ivl_assert(*this, sig_);
 
-	      // We don't have types for array signals yet.
 	    if (sig_->unpacked_dimensions() && !word_)
-		  return nullptr;
-
-	    ntype = sig_->net_type();
+		  ntype = sig_->array_type();
+	    else
+		  ntype = sig_->net_type();
       }
 
       if (!member_.nil()) {

--- a/net_expr.cc
+++ b/net_expr.cc
@@ -401,7 +401,13 @@ NetEProperty::NetEProperty(NetNet*net, size_t pidx, NetExpr*idx)
       ivl_assert(*this, use_type);
 
       ivl_type_t prop_type = use_type->get_prop_type(pidx_);
-      set_net_type(prop_type);
+      if (idx) {
+	    auto array_type = dynamic_cast<const netarray_t*>(prop_type);
+	    ivl_assert(*this, array_type);
+	    set_net_type(array_type->element_type());
+      } else {
+	    set_net_type(prop_type);
+      }
 }
 
 NetEProperty::~NetEProperty()

--- a/netlist.cc
+++ b/netlist.cc
@@ -598,6 +598,9 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
 
       initialize_dir_();
 
+      if (!unpacked_dims_.empty())
+	    array_type_ = new netuarray_t(unpacked_dims_, net_type_);
+
       s->add_signal(this);
 }
 
@@ -731,6 +734,14 @@ const netqueue_t* NetNet::queue_type(void) const
 const netclass_t* NetNet::class_type(void) const
 {
       return dynamic_cast<const netclass_t*> (net_type_);
+}
+
+const netarray_t* NetNet::array_type() const
+{
+      if (array_type_)
+	    return array_type_;
+
+      return darray_type();
 }
 
 /*

--- a/netlist.h
+++ b/netlist.h
@@ -709,6 +709,7 @@ class NetNet  : public NetObj, public PortType {
       const netdarray_t*darray_type(void) const;
       const netqueue_t*queue_type(void) const;
       const netclass_t*class_type(void) const;
+      const netarray_t*array_type(void) const;
 
 	/* Attach a discipline to the net. */
       ivl_discipline_t get_discipline() const;
@@ -803,6 +804,7 @@ class NetNet  : public NetObj, public PortType {
       PortType port_type_ : 3;
       bool local_flag_: 1;
       ivl_type_t net_type_;
+      netuarray_t *array_type_ = nullptr;
       ivl_discipline_t discipline_;
 
       std::vector<netrange_t> unpacked_dims_;

--- a/netlist.h
+++ b/netlist.h
@@ -86,6 +86,7 @@ struct enum_type_t;
 class netclass_t;
 class netdarray_t;
 class netparray_t;
+class netuarray_t;
 class netqueue_t;
 class netenum_t;
 class netstruct_t;
@@ -2106,6 +2107,7 @@ class NetEArrayPattern  : public NetExpr {
       NetEArrayPattern* dup_expr() const;
       NexusSet* nex_input(bool rem_out = true, bool always_sens = false,
                           bool nested_func = false) const;
+      NetNet* synthesize(Design *des, NetScope *scope, NetExpr *root);
 
     private:
       std::vector<NetExpr*> items_;

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -986,7 +986,23 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 
       ivl_variable_type_t cast_type = ivl_type_base(lv_net_type);
       ivl_variable_type_t expr_type = tmp->expr_type();
-      if ((cast_type != IVL_VT_NO_TYPE) && (cast_type != expr_type)) {
+
+      bool compatible;
+        // For arrays we need strict type checking here. Long term strict type
+	// checking should be used for all expressions, but at the moment not
+	// all expressions do have a ivl_type_t attached to it.
+      if (dynamic_cast<const netuarray_t*>(lv_net_type)) {
+	    if (tmp->net_type())
+		  compatible = lv_net_type->type_compatible(tmp->net_type());
+	    else
+		  compatible = false;
+      } else if (cast_type == IVL_VT_NO_TYPE) {
+	    compatible = true;
+      } else {
+	    compatible = cast_type == expr_type;
+      }
+
+      if (!compatible) {
 	      // Catch some special cases.
 	    switch (cast_type) {
 		case IVL_VT_DARRAY:


### PR DESCRIPTION
SystemVerilog allows to use assignment patterns to assign values to an
array. E.g. `int a[4] = '{1, 2, 3, 4}`.

Each value is evaluated in the context of the element type of the array.

Nested assignment patterns are supported. E.g. `int a[2][2] = '{'{1, 2},
'{1, 2}};`

Add initial support for array assignment patterns for both continuous as
well as procedural assignments.

For continuous assignments the assignment pattern is synthesized into an
array of nets. Each pin is connected to one of the assignment pattern
values and then the whole net array is connected to target array.

For procedural assignments it is unrolled in the vvp backend. E.g
effectively turning `a = '{1, 2};` into `a[0] = 1; a[1] = 2;`.

Not yet supported are indexed initializers or `default`.
E.g. `int a[10] = '{1:10, default: 20};`

Resolves #562