### PR TITLE
 Support SystemVerilog style partial ANSI port declarations

### DIFF
--- a/ivtest/ivltests/sv_module_port1.v
+++ b/ivtest/ivltests/sv_module_port1.v
@@ -1,0 +1,33 @@
+// Check that partial module ANSI port declarations are supported. Check that it
+// is possible to redefine the data type only.
+
+module test (input [3:0] a, [1:0] b, integer c, wire d);
+
+  bit failed = 1'b0;
+
+`define check(val, exp) do begin \
+    if ((val) !== (exp)) begin \
+      $display("FAILED(%0d): Expected `%d`, got `%d`.", `__LINE__, \
+               (exp), (val)); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  initial begin
+    `check($bits(a), 4);
+    `check($bits(b), 2);
+    `check($bits(c), $bits(integer));
+    `check($bits(d), 1);
+
+    // They should all be wires
+    `check(a, 'z);
+    `check(b, 'z);
+    `check(c, 'z);
+    `check(d, 'z);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_module_port2.v
+++ b/ivtest/ivltests/sv_module_port2.v
@@ -1,0 +1,29 @@
+// Check that partial module ANSI port declarations are supported. Check that it
+// is possible to redefine the unpacked dimensions only.
+
+module test (input integer a, b[1:0], c[2:0][3:0]);
+
+  bit failed = 1'b0;
+
+`define check(val, exp) do begin \
+    if ((val) !== (exp)) begin \
+      $display("FAILED(%0d): Expected `%d`, got `%d`.", `__LINE__, \
+               (exp), (val)); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  initial begin
+    `check($dimensions(a), 1);
+    `check($dimensions(b), 2);
+    `check($dimensions(c), 3);
+    `check($bits(a), $bits(integer));
+    `check($bits(b), $bits(integer) * 2);
+    `check($bits(c), $bits(integer) * 3 * 4);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_module_port3.v
+++ b/ivtest/ivltests/sv_module_port3.v
@@ -1,0 +1,49 @@
+// Check that it is possible to declare module ports without specifing the
+// direction.
+
+bit failed = 1'b0;
+
+`define check(val, exp) do begin \
+    if ((val) !== (exp)) begin \
+      $display("FAILED(%0d): Expected `%d`, got `%d`.", `__LINE__, \
+               (exp), (val)); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+// All ports should be inout if no direction is specified
+module M (wire [31:0] a, b, c);
+
+  assign c = a ^ b;
+
+  initial begin
+    `check($bits(a), 32);
+    `check($bits(b), 32);
+    `check($bits(c), 32);
+  end
+
+endmodule
+
+module test;
+
+  wire [31:0] a, b, c;
+
+  M i_m (a, b, c);
+
+  `define A 'h01234567
+  `define B 'hfedcba98
+
+  assign a = `A;
+  assign b = `B;
+
+  initial begin
+    #1
+
+    `check(c, `A ^ `B);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_module_port4.v
+++ b/ivtest/ivltests/sv_module_port4.v
@@ -1,0 +1,38 @@
+// Check that partial module ANSI port declarations are supported. Check that it
+// is possible to redefine the port kind only.
+
+
+
+module test(
+  output [3:0] a,
+  var b, c,
+  wire d);
+
+  bit failed = 1'b0;
+
+`define check(val, exp) do begin \
+    if ((val) !== (exp)) begin \
+      $display("FAILED(%0d): Expected `%d`, got `%d`.", `__LINE__, \
+               (exp), (val)); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  initial begin
+    `check($bits(a), 4);
+    `check($bits(b), 1);
+    `check($bits(c), 1);
+    `check($bits(d), 1);
+
+    // a and d are wires, b and c are variables
+    `check(a, 4'bzzzz);
+    `check(b, 1'bx);
+    `check(c, 1'bx);
+    `check(d, 1'bz);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -62,6 +62,10 @@ sv_array_cassign6		vvp_tests/sv_array_cassign6.json
 sv_array_cassign7		vvp_tests/sv_array_cassign7.json
 sv_foreach9			vvp_tests/sv_foreach9.json
 sv_foreach10			vvp_tests/sv_foreach10.json
+sv_module_port1			vvp_tests/sv_module_port1.json
+sv_module_port2			vvp_tests/sv_module_port2.json
+sv_module_port3			vvp_tests/sv_module_port3.json
+sv_module_port4			vvp_tests/sv_module_port4.json
 sv_wildcard_import8		vvp_tests/sv_wildcard_import8.json
 sdf_header			vvp_tests/sdf_header.json
 task_return1			vvp_tests/task_return1.json

--- a/ivtest/vvp_tests/sv_module_port1.json
+++ b/ivtest/vvp_tests/sv_module_port1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_module_port1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_module_port2.json
+++ b/ivtest/vvp_tests/sv_module_port2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_module_port2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_module_port3.json
+++ b/ivtest/vvp_tests/sv_module_port3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_module_port3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_module_port4.json
+++ b/ivtest/vvp_tests/sv_module_port4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_module_port4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
In Verilog it is possible to declare multiple ports as part of the same
port declaration. Ports declared this way all have same direction, signal
kind and data type. E.g.

```SystemVerilog
module M (input [3:0] a, b, c); ...
```

SystemVerilog extends this and allows to override on a per port basis
certain port attributes. E.g. redefine just the data type

```SystemVerilog
module test (input [3:0] a, [1:0] b, int c); ...
```

Or to just redefine the port kind

```SystemVerilog
module test(input [3:0] a, var b, wire c); ...
```

It is even possible to leave out the direction for the very first port. As
long as at least one other property of the port is specified. In that case
the direction will default to `inout`. E.g.

```SystemVerilog
module test(integer a, b, c); ...
```

Furthermore it is possible to specify unpacked dimensions for each of the
ports. E.g.

```SystemVerilog
module test(input integer a, b[1:0], c[3:0][1:0]); ...
```

If all port properties are omitted for the first port this indicates the
start of a non-ANSI port list.

Extend the parser to handle this.

If all three direction, port kind and data type are omitted they are
inherited from the previous port. Otherwise

 * If the direction is omitted it is inherited from the previous port.
 * If the data type is omitted it defaults to logic.
 * If the port kind is omitted the behavior depends on the direction.
   For output ports with an explicit data type it is a variable, for
   all others it is a net.