### PR TITLE
Always evaluate `vvp_fun_modpath_src` first

### DIFF
--- a/vvp/vvp_net.cc
+++ b/vvp/vvp_net.cc
@@ -199,8 +199,38 @@ vvp_net_t::vvp_net_t()
 void vvp_net_t::link(vvp_net_ptr_t port_to_link)
 {
       vvp_net_t*net = port_to_link.ptr();
-      net->port[port_to_link.port()] = out_;
-      out_ = port_to_link;
+
+      // Connect nodes with vvp_fun_modpath_src to the head of the
+      // linked list, so that vvp_fun_modpath_src are always evaluated
+      // before their respective vvp_fun_modpath
+      if (dynamic_cast<vvp_fun_modpath_src*>(net->fun))
+      {
+	      net->port[port_to_link.port()] = out_;
+	      out_ = port_to_link;
+      }
+      // All other nodes connect to the tail of the linked list
+      else
+      {
+	      // List is empty, just point to port_to_link
+	      if (out_.ptr() == nullptr)
+	      {
+		      out_ = port_to_link;
+		      net->port[port_to_link.port()] = vvp_net_ptr_t(nullptr,0);
+		      return;
+	      }
+
+	      vvp_net_ptr_t cur = out_;
+
+	      // Traverse through linked list
+	      while (cur.ptr()->port[cur.port()].ptr())
+	      {
+		      cur = cur.ptr()->port[cur.port()];
+	      }
+
+	      // Connect to the tail of list
+	      cur.ptr()->port[cur.port()] = port_to_link;
+	      net->port[port_to_link.port()] = vvp_net_ptr_t(nullptr,0);
+      }
 }
 
 /*

--- a/vvp/vvp_net.cc
+++ b/vvp/vvp_net.cc
@@ -208,28 +208,34 @@ void vvp_net_t::link(vvp_net_ptr_t port_to_link)
 	      net->port[port_to_link.port()] = out_;
 	      out_ = port_to_link;
       }
-      // All other nodes connect to the tail of the linked list
+      // All other nodes connect after the last vvp_fun_modpath_src
       else
       {
-	      // List is empty, just point to port_to_link
-	      if (out_.ptr() == nullptr)
+	      // List is empty or first node has no vvp_fun_modpath_src
+	      // then just insert the node into the head of linked list
+	      if (out_.ptr() == nullptr || ! dynamic_cast<vvp_fun_modpath_src*>(out_.ptr()->fun))
 	      {
+		      net->port[port_to_link.port()] = out_;
 		      out_ = port_to_link;
-		      net->port[port_to_link.port()] = vvp_net_ptr_t(nullptr,0);
 		      return;
 	      }
 
 	      vvp_net_ptr_t cur = out_;
+	      vvp_net_ptr_t prev = vvp_net_ptr_t(nullptr,0);
 
 	      // Traverse through linked list
-	      while (cur.ptr()->port[cur.port()].ptr())
+	      while (dynamic_cast<vvp_fun_modpath_src*>(cur.ptr()->fun))
 	      {
+		      prev = cur;
 		      cur = cur.ptr()->port[cur.port()];
+		      if (!cur.ptr()) break; // End of list
 	      }
 
-	      // Connect to the tail of list
-	      cur.ptr()->port[cur.port()] = port_to_link;
-	      net->port[port_to_link.port()] = vvp_net_ptr_t(nullptr,0);
+	      assert(prev.ptr());
+
+	      // Insert after last vvp_fun_modpath_src (or end of list)
+	      net->port[port_to_link.port()] = cur;
+	      prev.ptr()->port[prev.port()] = port_to_link;
       }
 }
 


### PR DESCRIPTION
Fixes #985

This PR ensures that whenever any `vvp_net_t`s are connected via `vvp_net_t::link`, nodes with `vvp_fun_modpath_src` are always inserted at the head of the linked list.

This guarantees that `vvp_fun_modpath_src`  are always evaluated before their respective `vvp_fun_modpath`, without any runtime penalty. 