### PR TITLE
Support initializer expression for unpacked array port declarations 

### DIFF
--- a/ivtest/ivltests/module_output_port_list_def.v
+++ b/ivtest/ivltests/module_output_port_list_def.v
@@ -2,7 +2,7 @@
 // output port declaration list.
 
 module M (
-  output [31:0] x = 1, y = 2
+  output reg [31:0] x = 1, y = 2
 );
 
   `define check(val, exp) \

--- a/ivtest/ivltests/module_port_array_init1.v
+++ b/ivtest/ivltests/module_port_array_init1.v
@@ -1,0 +1,23 @@
+// Check that initializers values are supported for module array ports
+
+module M (
+  input [31:0] x[0:1] = '{1, 2},
+  output reg [31:0] y[0:1] = '{3, 4}
+);
+
+  initial begin
+    #1
+    if (x[0] === 1 && x[1] === 2 && y[0] === 3 && y[1] === 4) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule
+
+module test;
+
+  M i_m ();
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -35,6 +35,7 @@ memsynth1			vvp_tests/memsynth1.json
 module_ordered_list1		vvp_tests/module_ordered_list1.json
 module_ordered_list2		vvp_tests/module_ordered_list2.json
 module_port_array1		vvp_tests/module_port_array1.json
+module_port_array_init1		vvp_tests/module_port_array_init1.json
 param-width			vvp_tests/param-width.json
 param-width-vlog95		vvp_tests/param-width-vlog95.json
 pr1388974			vvp_tests/pr1388974.json

--- a/ivtest/vvp_tests/module_port_array_init1.json
+++ b/ivtest/vvp_tests/module_port_array_init1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "module_port_array_init1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
At the moment there are two rules for port declarations. One that allows
the port to be declared as an unpacked array, the other that allows to
specify an initializer expression.

SystemVerilog allows both to be specified in the same port declaration. Add
support for this to the parser.