### PR TITLE
Fix Typo in vvp's scope search in interactive mode.

### DIFF
--- a/vvp/stop.cc
+++ b/vvp/stop.cc
@@ -138,7 +138,7 @@ static void cmd_call(unsigned argc, char*argv[])
 		      case vpiTask:
 		      case vpiNamedBegin:
 		      case vpiNamedFork:
-			scope = dynamic_cast<__vpiScope*>(table[idx]);
+			scope = dynamic_cast<__vpiScope*>(table[tmp]);
 			if (strcmp(scope->scope_name(), argv[idx+1]) == 0)
 			      handle = table[tmp];
 			break;


### PR DESCRIPTION
When `vvp` reads a command from the user which it thinks is a system call (because it starts with `$`). it tries to match the other strings to values in the scope. Because of the typo, `vvp` uses the wrong index variable to access the vpi table. This results in a failed [dynamic_cast](https://en.cppreference.com/w/cpp/language/dynamic_cast) which goes unchecked until the value is dereferenced, resulting in a segfault.