### PR TITLE
ci: Switch to checkout@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     name: '🍏 macOS'
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |
@@ -48,7 +48,7 @@ jobs:
     name: '🐧 Ubuntu ${{ matrix.os }}'
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |
@@ -90,7 +90,7 @@ jobs:
     - run: git config --global core.autocrlf input
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
The currently used checkout@v2 CI step shows the following deprecation warning

```
Node.js 12 actions are deprecated. Please update the following actions to
use Node.js 16: actions/checkout@v2. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Github has announced that this will eventually stop working somewhen in mid 2023.

Switch to checkout@v3 which uses Node.js 16 to avoid the ci from breaking in the near future.