### PR TITLE
Fix bit select on signed multi-dimensional packed array

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -4321,12 +4321,7 @@ unsigned PEIdent::test_width(Design*des, NetScope*scope, width_mode_t&mode)
 		const index_component_t&index_tail = name_tail.index.back();
 		ivl_assert(*this, index_tail.msb);
 	      }
-		// If we have a net in hand, then we can predict what the
-		// slice width will be. If not, then assume it will be a
-		// simple bit select. If the net only has a single dimension
-		// then this is still a simple bit select.
-	      if ((sr.net == 0) || (sr.net->packed_dimensions() <= 1))
-		    use_width = 1;
+	      use_width = 1;
 	      break;
 	  case index_component_t::SEL_BIT_LAST:
 	    if (debug_elaborate) {

--- a/ivtest/ivltests/bitsel11.v
+++ b/ivtest/ivltests/bitsel11.v
@@ -1,0 +1,63 @@
+// Check that element and bit select on multi-dimensional signed packed arrays
+// are unsigned.
+
+module test;
+
+  bit failed = 1'b0;
+
+`define check(val, exp) do begin \
+    if (val !== exp) begin \
+      $display("FAILED(%0d): Expected `%b`, got `%b`.", `__LINE__, exp, val); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  reg signed [3:0][3:0] arr;
+  integer idx;
+  reg [7:0] x;
+  reg [3:0] y;
+  reg [31:0] z;
+
+  initial begin
+    // Set lowest element to all 1
+    arr = 16'hffff;
+
+    // Elements of a signed packed array are unsigned, no sign extensions
+    idx = 0;
+    x = arr[idx];
+    `check(x, 8'h0f);
+
+    // Out-of-bounds
+    idx = -1;
+    x = arr[idx];
+    `check(x, 8'h0x);
+
+    // Undefined
+    idx = 'bx;
+    x = arr[idx];
+    `check(x, 8'h0x);
+
+    // Bit selects on a signed packed array are unsigned, no sign extensions
+    idx = 0;
+    y = arr[0][idx];
+    `check(y, 4'b0001);
+
+    // Out-of-bounds
+    idx = -1;
+    y = arr[0][idx];
+    `check(y, 4'b000x);
+
+    // Undefined
+    idx = 'bx;
+    y = arr[0][idx];
+    `check(y, 4'b000x);
+
+    // The array as a primary is signed, sign extension
+    z = arr;
+    `check(z, 32'hffffffff);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -3,6 +3,7 @@
 # describes the test.
 
 array_packed_write_read		vvp_tests/array_packed_write_read.json
+bitsel11			vvp_tests/bitsel11.json
 br_gh13a			vvp_tests/br_gh13a.json
 br_gh13a-vlog95			vvp_tests/br_gh13a-vlog95.json
 br_gh939			vvp_tests/br_gh939.json

--- a/ivtest/vvp_tests/bitsel11.json
+++ b/ivtest/vvp_tests/bitsel11.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "bitsel11.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
Bit selects on packed arrays are always unsigned and have a width of 1.
Element selects on a multi-dimensional packed array are always unsigned and
have the width of the element.

At the moment a element or bit select on the last level element of a
multi-dimensional signed array will incorrectly yield a signed expression.

Commit 40b36337e2c8 ("Fix some bugs with packed array dimensions") added
some special checks to fix the width on multi-dimensional array element
selects. But this removed the unsigned attribute from bit selects.

Commit 81947edaa5e9 ("A bit select is not the same as selecting part of a
packed array") fixed this for single dimensional packed array, but left it
broken for multi-dimensional arrays.

Commit 7c024d6cab16 ("Fix width calculation for bit/part selects of
multi-dimensioned packed arrays.") added some additional fixes for the
width calculation, which make the special checks in the first commit
unnecessary.

We can now remove those checks which will give us the correct behavior in
terms of the signedness of bit and element selects on both single- and
multi-dimensional packed arrays.