### PR TITLE
Handle delayed signals in timing checks as assignments

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -119,7 +119,7 @@ O = main.o async.o design_dump.o discipline.o dup_expr.o elaborate.o \
     pform_types.o \
     symbol_search.o sync.o sys_funcs.o verinum.o verireal.o vpi_modules.o target.o \
     Attrib.o HName.o Module.o PClass.o PDelays.o PEvent.o PExpr.o PFunction.o \
-    PGate.o PGenerate.o PModport.o PNamedItem.o PPackage.o PScope.o PSpec.o \
+    PGate.o PGenerate.o PModport.o PNamedItem.o PPackage.o PScope.o PSpec.o PTimingCheck.o \
     PTask.o PUdp.o PWire.o Statement.o AStatement.o $M $(FF) $(TT)
 
 all: dep config.h _pli_types.h version_tag.h ivl@EXEEXT@ version.exe iverilog-vpi.man

--- a/Module.h
+++ b/Module.h
@@ -37,6 +37,7 @@ class PGate;
 class PGenerate;
 class PModport;
 class PSpecPath;
+class PTimingCheck;
 class PTask;
 class PFunction;
 class PWire;
@@ -136,7 +137,9 @@ class Module : public PScopeExtra, public PNamedItem {
            program blocks. */
       std::map<perm_string,PModport*> modports;
 
+	/* List for specify paths and timing checks */
       std::list<PSpecPath*> specify_paths;
+      std::list<PTimingCheck*> timing_checks;
 
 	// The mod_name() is the name of the module type.
       perm_string mod_name() const { return pscope_name(); }
@@ -170,6 +173,7 @@ class Module : public PScopeExtra, public PNamedItem {
 
     private:
       void dump_specparams_(std::ostream&out, unsigned indent) const;
+      void dump_timingchecks_(std::ostream&out, unsigned indent) const;
       std::list<PGate*> gates_;
 
     private: // Not implemented

--- a/PTimingCheck.cc
+++ b/PTimingCheck.cc
@@ -20,29 +20,32 @@
 # include  "PTimingCheck.h"
 
 PRecRem::PRecRem(event_t reference_event,
-                    event_t data_event,
-                    //PExpr setup_limit,
-                    //PExpr hold_limit,
-                    pform_name_t* notifier,
-                    pform_name_t* timestamp_cond,
-                    pform_name_t* timecheck_cond,
-                    pform_name_t* delayed_reference,
-                    pform_name_t* delayed_data)
-                    :
-                    reference_event_ (reference_event),
-                    data_event_ (data_event),
-                    //setup_limit (setup_limit),
-                    //hold_limit (hold_limit),
-                    notifier_ (notifier),
-                    timestamp_cond_ (timestamp_cond),
-                    timecheck_cond_ (timecheck_cond),
-                    delayed_reference_ (delayed_reference),
-                    delayed_data_ (delayed_data)
+      event_t data_event,
+      PExpr* setup_limit,
+      PExpr* hold_limit,
+      pform_name_t* notifier,
+      pform_name_t* timestamp_cond,
+      pform_name_t* timecheck_cond,
+      pform_name_t* delayed_reference,
+      pform_name_t* delayed_data)
+      :
+      reference_event_ (reference_event),
+      data_event_ (data_event),
+      setup_limit_ (setup_limit),
+      hold_limit_ (hold_limit),
+      notifier_ (notifier),
+      timestamp_cond_ (timestamp_cond),
+      timecheck_cond_ (timecheck_cond),
+      delayed_reference_ (delayed_reference),
+      delayed_data_ (delayed_data)
 {
 }
 
 PRecRem::~PRecRem()
 {
+      delete setup_limit_;
+      delete hold_limit_;
+
       // Delete optional arguments
       if (reference_event_.condition) delete reference_event_.condition;
       if (data_event_.condition) delete data_event_.condition;
@@ -57,29 +60,32 @@ PRecRem::~PRecRem()
 }
 
 PSetupHold::PSetupHold(event_t reference_event,
-                    event_t data_event,
-                    //PExpr setup_limit,
-                    //PExpr hold_limit,
-                    pform_name_t* notifier,
-                    pform_name_t* timestamp_cond,
-                    pform_name_t* timecheck_cond,
-                    pform_name_t* delayed_reference,
-                    pform_name_t* delayed_data)
-                    :
-                    reference_event_ (reference_event),
-                    data_event_ (data_event),
-                    //setup_limit (setup_limit),
-                    //hold_limit (hold_limit),
-                    notifier_ (notifier),
-                    timestamp_cond_ (timestamp_cond),
-                    timecheck_cond_ (timecheck_cond),
-                    delayed_reference_ (delayed_reference),
-                    delayed_data_ (delayed_data)
+      event_t data_event,
+      PExpr* setup_limit,
+      PExpr* hold_limit,
+      pform_name_t* notifier,
+      pform_name_t* timestamp_cond,
+      pform_name_t* timecheck_cond,
+      pform_name_t* delayed_reference,
+      pform_name_t* delayed_data)
+      :
+      reference_event_ (reference_event),
+      data_event_ (data_event),
+      setup_limit_ (setup_limit),
+      hold_limit_ (hold_limit),
+      notifier_ (notifier),
+      timestamp_cond_ (timestamp_cond),
+      timecheck_cond_ (timecheck_cond),
+      delayed_reference_ (delayed_reference),
+      delayed_data_ (delayed_data)
 {
 }
 
 PSetupHold::~PSetupHold()
 {
+      delete setup_limit_;
+      delete hold_limit_;
+
       // Delete optional arguments
       if (reference_event_.condition) delete reference_event_.condition;
       if (data_event_.condition) delete data_event_.condition;

--- a/PTimingCheck.cc
+++ b/PTimingCheck.cc
@@ -19,8 +19,8 @@
 
 # include  "PTimingCheck.h"
 
-PRecRem::PRecRem(event_t reference_event,
-      event_t data_event,
+PRecRem::PRecRem(event_t* reference_event,
+      event_t* data_event,
       PExpr* setup_limit,
       PExpr* hold_limit,
       pform_name_t* notifier,
@@ -43,24 +43,10 @@ PRecRem::PRecRem(event_t reference_event,
 
 PRecRem::~PRecRem()
 {
-      delete setup_limit_;
-      delete hold_limit_;
-
-      // Delete optional arguments
-      if (reference_event_.condition) delete reference_event_.condition;
-      if (data_event_.condition) delete data_event_.condition;
-
-      if(notifier_) delete notifier_;
-
-      if(timestamp_cond_) delete timestamp_cond_;
-      if(timecheck_cond_) delete timecheck_cond_;
-
-      if(delayed_reference_) delete delayed_reference_;
-      if(delayed_data_) delete delayed_data_;
 }
 
-PSetupHold::PSetupHold(event_t reference_event,
-      event_t data_event,
+PSetupHold::PSetupHold(event_t* reference_event,
+      event_t* data_event,
       PExpr* setup_limit,
       PExpr* hold_limit,
       pform_name_t* notifier,
@@ -83,18 +69,4 @@ PSetupHold::PSetupHold(event_t reference_event,
 
 PSetupHold::~PSetupHold()
 {
-      delete setup_limit_;
-      delete hold_limit_;
-
-      // Delete optional arguments
-      if (reference_event_.condition) delete reference_event_.condition;
-      if (data_event_.condition) delete data_event_.condition;
-
-      if(notifier_) delete notifier_;
-
-      if(timestamp_cond_) delete timestamp_cond_;
-      if(timecheck_cond_) delete timecheck_cond_;
-
-      if(delayed_reference_) delete delayed_reference_;
-      if(delayed_data_) delete delayed_data_;
 }

--- a/PTimingCheck.cc
+++ b/PTimingCheck.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2006-2023 Stephen Williams <steve@icarus.com>
+ *
+ *    This source code is free software; you can redistribute it
+ *    and/or modify it in source code form under the terms of the GNU
+ *    General Public License as published by the Free Software
+ *    Foundation; either version 2 of the License, or (at your option)
+ *    any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+# include  "PTimingCheck.h"
+
+PRecRem::PRecRem(event_t reference_event,
+                    event_t data_event,
+                    //PExpr setup_limit,
+                    //PExpr hold_limit,
+                    pform_name_t* notifier,
+                    pform_name_t* timestamp_cond,
+                    pform_name_t* timecheck_cond,
+                    pform_name_t* delayed_reference,
+                    pform_name_t* delayed_data)
+                    :
+                    reference_event_ (reference_event),
+                    data_event_ (data_event),
+                    //setup_limit (setup_limit),
+                    //hold_limit (hold_limit),
+                    notifier_ (notifier),
+                    timestamp_cond_ (timestamp_cond),
+                    timecheck_cond_ (timecheck_cond),
+                    delayed_reference_ (delayed_reference),
+                    delayed_data_ (delayed_data)
+{
+}
+
+PRecRem::~PRecRem()
+{
+      // Delete optional arguments
+      if (reference_event_.condition) delete reference_event_.condition;
+      if (data_event_.condition) delete data_event_.condition;
+
+      if(notifier_) delete notifier_;
+
+      if(timestamp_cond_) delete timestamp_cond_;
+      if(timecheck_cond_) delete timecheck_cond_;
+
+      if(delayed_reference_) delete delayed_reference_;
+      if(delayed_data_) delete delayed_data_;
+}
+
+PSetupHold::PSetupHold(event_t reference_event,
+                    event_t data_event,
+                    //PExpr setup_limit,
+                    //PExpr hold_limit,
+                    pform_name_t* notifier,
+                    pform_name_t* timestamp_cond,
+                    pform_name_t* timecheck_cond,
+                    pform_name_t* delayed_reference,
+                    pform_name_t* delayed_data)
+                    :
+                    reference_event_ (reference_event),
+                    data_event_ (data_event),
+                    //setup_limit (setup_limit),
+                    //hold_limit (hold_limit),
+                    notifier_ (notifier),
+                    timestamp_cond_ (timestamp_cond),
+                    timecheck_cond_ (timecheck_cond),
+                    delayed_reference_ (delayed_reference),
+                    delayed_data_ (delayed_data)
+{
+}
+
+PSetupHold::~PSetupHold()
+{
+      // Delete optional arguments
+      if (reference_event_.condition) delete reference_event_.condition;
+      if (data_event_.condition) delete data_event_.condition;
+
+      if(notifier_) delete notifier_;
+
+      if(timestamp_cond_) delete timestamp_cond_;
+      if(timecheck_cond_) delete timecheck_cond_;
+
+      if(delayed_reference_) delete delayed_reference_;
+      if(delayed_data_) delete delayed_data_;
+}

--- a/PTimingCheck.cc
+++ b/PTimingCheck.cc
@@ -24,8 +24,8 @@ PRecRem::PRecRem(event_t* reference_event,
       PExpr* setup_limit,
       PExpr* hold_limit,
       pform_name_t* notifier,
-      pform_name_t* timestamp_cond,
-      pform_name_t* timecheck_cond,
+      PExpr* timestamp_cond,
+      PExpr* timecheck_cond,
       pform_name_t* delayed_reference,
       pform_name_t* delayed_data)
       :
@@ -50,8 +50,8 @@ PSetupHold::PSetupHold(event_t* reference_event,
       PExpr* setup_limit,
       PExpr* hold_limit,
       pform_name_t* notifier,
-      pform_name_t* timestamp_cond,
-      pform_name_t* timecheck_cond,
+      PExpr* timestamp_cond,
+      PExpr* timecheck_cond,
       pform_name_t* delayed_reference,
       pform_name_t* delayed_data)
       :

--- a/PTimingCheck.h
+++ b/PTimingCheck.h
@@ -20,9 +20,8 @@
  */
 
 # include  "LineInfo.h"
+# include  "PExpr.h"
 # include  "pform_types.h"
-
-// TODO cleanup in destructor and cleanup in Module!
 
 /*
 * The PTimingCheck is the base class for all timing checks
@@ -40,6 +39,17 @@ class PTimingCheck  : public LineInfo {
         PExpr* condition;
       };
 
+      // This struct is used to parse the optional arguments
+      struct optional_args_t {
+        pform_name_t* notifier          = nullptr;
+        pform_name_t* timestamp_cond    = nullptr;
+        pform_name_t* timecheck_cond    = nullptr;
+        pform_name_t* delayed_reference = nullptr;
+        pform_name_t* delayed_data      = nullptr;
+        PExpr* event_based_flag         = nullptr;
+        PExpr* remain_active_flag       = nullptr;
+      };
+
       PTimingCheck() { }
       virtual ~PTimingCheck() { }
 
@@ -54,10 +64,11 @@ class PTimingCheck  : public LineInfo {
 class PRecRem : public PTimingCheck {
 
     public:
+
       PRecRem(event_t reference_event,
                     event_t data_event,
-                    //PExpr setup_limit,
-                    //PExpr hold_limit,
+                    PExpr* setup_limit,
+                    PExpr* hold_limit,
                     pform_name_t* notifier,
                     pform_name_t* timestamp_cond,
                     pform_name_t* timecheck_cond,
@@ -70,12 +81,12 @@ class PRecRem : public PTimingCheck {
 
       void dump(std::ostream&out, unsigned ind) const override;
 
-    public: // TODO
+    private:
       event_t reference_event_; // hierarchy_identifier
       event_t data_event_;
 
-      //PExpr setup_limit;
-      //PExpr hold_limit;
+      PExpr* setup_limit_;
+      PExpr* hold_limit_;
 
       pform_name_t* notifier_;
 
@@ -94,8 +105,8 @@ class PSetupHold : public PTimingCheck {
     public:
       PSetupHold(event_t reference_event,
                     event_t data_event,
-                    //PExpr setup_limit,
-                    //PExpr hold_limit,
+                    PExpr* setup_limit,
+                    PExpr* hold_limit,
                     pform_name_t* notifier,
                     pform_name_t* timestamp_cond,
                     pform_name_t* timecheck_cond,
@@ -108,12 +119,12 @@ class PSetupHold : public PTimingCheck {
 
       void dump(std::ostream&out, unsigned ind) const override;
 
-    public: // TODO
+    private:
       event_t reference_event_; // hierarchy_identifier
       event_t data_event_;
 
-      //PExpr setup_limit;
-      //PExpr hold_limit;
+      PExpr* setup_limit_;
+      PExpr* hold_limit_;
 
       pform_name_t* notifier_;
 

--- a/PTimingCheck.h
+++ b/PTimingCheck.h
@@ -1,0 +1,127 @@
+#ifndef IVL_PTimingCheck_H
+#define IVL_PTimingCheck_H
+/*
+ * Copyright (c) 2006-2023 Stephen Williams <steve@icarus.com>
+ *
+ *    This source code is free software; you can redistribute it
+ *    and/or modify it in source code form under the terms of the GNU
+ *    General Public License as published by the Free Software
+ *    Foundation; either version 2 of the License, or (at your option)
+ *    any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+# include  "LineInfo.h"
+# include  "pform_types.h"
+
+// TODO cleanup in destructor and cleanup in Module!
+
+/*
+* The PTimingCheck is the base class for all timing checks
+*/
+class PTimingCheck  : public LineInfo {
+
+    public:
+      enum EdgeType {EDGE_01, EDGE_0X, EDGE_10, EDGE_1X, EDGE_X0, EDGE_X1};
+
+      struct event_t {
+        pform_name_t name;
+        bool posedge;
+        bool negedge;
+        std::vector<EdgeType> edges;
+        PExpr* condition;
+      };
+
+      PTimingCheck() { }
+      virtual ~PTimingCheck() { }
+
+      virtual void elaborate(class Design*des, class NetScope*scope) const = 0;
+
+      virtual void dump(std::ostream&out, unsigned ind) const = 0;
+};
+
+/*
+* The PRecRem is the parse of a $recrem timing check
+*/
+class PRecRem : public PTimingCheck {
+
+    public:
+      PRecRem(event_t reference_event,
+                    event_t data_event,
+                    //PExpr setup_limit,
+                    //PExpr hold_limit,
+                    pform_name_t* notifier,
+                    pform_name_t* timestamp_cond,
+                    pform_name_t* timecheck_cond,
+                    pform_name_t* delayed_reference,
+                    pform_name_t* delayed_data);
+
+      ~PRecRem();
+
+      void elaborate(class Design*des, class NetScope*scope) const override;
+
+      void dump(std::ostream&out, unsigned ind) const override;
+
+    public: // TODO
+      event_t reference_event_; // hierarchy_identifier
+      event_t data_event_;
+
+      //PExpr setup_limit;
+      //PExpr hold_limit;
+
+      pform_name_t* notifier_;
+
+      pform_name_t* timestamp_cond_;
+      pform_name_t* timecheck_cond_;
+
+      pform_name_t* delayed_reference_;
+      pform_name_t* delayed_data_;
+};
+
+/*
+* The PSetupHold is the parse of a $setuphold timing check
+*/
+class PSetupHold : public PTimingCheck {
+
+    public:
+      PSetupHold(event_t reference_event,
+                    event_t data_event,
+                    //PExpr setup_limit,
+                    //PExpr hold_limit,
+                    pform_name_t* notifier,
+                    pform_name_t* timestamp_cond,
+                    pform_name_t* timecheck_cond,
+                    pform_name_t* delayed_reference,
+                    pform_name_t* delayed_data);
+
+      ~PSetupHold();
+
+      void elaborate(class Design*des, class NetScope*scope) const override;
+
+      void dump(std::ostream&out, unsigned ind) const override;
+
+    public: // TODO
+      event_t reference_event_; // hierarchy_identifier
+      event_t data_event_;
+
+      //PExpr setup_limit;
+      //PExpr hold_limit;
+
+      pform_name_t* notifier_;
+
+      pform_name_t* timestamp_cond_;
+      pform_name_t* timecheck_cond_;
+
+      pform_name_t* delayed_reference_;
+      pform_name_t* delayed_data_;
+};
+
+#endif /* IVL_PTimingCheck_H */

--- a/PTimingCheck.h
+++ b/PTimingCheck.h
@@ -22,6 +22,7 @@
 # include  "LineInfo.h"
 # include  "PExpr.h"
 # include  "pform_types.h"
+# include  <memory>
 
 /*
 * The PTimingCheck is the base class for all timing checks
@@ -36,7 +37,7 @@ class PTimingCheck  : public LineInfo {
         bool posedge;
         bool negedge;
         std::vector<EdgeType> edges;
-        PExpr* condition;
+        std::unique_ptr<PExpr> condition;
       };
 
       // This struct is used to parse the optional arguments
@@ -65,8 +66,8 @@ class PRecRem : public PTimingCheck {
 
     public:
 
-      PRecRem(event_t reference_event,
-                    event_t data_event,
+      PRecRem(event_t* reference_event,
+                    event_t* data_event,
                     PExpr* setup_limit,
                     PExpr* hold_limit,
                     pform_name_t* notifier,
@@ -82,19 +83,19 @@ class PRecRem : public PTimingCheck {
       void dump(std::ostream&out, unsigned ind) const override;
 
     private:
-      event_t reference_event_; // hierarchy_identifier
-      event_t data_event_;
+      std::unique_ptr<event_t> reference_event_;
+      std::unique_ptr<event_t> data_event_;
 
-      PExpr* setup_limit_;
-      PExpr* hold_limit_;
+      std::unique_ptr<PExpr> setup_limit_;
+      std::unique_ptr<PExpr> hold_limit_;
 
-      pform_name_t* notifier_;
+      std::unique_ptr<pform_name_t> notifier_;
 
-      pform_name_t* timestamp_cond_;
-      pform_name_t* timecheck_cond_;
+      std::unique_ptr<pform_name_t> timestamp_cond_;
+      std::unique_ptr<pform_name_t> timecheck_cond_;
 
-      pform_name_t* delayed_reference_;
-      pform_name_t* delayed_data_;
+      std::unique_ptr<pform_name_t> delayed_reference_;
+      std::unique_ptr<pform_name_t> delayed_data_;
 };
 
 /*
@@ -103,8 +104,8 @@ class PRecRem : public PTimingCheck {
 class PSetupHold : public PTimingCheck {
 
     public:
-      PSetupHold(event_t reference_event,
-                    event_t data_event,
+      PSetupHold(event_t* reference_event,
+                    event_t* data_event,
                     PExpr* setup_limit,
                     PExpr* hold_limit,
                     pform_name_t* notifier,
@@ -120,19 +121,19 @@ class PSetupHold : public PTimingCheck {
       void dump(std::ostream&out, unsigned ind) const override;
 
     private:
-      event_t reference_event_; // hierarchy_identifier
-      event_t data_event_;
+      std::unique_ptr<event_t> reference_event_;
+      std::unique_ptr<event_t> data_event_;
 
-      PExpr* setup_limit_;
-      PExpr* hold_limit_;
+      std::unique_ptr<PExpr> setup_limit_;
+      std::unique_ptr<PExpr> hold_limit_;
 
-      pform_name_t* notifier_;
+      std::unique_ptr<pform_name_t> notifier_;
 
-      pform_name_t* timestamp_cond_;
-      pform_name_t* timecheck_cond_;
+      std::unique_ptr<pform_name_t> timestamp_cond_;
+      std::unique_ptr<pform_name_t> timecheck_cond_;
 
-      pform_name_t* delayed_reference_;
-      pform_name_t* delayed_data_;
+      std::unique_ptr<pform_name_t> delayed_reference_;
+      std::unique_ptr<pform_name_t> delayed_data_;
 };
 
 #endif /* IVL_PTimingCheck_H */

--- a/PTimingCheck.h
+++ b/PTimingCheck.h
@@ -43,8 +43,8 @@ class PTimingCheck  : public LineInfo {
       // This struct is used to parse the optional arguments
       struct optional_args_t {
         pform_name_t* notifier          = nullptr;
-        pform_name_t* timestamp_cond    = nullptr;
-        pform_name_t* timecheck_cond    = nullptr;
+        PExpr* timestamp_cond    = nullptr;
+        PExpr* timecheck_cond    = nullptr;
         pform_name_t* delayed_reference = nullptr;
         pform_name_t* delayed_data      = nullptr;
         PExpr* event_based_flag         = nullptr;
@@ -71,8 +71,8 @@ class PRecRem : public PTimingCheck {
                     PExpr* setup_limit,
                     PExpr* hold_limit,
                     pform_name_t* notifier,
-                    pform_name_t* timestamp_cond,
-                    pform_name_t* timecheck_cond,
+                    PExpr* timestamp_cond,
+                    PExpr* timecheck_cond,
                     pform_name_t* delayed_reference,
                     pform_name_t* delayed_data);
 
@@ -91,8 +91,8 @@ class PRecRem : public PTimingCheck {
 
       std::unique_ptr<pform_name_t> notifier_;
 
-      std::unique_ptr<pform_name_t> timestamp_cond_;
-      std::unique_ptr<pform_name_t> timecheck_cond_;
+      std::unique_ptr<PExpr> timestamp_cond_;
+      std::unique_ptr<PExpr> timecheck_cond_;
 
       std::unique_ptr<pform_name_t> delayed_reference_;
       std::unique_ptr<pform_name_t> delayed_data_;
@@ -109,8 +109,8 @@ class PSetupHold : public PTimingCheck {
                     PExpr* setup_limit,
                     PExpr* hold_limit,
                     pform_name_t* notifier,
-                    pform_name_t* timestamp_cond,
-                    pform_name_t* timecheck_cond,
+                    PExpr* timestamp_cond,
+                    PExpr* timecheck_cond,
                     pform_name_t* delayed_reference,
                     pform_name_t* delayed_data);
 
@@ -129,8 +129,8 @@ class PSetupHold : public PTimingCheck {
 
       std::unique_ptr<pform_name_t> notifier_;
 
-      std::unique_ptr<pform_name_t> timestamp_cond_;
-      std::unique_ptr<pform_name_t> timecheck_cond_;
+      std::unique_ptr<PExpr> timestamp_cond_;
+      std::unique_ptr<PExpr> timecheck_cond_;
 
       std::unique_ptr<pform_name_t> delayed_reference_;
       std::unique_ptr<pform_name_t> delayed_data_;

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -6320,7 +6320,7 @@ void PRecRem::elaborate(Design*des, NetScope*scope) const
       if (delayed_reference_ != nullptr)
       {
 	      if (debug_elaborate) {
-		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning"
+		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning "
 		       << reference_event_.name
 		       << " to " << *delayed_reference_ << endl;
 	      }
@@ -6349,9 +6349,9 @@ void PRecRem::elaborate(Design*des, NetScope*scope) const
       if (delayed_data_ != nullptr)
       {
 	      if (debug_elaborate) {
-		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning"
-		       << reference_event_.name
-		       << " to " << *delayed_reference_ << endl;
+		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning "
+		       << data_event_.name
+		       << " to " << *delayed_data_ << endl;
 	      }
 
 	      NetNet*sig = des->find_signal(scope, data_event_.name);

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -41,6 +41,7 @@
 # include  "PPackage.h"
 # include  "PScope.h"
 # include  "PSpec.h"
+# include  "PTimingCheck.h"
 # include  "netlist.h"
 # include  "netenum.h"
 # include  "netvector.h"
@@ -6308,6 +6309,140 @@ void PSpecPath::elaborate(Design*des, NetScope*scope) const
       }
 }
 
+void PRecRem::elaborate(Design*des, NetScope*scope) const
+{
+      // At present, no timing checks are supported.
+      // Still, in order to get some models working
+      // assign the original reference and data signals to
+      // the delayed reference and data signals as per
+      // 15.5.4 Option behavior
+
+      if (delayed_reference_ != nullptr)
+      {
+	      if (debug_elaborate) {
+		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning"
+		       << reference_event_.name
+		       << " to " << *delayed_reference_ << endl;
+	      }
+
+	      NetNet*sig = des->find_signal(scope, reference_event_.name);
+
+	      if (sig == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << reference_event_.name << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      NetNet*sig_delayed = des->find_signal(scope, *delayed_reference_);
+
+	      if (sig_delayed == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << *delayed_reference_ << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      connect(sig->pin(0), sig_delayed->pin(0));
+      }
+
+      if (delayed_data_ != nullptr)
+      {
+	      if (debug_elaborate) {
+		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning"
+		       << reference_event_.name
+		       << " to " << *delayed_reference_ << endl;
+	      }
+
+	      NetNet*sig = des->find_signal(scope, data_event_.name);
+
+	      if (sig == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << data_event_.name << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      NetNet*sig_delayed = des->find_signal(scope, *delayed_data_);
+
+	      if (sig_delayed == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << *delayed_data_ << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      connect(sig->pin(0), sig_delayed->pin(0));
+      }
+}
+
+void PSetupHold::elaborate(Design*des, NetScope*scope) const
+{
+      // At present, no timing checks are supported.
+      // Still, in order to get some models working
+      // assign the original reference and data signals to
+      // the delayed reference and data signals as per
+      // 15.5.4 Option behavior
+
+      if (delayed_reference_ != nullptr)
+      {
+	      if (debug_elaborate) {
+		    cerr << get_fileline() << ": PSetupHold::elaborate: Assigning"
+		       << reference_event_.name
+		       << " to " << *delayed_reference_ << endl;
+	      }
+
+	      NetNet*sig = des->find_signal(scope, reference_event_.name);
+
+	      if (sig == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << reference_event_.name << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      NetNet*sig_delayed = des->find_signal(scope, *delayed_reference_);
+
+	      if (sig_delayed == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << *delayed_reference_ << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      connect(sig->pin(0), sig_delayed->pin(0));
+      }
+
+      if (delayed_data_ != nullptr)
+      {
+	      if (debug_elaborate) {
+		    cerr << get_fileline() << ": PSetupHold::elaborate: Assigning"
+		       << reference_event_.name
+		       << " to " << *delayed_reference_ << endl;
+	      }
+
+	      NetNet*sig = des->find_signal(scope, data_event_.name);
+
+	      if (sig == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << data_event_.name << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      NetNet*sig_delayed = des->find_signal(scope, *delayed_data_);
+
+	      if (sig_delayed == nullptr) {
+		    cerr << get_fileline() << ": error: Cannot find: "
+		       << *delayed_data_ << endl;
+		    des->errors += 1;
+		    return;
+	      }
+
+	      connect(sig->pin(0), sig_delayed->pin(0));
+      }
+}
+
 static void elaborate_functions(Design*des, NetScope*scope,
 				const map<perm_string,PFunction*>&funcs)
 {
@@ -6421,11 +6556,17 @@ bool Module::elaborate(Design*des, NetScope*scope) const
       result_flag &= elaborate_behaviors_(des, scope);
 
 	// Elaborate the specify paths of the module.
-
       for (list<PSpecPath*>::const_iterator sp = specify_paths.begin()
 		 ; sp != specify_paths.end() ; ++ sp ) {
 
 	    (*sp)->elaborate(des, scope);
+      }
+
+	// Elaborate the timing checks of the module.
+      for (list<PTimingCheck*>::const_iterator tc = timing_checks.begin()
+		 ; tc != timing_checks.end() ; ++ tc ) {
+
+	    (*tc)->elaborate(des, scope);
       }
 
 	// Elaborate the elaboration tasks.

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -6321,15 +6321,15 @@ void PRecRem::elaborate(Design*des, NetScope*scope) const
       {
 	      if (debug_elaborate) {
 		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning "
-		       << reference_event_.name
+		       << reference_event_->name
 		       << " to " << *delayed_reference_ << endl;
 	      }
 
-	      NetNet*sig = des->find_signal(scope, reference_event_.name);
+	      NetNet*sig = des->find_signal(scope, reference_event_->name);
 
 	      if (sig == nullptr) {
 		    cerr << get_fileline() << ": error: Cannot find: "
-		       << reference_event_.name << endl;
+		       << reference_event_->name << endl;
 		    des->errors += 1;
 		    return;
 	      }
@@ -6350,15 +6350,15 @@ void PRecRem::elaborate(Design*des, NetScope*scope) const
       {
 	      if (debug_elaborate) {
 		    cerr << get_fileline() << ": PRecRem::elaborate: Assigning "
-		       << data_event_.name
+		       << data_event_->name
 		       << " to " << *delayed_data_ << endl;
 	      }
 
-	      NetNet*sig = des->find_signal(scope, data_event_.name);
+	      NetNet*sig = des->find_signal(scope, data_event_->name);
 
 	      if (sig == nullptr) {
 		    cerr << get_fileline() << ": error: Cannot find: "
-		       << data_event_.name << endl;
+		       << data_event_->name << endl;
 		    des->errors += 1;
 		    return;
 	      }
@@ -6388,15 +6388,15 @@ void PSetupHold::elaborate(Design*des, NetScope*scope) const
       {
 	      if (debug_elaborate) {
 		    cerr << get_fileline() << ": PSetupHold::elaborate: Assigning"
-		       << reference_event_.name
+		       << reference_event_->name
 		       << " to " << *delayed_reference_ << endl;
 	      }
 
-	      NetNet*sig = des->find_signal(scope, reference_event_.name);
+	      NetNet*sig = des->find_signal(scope, reference_event_->name);
 
 	      if (sig == nullptr) {
 		    cerr << get_fileline() << ": error: Cannot find: "
-		       << reference_event_.name << endl;
+		       << reference_event_->name << endl;
 		    des->errors += 1;
 		    return;
 	      }
@@ -6417,15 +6417,15 @@ void PSetupHold::elaborate(Design*des, NetScope*scope) const
       {
 	      if (debug_elaborate) {
 		    cerr << get_fileline() << ": PSetupHold::elaborate: Assigning"
-		       << reference_event_.name
-		       << " to " << *delayed_reference_ << endl;
+		       << data_event_->name
+		       << " to " << *delayed_data_ << endl;
 	      }
 
-	      NetNet*sig = des->find_signal(scope, data_event_.name);
+	      NetNet*sig = des->find_signal(scope, data_event_->name);
 
 	      if (sig == nullptr) {
 		    cerr << get_fileline() << ": error: Cannot find: "
-		       << data_event_.name << endl;
+		       << data_event_->name << endl;
 		    des->errors += 1;
 		    return;
 	      }
@@ -6518,10 +6518,8 @@ bool Module::elaborate(Design*des, NetScope*scope) const
       bool result_flag = true;
 
 	// Elaborate within the generate blocks.
-      typedef list<PGenerate*>::const_iterator generate_it_t;
-      for (generate_it_t cur = generate_schemes.begin()
-		 ; cur != generate_schemes.end() ; ++ cur ) {
-	    (*cur)->elaborate(des, scope);
+      for (const auto cur : generate_schemes) {
+	    cur->elaborate(des, scope);
       }
 
 	// Elaborate functions.
@@ -6540,10 +6538,8 @@ bool Module::elaborate(Design*des, NetScope*scope) const
 	// complex.
       const list<PGate*>&gl = get_gates();
 
-      for (list<PGate*>::const_iterator gt = gl.begin()
-		 ; gt != gl.end() ; ++ gt ) {
-
-	    (*gt)->elaborate(des, scope);
+      for (const auto gt : gl) {
+	    gt->elaborate(des, scope);
       }
 
 	// Elaborate the variable initialization statements, making a
@@ -6556,23 +6552,18 @@ bool Module::elaborate(Design*des, NetScope*scope) const
       result_flag &= elaborate_behaviors_(des, scope);
 
 	// Elaborate the specify paths of the module.
-      for (list<PSpecPath*>::const_iterator sp = specify_paths.begin()
-		 ; sp != specify_paths.end() ; ++ sp ) {
-
-	    (*sp)->elaborate(des, scope);
+      for (const auto sp : specify_paths) {
+	    sp->elaborate(des, scope);
       }
 
 	// Elaborate the timing checks of the module.
-      for (list<PTimingCheck*>::const_iterator tc = timing_checks.begin()
-		 ; tc != timing_checks.end() ; ++ tc ) {
-
-	    (*tc)->elaborate(des, scope);
+      for (const auto tc : timing_checks) {
+	    tc->elaborate(des, scope);
       }
 
 	// Elaborate the elaboration tasks.
-      for (list<PCallTask*>::const_iterator et = elab_tasks.begin()
-		 ; et != elab_tasks.end() ; ++ et ) {
-	    result_flag &= (*et)->elaborate_elab(des, scope);
+      for (const auto et : elab_tasks) {
+	    result_flag &= et->elaborate_elab(des, scope);
       }
 
       return result_flag;

--- a/ivtest/ivltests/timing_check_delayed_signals.v
+++ b/ivtest/ivltests/timing_check_delayed_signals.v
@@ -1,0 +1,39 @@
+// Check that when timing checks are disabled (or in the case of Icarus Verilog not supported)
+// that the delayed reference and data signals become copies of the original reference and data signals
+
+module test;
+
+  wire sig1, sig2, del_sig1, del_sig2, del_sig3, del_sig4, notifier, cond1, cond2;
+
+  assign sig1 = 1'b0;
+  assign sig2 = 1'b1;
+
+  specify
+
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier , cond1 , cond2 , del_sig1 , del_sig2 ) ;
+
+    /*
+    Internally the simulator does the following:
+    assign del_sig1 = sig1;
+    assign del_sig2 = sig2;
+    */
+
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier, cond1 , cond2 , del_sig3 , del_sig4 );
+
+    /*
+    Internally the simulator does the following:
+    assign del_sig3 = sig1;
+    assign del_sig4 = sig2;
+    */
+
+  endspecify
+  
+  initial begin
+  
+      if (del_sig1 == 1'b0 && del_sig2 == 1'b1 && del_sig3 == 1'b0 && del_sig4 == 1'b1)
+        $display("PASSED");
+      else
+        $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/timing_check_syntax.v
+++ b/ivtest/ivltests/timing_check_syntax.v
@@ -84,9 +84,9 @@ module test;
     $timeskew(posedge sig1, negedge sig2 , 0:0:0 , notifier);
     $timeskew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
     $timeskew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
-    // TODO $timeskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
-    // TODO $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
-    // TODO $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
+    $timeskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
+    $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
+    $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
 
     $fullskew(posedge sig1 , negedge sig2 , 0:0:0 , 0:0:0);
     $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0);
@@ -95,9 +95,9 @@ module test;
     $fullskew(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier);
     $fullskew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier);
     $fullskew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , 0:0:0 , notifier);
-    // TODO $fullskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
-    // TODO $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
-    // TODO $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
+    $fullskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
+    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
+    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
 
     $width(posedge sig1 , 0:0:0 );
     $width(posedge sig1 &&& cond1 , 0:0:0 , 0 );

--- a/ivtest/ivltests/timing_check_syntax.v
+++ b/ivtest/ivltests/timing_check_syntax.v
@@ -1,0 +1,118 @@
+// Check that various timing checks can be parsed
+
+module test;
+
+  initial begin
+      $display("PASSED");
+  end
+  
+  wire sig1, sig2, del_sig1, del_sig2, notifier, cond1, cond2;
+
+  specify
+    $setup(posedge sig1 , negedge sig2 , 0:0:0);
+    $setup(negedge sig1 , posedge sig2 , 0:0:0);
+    $setup(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $setup(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $setup(posedge sig1, negedge sig2 , 0:0:0 , notifier);
+    $setup(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
+    $setup(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
+
+    $hold(posedge sig1 , negedge sig2 , 0:0:0);
+    $hold(negedge sig1 , posedge sig2 , 0:0:0);
+    $hold(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $hold(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $hold(posedge sig1, negedge sig2 , 0:0:0 , notifier);
+    $hold(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
+    $hold(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
+
+    $setuphold(posedge sig1 , negedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $setuphold(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $setuphold(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , 0:0:0 , notifier);
+    $setuphold(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , 0:0:0 , notifier);
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier, cond1 , cond2) ;
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier, cond1 , cond2 , del_sig1 , del_sig2 ) ;
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,, del_sig1 , del_sig2 ) ;
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,, del_sig1 , del_sig2 ) ;
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,,, del_sig2 ) ;
+    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,, del_sig1 ,) ;
+    $setuphold(edge [10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $setuphold(posedge sig1 , edge [10, x0, 1x] sig2 , 0:0:0 , 0:0:0 , notifier);
+
+    $removal(posedge sig1 , negedge sig2 , 0:0:0);
+    $removal(negedge sig1 , posedge sig2 , 0:0:0);
+    $removal(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $removal(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $removal(posedge sig1, negedge sig2 , 0:0:0 , notifier);
+    $removal(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
+    $removal(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
+
+    $recovery(posedge sig1 , negedge sig2 , 0:0:0);
+    $recovery(negedge sig1 , posedge sig2 , 0:0:0);
+    $recovery(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $recovery(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $recovery(posedge sig1, negedge sig2 , 0:0:0 , notifier);
+    $recovery(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
+    $recovery(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
+
+    $recrem(posedge sig1 , negedge sig2 , 0:0:0 , 0:0:0);
+    $recrem(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0);
+    $recrem(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , 0:0:0 , notifier);
+    $recrem(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , 0:0:0 , notifier);
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier, cond1 , cond2);
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier, cond1 , cond2 , del_sig1 , del_sig2 );
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,, del_sig1 , del_sig2 );
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,, del_sig1 , del_sig2 );
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,,, del_sig2 );
+    $recrem(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier,,, del_sig1 ,);
+    $recrem(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $recrem(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , 0:0:0 , notifier);
+
+    $skew(posedge sig1 , negedge sig2 , 0:0:0);
+    $skew(negedge sig1 , posedge sig2 , 0:0:0);
+    $skew(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $skew(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $skew(posedge sig1, negedge sig2 , 0:0:0 , notifier);
+    $skew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
+    $skew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
+
+    $timeskew(posedge sig1 , negedge sig2 , 0:0:0);
+    $timeskew(negedge sig1 , posedge sig2 , 0:0:0);
+    $timeskew(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $timeskew(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , notifier);
+    $timeskew(posedge sig1, negedge sig2 , 0:0:0 , notifier);
+    $timeskew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
+    $timeskew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
+    // TODO $timeskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
+    // TODO $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
+    // TODO $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
+
+    $fullskew(posedge sig1 , negedge sig2 , 0:0:0 , 0:0:0);
+    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0);
+    $fullskew(posedge sig1 &&& cond1 == cond2 , posedge sig2 &&& cond1 == cond2 , 0:0:0 , 0:0:0 , notifier);
+    $fullskew(negedge sig1 &&& cond1 == cond2 , negedge sig2 &&& cond1 == cond2 , 0:0:0 , 0:0:0 , notifier);
+    $fullskew(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $fullskew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier);
+    $fullskew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , 0:0:0 , notifier);
+    // TODO $fullskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
+    // TODO $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
+    // TODO $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
+
+    $width(posedge sig1 , 0:0:0 );
+    $width(posedge sig1 &&& cond1 , 0:0:0 , 0 );
+    $width(posedge sig1 &&& cond1 , 0:0:0 , 0 , notifier );
+    $width(edge[10, x0, 1x] sig1 &&& cond1 , 0:0:0 );
+
+    $period(posedge sig1 , 0:0:0 );
+    $period(negedge sig1 &&& cond1 , 0:0:0 , notifier );
+    $period(edge[10, x0, 1x] sig1 &&& cond1 , 0:0:0 );
+
+    $nochange(posedge sig1 , posedge sig2 , 10 , 20 );
+    $nochange(negedge sig1 &&& cond1 , posedge sig2 , 10 , 20 );
+    $nochange(negedge sig1 , posedge sig2 &&& cond1 , 10 , 20 , notifier );
+    $nochange(edge[10, x0, 1x] sig1 &&& cond1 , posedge sig2 , 10 , 20 );
+    $nochange(posedge sig1 &&& cond1 , edge[10, x0, 1x] sig2 , 10 , 20 );
+
+  endspecify
+endmodule

--- a/ivtest/ivltests/timing_check_syntax.v
+++ b/ivtest/ivltests/timing_check_syntax.v
@@ -84,9 +84,9 @@ module test;
     $timeskew(posedge sig1, negedge sig2 , 0:0:0 , notifier);
     $timeskew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , notifier);
     $timeskew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , notifier);
-    $timeskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
-    $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
-    $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
+    $timeskew(posedge sig1 , negedge sig2 , 0:0:0 , notifier , 1'b0);
+    $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , notifier , 1'b1 , 1'b0);
+    $timeskew(negedge sig1 , posedge sig2 , 0:0:0 , , , 1'b1);
 
     $fullskew(posedge sig1 , negedge sig2 , 0:0:0 , 0:0:0);
     $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0);
@@ -95,9 +95,9 @@ module test;
     $fullskew(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier);
     $fullskew(edge[10, x0, 1x] sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier);
     $fullskew(posedge sig1 , edge[10, x0, 1x] sig2 , 0:0:0 , 0:0:0 , notifier);
-    $fullskew(posedge sig1 , negedge sig2 , 0:0:0, notifier , 1'b0);
-    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 1'b1 , 1'b0);
-    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , , 1'b1);
+    $fullskew(posedge sig1 , negedge sig2 , 0:0:0 , 0:0:0 , notifier , 1'b0);
+    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0 , notifier , 1'b1 , 1'b0);
+    $fullskew(negedge sig1 , posedge sig2 , 0:0:0 , 0:0:0 , , , 1'b1);
 
     $width(posedge sig1 , 0:0:0 );
     $width(posedge sig1 &&& cond1 , 0:0:0 , 0 );

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -72,3 +72,5 @@ task_return1			vvp_tests/task_return1.json
 task_return2			vvp_tests/task_return2.json
 task_return_fail1		vvp_tests/task_return_fail1.json
 task_return_fail2		vvp_tests/task_return_fail2.json
+timing_check_syntax		vvp_tests/timing_check_syntax.json
+timing_check_delayed_signals	vvp_tests/timing_check_delayed_signals.json

--- a/ivtest/vvp_tests/timing_check_delayed_signals.json
+++ b/ivtest/vvp_tests/timing_check_delayed_signals.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "normal",
+    "source"        : "timing_check_delayed_signals.v"
+}

--- a/ivtest/vvp_tests/timing_check_syntax.json
+++ b/ivtest/vvp_tests/timing_check_syntax.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "normal",
+    "source"        : "timing_check_syntax.v"
+}

--- a/parse.y
+++ b/parse.y
@@ -5915,9 +5915,9 @@ specify_item
 	delete $7; // delay_value
 	delete $9; // delay_value
 
-	if ($10->notifier) delete $10->notifier;
-	if ($10->event_based_flag) delete $10->event_based_flag;
-	if ($10->remain_active_flag) delete $10->remain_active_flag;
+	delete $10->notifier;
+	delete $10->event_based_flag;
+	delete $10->remain_active_flag;
 
 	delete $10; // fullskew_opt_args
       }
@@ -5928,7 +5928,7 @@ specify_item
 	delete $3; // spec_reference_event
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
-	if($8) delete $8; // spec_notifier_opt
+	delete $8; // spec_notifier_opt
       }
   | K_Snochange '(' spec_reference_event ',' spec_reference_event
 	  ',' delay_value ',' delay_value spec_notifier_opt ')' ';'
@@ -5938,7 +5938,7 @@ specify_item
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
 	delete $9; // delay_value
-	if($10) delete $10; // spec_notifier_opt
+	delete $10; // spec_notifier_opt
       }
   | K_Speriod '(' spec_reference_event ',' delay_value
     spec_notifier_opt ')' ';'
@@ -5946,7 +5946,7 @@ specify_item
 	cerr << @3 << ": warning: Timing checks are not supported." << endl;
 	delete $3; // spec_reference_event
 	delete $5; // delay_value
-	if($6) delete $6; // spec_notifier_opt
+	delete $6; // spec_notifier_opt
       }
   | K_Srecovery '(' spec_reference_event ',' spec_reference_event
     ',' delay_value spec_notifier_opt ')' ';'
@@ -5955,7 +5955,7 @@ specify_item
 	delete $3; // spec_reference_event
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
-	if($8) delete $8; // spec_notifier_opt
+	delete $8; // spec_notifier_opt
       }
   | K_Srecrem '(' spec_reference_event ',' spec_reference_event
     ',' expr_mintypmax ',' expr_mintypmax recrem_opt_args ')' ';'
@@ -5983,7 +5983,7 @@ specify_item
 	delete $3; // spec_reference_event
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
-	if($8) delete $8; // spec_notifier_opt
+	delete $8; // spec_notifier_opt
       }
   | K_Ssetup '(' spec_reference_event ',' spec_reference_event
     ',' delay_value spec_notifier_opt ')' ';'
@@ -5992,7 +5992,7 @@ specify_item
 	delete $3; // spec_reference_event
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
-	if($8) delete $8; // spec_notifier_opt
+	delete $8; // spec_notifier_opt
       }
   | K_Ssetuphold '(' spec_reference_event ',' spec_reference_event
     ',' expr_mintypmax ',' expr_mintypmax setuphold_opt_args ')' ';'
@@ -6020,7 +6020,7 @@ specify_item
 	delete $3; // spec_reference_event
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
-	if($8) delete $8; // spec_notifier_opt
+	delete $8; // spec_notifier_opt
       }
   | K_Stimeskew '(' spec_reference_event ',' spec_reference_event
     ',' delay_value timeskew_opt_args ')' ';'
@@ -6030,9 +6030,9 @@ specify_item
 	delete $5; // spec_reference_event
 	delete $7; // delay_value
 
-	if ($8->notifier) delete $8->notifier;
-	if ($8->event_based_flag) delete $8->event_based_flag;
-	if ($8->remain_active_flag) delete $8->remain_active_flag;
+	delete $8->notifier;
+	delete $8->event_based_flag;
+	delete $8->remain_active_flag;
 
 	delete $8; // timeskew_opt_args
       }
@@ -6043,7 +6043,7 @@ specify_item
 	delete $3; // spec_reference_event
 	delete $5; // delay_value
 	delete $7; // expression
-	if($8) delete $8;
+	delete $8;
       }
   | K_Swidth '(' spec_reference_event ',' delay_value ')' ';'
       {

--- a/parse.y
+++ b/parse.y
@@ -6378,7 +6378,7 @@ setuphold_recrem_opt_timestamp_cond
         PTimingCheck::optional_args_t* args = new PTimingCheck::optional_args_t;
         $$ = args;
       }
-  | ',' hierarchy_identifier // End of list
+  | ',' expression // End of list
       {
         PTimingCheck::optional_args_t* args = new PTimingCheck::optional_args_t;
         args->timestamp_cond = $2;
@@ -6386,7 +6386,7 @@ setuphold_recrem_opt_timestamp_cond
       }
   | ',' setuphold_recrem_opt_timecheck_cond // Empty
       { $$ = $2; }
-  | ',' hierarchy_identifier setuphold_recrem_opt_timecheck_cond
+  | ',' expression setuphold_recrem_opt_timecheck_cond
         {
           $$ = $3;
           $$->timestamp_cond = $2;
@@ -6399,7 +6399,7 @@ setuphold_recrem_opt_timecheck_cond
         PTimingCheck::optional_args_t* args = new PTimingCheck::optional_args_t;
         $$ = args;
       }
-  | ',' hierarchy_identifier // End of list
+  | ',' expression // End of list
       {
         PTimingCheck::optional_args_t* args = new PTimingCheck::optional_args_t;
         args->timecheck_cond = $2;
@@ -6407,7 +6407,7 @@ setuphold_recrem_opt_timecheck_cond
       }
   | ',' setuphold_recrem_opt_delayed_reference // Empty
       { $$ = $2; }
-  | ',' hierarchy_identifier setuphold_recrem_opt_delayed_reference
+  | ',' expression setuphold_recrem_opt_delayed_reference
         {
           $$ = $3;
           $$->timecheck_cond = $2;

--- a/parse.y
+++ b/parse.y
@@ -33,6 +33,7 @@
 # include  <stack>
 # include  <cstring>
 # include  <sstream>
+# include  <memory>
 
 using namespace std;
 
@@ -5970,11 +5971,9 @@ specify_item
 		cerr << endl;
 	}
 
-	PRecRem*recrem = pform_make_recrem(@1, *$3, *$5, $7, $9, $10);
-	pform_module_timing_check((PTimingCheck*)recrem);
+	PRecRem*recrem = pform_make_recrem(@1, $3, $5, $7, $9, $10);
+	pform_module_timing_check(recrem);
 
-	delete $3; // spec_reference_event
-	delete $5; // spec_reference_event
 	delete $10; // setuphold_recrem_opt_notifier
       }
   | K_Sremoval '(' spec_reference_event ',' spec_reference_event
@@ -6009,11 +6008,9 @@ specify_item
 		cerr << endl;
 	}
 
-	PSetupHold*setuphold = pform_make_setuphold(@1, *$3, *$5, $7, $9, $10);
-	pform_module_timing_check((PTimingCheck*)setuphold);
+	PSetupHold*setuphold = pform_make_setuphold(@1, $3, $5, $7, $9, $10);
+	pform_module_timing_check(setuphold);
 
-	delete $3; // spec_reference_event
-	delete $5; // spec_reference_event
 	delete $10; // setuphold_recrem_opt_notifier
       }
   | K_Sskew '(' spec_reference_event ',' spec_reference_event
@@ -6267,7 +6264,7 @@ spec_reference_event
 	event->name = *$1;
 	event->posedge = false;
 	event->negedge = false;
-	event->condition = $3;
+	event->condition = std::unique_ptr<PExpr>($3);
 	delete $1;
 	$$ = event;
       }
@@ -6294,7 +6291,7 @@ spec_reference_event
 	event->name = *$2;
 	event->posedge = true;
 	event->negedge = false;
-	event->condition = $4;
+	event->condition = std::unique_ptr<PExpr>($4);
 	delete $2;
 	$$ = event;
       }
@@ -6303,7 +6300,7 @@ spec_reference_event
 	event->name = *$2;
 	event->posedge = false;
 	event->negedge = true;
-	event->condition = $4;
+	event->condition = std::unique_ptr<PExpr>($4);
 	delete $2;
 	$$ = event;
       }
@@ -6323,7 +6320,7 @@ spec_reference_event
 	event->posedge = false;
 	event->negedge = false;
 	// TODO add edge descriptors
-	event->condition = $7;
+	event->condition = std::unique_ptr<PExpr>($7);
 	delete $5;
 	$$ = event;
       }
@@ -6526,14 +6523,14 @@ timeskew_fullskew_opt_remain_active_flag
 
 spec_notifier_opt
   : /* empty */
-      { $$ = 0; }
+      { $$ = nullptr; }
   | spec_notifier
       { $$ = $1; }
   ;
 
 spec_notifier
   : ','
-      { $$ = 0; }
+      { $$ = nullptr; }
   | ','  hierarchy_identifier
       { $$ = $2; }
   ;

--- a/pform.cc
+++ b/pform.cc
@@ -3113,59 +3113,55 @@ extern void pform_module_specify_path(PSpecPath*obj)
 /*
  * Timing checks.
  */
- extern PRecRem* pform_make_rec_rem(const struct vlltype&li,
+ extern PRecRem* pform_make_recrem(const struct vlltype&li,
 			 PTimingCheck::event_t&reference_event,
 			 PTimingCheck::event_t&data_event,
-			 PExpr&setup_limit,
-			 PExpr&hold_limit,
-			 pform_name_t* notifier,
-			 pform_name_t* timestamp_cond,
-			 pform_name_t* timecheck_cond,
-			 pform_name_t* delayed_reference,
-			 pform_name_t* delayed_data)
+			 PExpr*setup_limit,
+			 PExpr*hold_limit,
+			 PTimingCheck::optional_args_t* args)
 {
-      PRecRem*rec_rem = new PRecRem(
+      ivl_assert(li, args);
+
+      PRecRem*recrem = new PRecRem(
 	      reference_event,
 	      data_event,
-	      //setup_limit,
-	      //hold_limit,
-	      notifier,
-	      timestamp_cond,
-	      timecheck_cond,
-	      delayed_reference,
-	      delayed_data
+	      setup_limit,
+	      hold_limit,
+	      args->notifier,
+	      args->timestamp_cond,
+	      args->timecheck_cond,
+	      args->delayed_reference,
+	      args->delayed_data
       );
 
-      FILE_NAME(rec_rem, li);
+      FILE_NAME(recrem, li);
 
-      return rec_rem;
+      return recrem;
 }
-extern PSetupHold* pform_make_setup_hold(const struct vlltype&li,
+extern PSetupHold* pform_make_setuphold(const struct vlltype&li,
 			 PTimingCheck::event_t&reference_event,
 			 PTimingCheck::event_t&data_event,
-			 PExpr&setup_limit,
-			 PExpr&hold_limit,
-			 pform_name_t* notifier,
-			 pform_name_t* timestamp_cond,
-			 pform_name_t* timecheck_cond,
-			 pform_name_t* delayed_reference,
-			 pform_name_t* delayed_data)
+			 PExpr*setup_limit,
+			 PExpr*hold_limit,
+			 PTimingCheck::optional_args_t* args)
 {
-      PSetupHold*setup_hold = new PSetupHold(
+      ivl_assert(li, args);
+
+      PSetupHold*setuphold = new PSetupHold(
 	      reference_event,
 	      data_event,
-	      //setup_limit,
-	      //hold_limit,
-	      notifier,
-	      timestamp_cond,
-	      timecheck_cond,
-	      delayed_reference,
-	      delayed_data
+	      setup_limit,
+	      hold_limit,
+	      args->notifier,
+	      args->timestamp_cond,
+	      args->timecheck_cond,
+	      args->delayed_reference,
+	      args->delayed_data
       );
 
-      FILE_NAME(setup_hold, li);
+      FILE_NAME(setuphold, li);
 
-      return setup_hold;
+      return setuphold;
 }
 
 extern void pform_module_timing_check(PTimingCheck*obj)

--- a/pform.cc
+++ b/pform.cc
@@ -3114,8 +3114,8 @@ extern void pform_module_specify_path(PSpecPath*obj)
  * Timing checks.
  */
  extern PRecRem* pform_make_recrem(const struct vlltype&li,
-			 PTimingCheck::event_t&reference_event,
-			 PTimingCheck::event_t&data_event,
+			 PTimingCheck::event_t*reference_event,
+			 PTimingCheck::event_t*data_event,
 			 PExpr*setup_limit,
 			 PExpr*hold_limit,
 			 PTimingCheck::optional_args_t* args)
@@ -3139,8 +3139,8 @@ extern void pform_module_specify_path(PSpecPath*obj)
       return recrem;
 }
 extern PSetupHold* pform_make_setuphold(const struct vlltype&li,
-			 PTimingCheck::event_t&reference_event,
-			 PTimingCheck::event_t&data_event,
+			 PTimingCheck::event_t*reference_event,
+			 PTimingCheck::event_t*data_event,
 			 PExpr*setup_limit,
 			 PExpr*hold_limit,
 			 PTimingCheck::optional_args_t* args)
@@ -3166,7 +3166,7 @@ extern PSetupHold* pform_make_setuphold(const struct vlltype&li,
 
 extern void pform_module_timing_check(PTimingCheck*obj)
 {
-      if (obj == 0)
+      if (!obj)
 	    return;
 
       pform_cur_module.front()->timing_checks.push_back(obj);

--- a/pform.cc
+++ b/pform.cc
@@ -32,6 +32,7 @@
 # include  "PGenerate.h"
 # include  "PModport.h"
 # include  "PSpec.h"
+# include  "PTimingCheck.h"
 # include  "discipline.h"
 # include  <list>
 # include  <map>
@@ -3107,6 +3108,72 @@ extern void pform_module_specify_path(PSpecPath*obj)
       if (obj == 0)
 	    return;
       pform_cur_module.front()->specify_paths.push_back(obj);
+}
+
+/*
+ * Timing checks.
+ */
+ extern PRecRem* pform_make_rec_rem(const struct vlltype&li,
+			 PTimingCheck::event_t&reference_event,
+			 PTimingCheck::event_t&data_event,
+			 PExpr&setup_limit,
+			 PExpr&hold_limit,
+			 pform_name_t* notifier,
+			 pform_name_t* timestamp_cond,
+			 pform_name_t* timecheck_cond,
+			 pform_name_t* delayed_reference,
+			 pform_name_t* delayed_data)
+{
+      PRecRem*rec_rem = new PRecRem(
+	      reference_event,
+	      data_event,
+	      //setup_limit,
+	      //hold_limit,
+	      notifier,
+	      timestamp_cond,
+	      timecheck_cond,
+	      delayed_reference,
+	      delayed_data
+      );
+
+      FILE_NAME(rec_rem, li);
+
+      return rec_rem;
+}
+extern PSetupHold* pform_make_setup_hold(const struct vlltype&li,
+			 PTimingCheck::event_t&reference_event,
+			 PTimingCheck::event_t&data_event,
+			 PExpr&setup_limit,
+			 PExpr&hold_limit,
+			 pform_name_t* notifier,
+			 pform_name_t* timestamp_cond,
+			 pform_name_t* timecheck_cond,
+			 pform_name_t* delayed_reference,
+			 pform_name_t* delayed_data)
+{
+      PSetupHold*setup_hold = new PSetupHold(
+	      reference_event,
+	      data_event,
+	      //setup_limit,
+	      //hold_limit,
+	      notifier,
+	      timestamp_cond,
+	      timecheck_cond,
+	      delayed_reference,
+	      delayed_data
+      );
+
+      FILE_NAME(setup_hold, li);
+
+      return setup_hold;
+}
+
+extern void pform_module_timing_check(PTimingCheck*obj)
+{
+      if (obj == 0)
+	    return;
+
+      pform_cur_module.front()->timing_checks.push_back(obj);
 }
 
 

--- a/pform.h
+++ b/pform.h
@@ -433,27 +433,19 @@ extern void pform_module_specify_path(PSpecPath*obj);
 /*
  * Functions related to timing checks.
  */
-extern PRecRem* pform_make_rec_rem(const struct vlltype&li,
+extern PRecRem* pform_make_recrem(const struct vlltype&li,
 			    PTimingCheck::event_t&reference_event,
 			    PTimingCheck::event_t&data_event,
-			    PExpr&setup_limit,
-			    PExpr&hold_limit,
-			    pform_name_t* notifier,
-			    pform_name_t* timestamp_cond,
-			    pform_name_t* timecheck_cond,
-			    pform_name_t* delayed_reference,
-			    pform_name_t* delayed_data
+			    PExpr*setup_limit,
+			    PExpr*hold_limit,
+			    PTimingCheck::optional_args_t* args
 			    );
-extern PSetupHold* pform_make_setup_hold(const struct vlltype&li,
+extern PSetupHold* pform_make_setuphold(const struct vlltype&li,
 			    PTimingCheck::event_t&reference_event,
 			    PTimingCheck::event_t&data_event,
-			    PExpr&setup_limit,
-			    PExpr&hold_limit,
-			    pform_name_t* notifier,
-			    pform_name_t* timestamp_cond,
-			    pform_name_t* timecheck_cond,
-			    pform_name_t* delayed_reference,
-			    pform_name_t* delayed_data
+			    PExpr*setup_limit,
+			    PExpr*hold_limit,
+			    PTimingCheck::optional_args_t* args
 			    );
 extern void pform_module_timing_check(PTimingCheck*obj);
 

--- a/pform.h
+++ b/pform.h
@@ -30,6 +30,7 @@
 # include  "PTask.h"
 # include  "PUdp.h"
 # include  "PWire.h"
+# include  "PTimingCheck.h"
 # include  "verinum.h"
 # include  "discipline.h"
 # include  <iostream>
@@ -428,6 +429,33 @@ extern PSpecPath*pform_make_specify_edge_path(const struct vlltype&li,
 extern PSpecPath*pform_assign_path_delay(PSpecPath*obj, std::list<PExpr*>*delays);
 
 extern void pform_module_specify_path(PSpecPath*obj);
+
+/*
+ * Functions related to timing checks.
+ */
+extern PRecRem* pform_make_rec_rem(const struct vlltype&li,
+			    PTimingCheck::event_t&reference_event,
+			    PTimingCheck::event_t&data_event,
+			    PExpr&setup_limit,
+			    PExpr&hold_limit,
+			    pform_name_t* notifier,
+			    pform_name_t* timestamp_cond,
+			    pform_name_t* timecheck_cond,
+			    pform_name_t* delayed_reference,
+			    pform_name_t* delayed_data
+			    );
+extern PSetupHold* pform_make_setup_hold(const struct vlltype&li,
+			    PTimingCheck::event_t&reference_event,
+			    PTimingCheck::event_t&data_event,
+			    PExpr&setup_limit,
+			    PExpr&hold_limit,
+			    pform_name_t* notifier,
+			    pform_name_t* timestamp_cond,
+			    pform_name_t* timecheck_cond,
+			    pform_name_t* delayed_reference,
+			    pform_name_t* delayed_data
+			    );
+extern void pform_module_timing_check(PTimingCheck*obj);
 
 /*
  * pform_make_behavior creates processes that are declared with always

--- a/pform.h
+++ b/pform.h
@@ -434,15 +434,15 @@ extern void pform_module_specify_path(PSpecPath*obj);
  * Functions related to timing checks.
  */
 extern PRecRem* pform_make_recrem(const struct vlltype&li,
-			    PTimingCheck::event_t&reference_event,
-			    PTimingCheck::event_t&data_event,
+			    PTimingCheck::event_t*reference_event,
+			    PTimingCheck::event_t*data_event,
 			    PExpr*setup_limit,
 			    PExpr*hold_limit,
 			    PTimingCheck::optional_args_t* args
 			    );
 extern PSetupHold* pform_make_setuphold(const struct vlltype&li,
-			    PTimingCheck::event_t&reference_event,
-			    PTimingCheck::event_t&data_event,
+			    PTimingCheck::event_t*reference_event,
+			    PTimingCheck::event_t*data_event,
 			    PExpr*setup_limit,
 			    PExpr*hold_limit,
 			    PTimingCheck::optional_args_t* args

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -1442,6 +1442,16 @@ void PSpecPath::dump(std::ostream&out, unsigned ind) const
       out << ");" << endl;
 }
 
+void PRecRem::dump(std::ostream&out, unsigned ind) const
+{
+	    out << setw(ind) << "" << "recrem ";
+}
+
+void PSetupHold::dump(std::ostream&out, unsigned ind) const
+{
+	    out << setw(ind) << "" << "setuphold ";
+}
+
 void PGenerate::dump(ostream&out, unsigned indent) const
 {
       out << setw(indent) << "" << "generate(" << id_number << ")";
@@ -1704,6 +1714,17 @@ void Module::dump_specparams_(ostream&out, unsigned indent) const
       }
 }
 
+void Module::dump_timingchecks_(ostream&out, unsigned indent) const
+{
+      cout << "dump_timingchecks_" << endl;
+
+      typedef list<PTimingCheck*>::const_iterator tcheck_iter_t;
+      for (tcheck_iter_t cur = timing_checks.begin()
+		 ; cur != timing_checks.end() ; ++ cur ) {
+		 (*cur)->dump(out, indent);
+      }
+}
+
 void Module::dump(ostream&out) const
 {
       if (attributes.begin() != attributes.end()) {
@@ -1751,6 +1772,8 @@ void Module::dump(ostream&out) const
       dump_parameters_(out, 4);
 
       dump_specparams_(out, 4);
+
+      dump_timingchecks_(out, 4);
 
       dump_enumerations_(out, 4);
 

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -1718,10 +1718,8 @@ void Module::dump_timingchecks_(ostream&out, unsigned indent) const
 {
       cout << "dump_timingchecks_" << endl;
 
-      typedef list<PTimingCheck*>::const_iterator tcheck_iter_t;
-      for (tcheck_iter_t cur = timing_checks.begin()
-		 ; cur != timing_checks.end() ; ++ cur ) {
-		 (*cur)->dump(out, indent);
+      for (const auto cur : timing_checks) {
+		cur->dump(out, indent);
       }
 }
 


### PR DESCRIPTION
Since timing checks are currently not supported in Icarus Verilog, they are ignored. This is an issue for some models:

Both `$setuphold` and `$recrem` have support for negative timing checks. For this to work, delayed versions of the reference and data signals must be created. The model has access to these delayed signals. The current situation is that these signals are never assigned.

This PR does what is proposed under 15.5.4 Option behavior in the standard. When timing checks are disabled (or in the case of Icarus Verilog not yet supported) the delayed reference and data signals become copies of the original reference and data signals.

For example, with the following timing check:

    $setuphold(posedge sig1, negedge sig2 , 0:0:0 , 0:0:0 , notifier , cond1 , cond2 , del_sig1 , del_sig2 ) ;

Internally the simulator does the following:

    assign del_sig1 = sig1;
    assign del_sig2 = sig2;

Two tests were added to the regression suite:

- `timing_check_delayed_signals` - This test checks what this PR implements
- `timing_check_syntax` - This test makes sure that all timing checks can still be parsed
