### PR TITLE
Avoid exponential execution time behavior in arith_expr_type()

### DIFF
--- a/net_expr.cc
+++ b/net_expr.cc
@@ -114,12 +114,15 @@ NetEBAdd::~NetEBAdd()
 
 static ivl_variable_type_t arith_expr_type(const NetExpr *l, const NetExpr *r)
 {
-      if (l->expr_type() == IVL_VT_REAL ||
-          r->expr_type() == IVL_VT_REAL)
+      auto l_expr_type = l->expr_type();
+      auto r_expr_type = r->expr_type();
+
+      if (l_expr_type == IVL_VT_REAL ||
+          r_expr_type == IVL_VT_REAL)
 	    return IVL_VT_REAL;
 
-      if (l->expr_type() == IVL_VT_LOGIC ||
-          r->expr_type() == IVL_VT_LOGIC)
+      if (l_expr_type == IVL_VT_LOGIC ||
+          r_expr_type == IVL_VT_LOGIC)
 	    return IVL_VT_LOGIC;
 
       return IVL_VT_BOOL;


### PR DESCRIPTION
arith_expr_type() queries the expression type of its two child nodes up to two times. Since the child nodes might also need to query their child nodes expression type to determine their own this can lead to an exponential runtime.

For complex expressions this can easily result in very long elaboration time.

Avoid this by querying the expression type only once for each child node.

Resolves #967