### PR TITLE
Make sure `const var` variables are constant

### DIFF
--- a/ivtest/ivltests/sv_const_fail9.v
+++ b/ivtest/ivltests/sv_const_fail9.v
@@ -1,0 +1,13 @@
+// Check that blocking assignment to a const variable fails, when the variable is
+// declared with the `var` keyword.
+
+module test;
+
+  const var integer x = 10;
+
+  initial begin
+    x = 20; // Error: Assignment to const variable
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -73,6 +73,7 @@ sv_const_fail5			vvp_tests/sv_const_fail5.json
 sv_const_fail6			vvp_tests/sv_const_fail6.json
 sv_const_fail7			vvp_tests/sv_const_fail7.json
 sv_const_fail8			vvp_tests/sv_const_fail8.json
+sv_const_fail9			vvp_tests/sv_const_fail9.json
 sv_foreach9			vvp_tests/sv_foreach9.json
 sv_foreach10			vvp_tests/sv_foreach10.json
 sv_module_port1			vvp_tests/sv_module_port1.json

--- a/ivtest/vvp_tests/sv_const_fail9.json
+++ b/ivtest/vvp_tests/sv_const_fail9.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_const_fail9.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/parse.y
+++ b/parse.y
@@ -2738,7 +2738,7 @@ block_item_decl
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
 	      FILE_NAME(data_type, @2);
 	}
-	pform_make_var(@2, $5, data_type, attributes_in_context);
+	pform_make_var(@2, $5, data_type, attributes_in_context, $1);
 	var_lifetime = LexicalScope::INHERITED;
       }
 


### PR DESCRIPTION
Commit 3daa2982acb2 ("Add support for `const` variables") added support for
constant variables, but had a small mistake and did propagate the constant
flag from the parser if the variable is declared with the `var` keyword.
Still allowing to modify those variables. Fix this.