### PR TITLE
Add support for binding function/task arguments by name

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -114,7 +114,8 @@ O = main.o async.o design_dump.o discipline.o dup_expr.o elaborate.o \
     net_event.o net_expr.o net_func.o \
     net_func_eval.o net_link.o net_modulo.o \
     net_nex_input.o net_nex_output.o net_proc.o net_scope.o net_tran.o \
-    net_udp.o pad_to_width.o parse.o parse_misc.o pform.o pform_analog.o \
+    net_udp.o map_named_args.o \
+    pad_to_width.o parse.o parse_misc.o pform.o pform_analog.o \
     pform_disciplines.o pform_dump.o pform_package.o pform_pclass.o \
     pform_types.o \
     symbol_search.o sync.o sys_funcs.o verinum.o verireal.o vpi_modules.o target.o \

--- a/PExpr.cc
+++ b/PExpr.cc
@@ -215,12 +215,12 @@ PEBShift::~PEBShift()
 {
 }
 
-PECallFunction::PECallFunction(const pform_name_t&n, const vector<PExpr *> &parms)
+PECallFunction::PECallFunction(const pform_name_t &n, const vector<named_pexpr_t> &parms)
 : path_(n), parms_(parms), is_overridden_(false)
 {
 }
 
-PECallFunction::PECallFunction(PPackage*pkg, const pform_name_t&n, const vector<PExpr *> &parms)
+PECallFunction::PECallFunction(PPackage *pkg, const pform_name_t &n, const vector<named_pexpr_t> &parms)
 : path_(pkg, n), parms_(parms), is_overridden_(false)
 {
 }
@@ -233,12 +233,12 @@ static pform_name_t pn_from_ps(perm_string n)
       return tmp;
 }
 
-PECallFunction::PECallFunction(PPackage*pkg, const pform_name_t&n, const list<PExpr *> &parms)
+PECallFunction::PECallFunction(PPackage *pkg, const pform_name_t &n, const list<named_pexpr_t> &parms)
 : path_(pkg, n), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
 }
 
-PECallFunction::PECallFunction(perm_string n, const vector<PExpr*>&parms)
+PECallFunction::PECallFunction(perm_string n, const vector<named_pexpr_t> &parms)
 : path_(pn_from_ps(n)), parms_(parms), is_overridden_(false)
 {
 }
@@ -249,13 +249,13 @@ PECallFunction::PECallFunction(perm_string n)
 }
 
 // NOTE: Anachronism. Try to work all use of svector out.
-PECallFunction::PECallFunction(const pform_name_t&n, const list<PExpr *> &parms)
+PECallFunction::PECallFunction(const pform_name_t &n, const list<named_pexpr_t> &parms)
 : path_(n), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
 }
 
-PECallFunction::PECallFunction(perm_string n, const list<PExpr*>&parms)
-: package_(0), path_(pn_from_ps(n)), parms_(parms.begin(), parms.end()), is_overridden_(false)
+PECallFunction::PECallFunction(perm_string n, const list<named_pexpr_t> &parms)
+: path_(pn_from_ps(n)), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
 }
 
@@ -265,18 +265,18 @@ PECallFunction::~PECallFunction()
 
 void PECallFunction::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 {
-      for (unsigned idx = 0 ; idx < parms_.size() ; idx += 1) {
-	    if (parms_[idx])
-		  parms_[idx]->declare_implicit_nets(scope, type);
+      for (const auto &parm : parms_) {
+	    if (parm.parm)
+		  parm.parm->declare_implicit_nets(scope, type);
       }
 }
 
 bool PECallFunction::has_aa_term(Design*des, NetScope*scope) const
 {
       bool flag = false;
-      for (unsigned idx = 0 ; idx < parms_.size() ; idx += 1) {
-	    if (parms_[idx])
-		  flag |= parms_[idx]->has_aa_term(des, scope);
+      for (const auto &parm : parms_) {
+	    if (parm.parm)
+		  flag |= parm.parm->has_aa_term(des, scope);
       }
       return flag;
 }
@@ -466,7 +466,7 @@ PENewClass::PENewClass(void)
 {
 }
 
-PENewClass::PENewClass(const list<PExpr*>&p, data_type_t *class_type)
+PENewClass::PENewClass(const list<named_pexpr_t> &p, data_type_t *class_type)
 : parms_(p.begin(), p.end()), class_type_(class_type)
 {
 }

--- a/PExpr.cc
+++ b/PExpr.cc
@@ -99,14 +99,8 @@ PEAssignPattern::PEAssignPattern()
 }
 
 PEAssignPattern::PEAssignPattern(const list<PExpr*>&p)
-: parms_(p.size())
+: parms_(p.begin(), p.end())
 {
-      size_t idx = 0;
-      for (list<PExpr*>::const_iterator cur = p.begin()
-		 ; cur != p.end() ; ++cur) {
-	    parms_[idx] = *cur;
-	    idx += 1;
-      }
 }
 
 PEAssignPattern::~PEAssignPattern()
@@ -239,14 +233,9 @@ static pform_name_t pn_from_ps(perm_string n)
       return tmp;
 }
 
-PECallFunction::PECallFunction(PPackage*pkg, const pform_name_t &n, const list<PExpr *> &parms)
-: path_(pkg, n), parms_(parms.size()), is_overridden_(false)
+PECallFunction::PECallFunction(PPackage*pkg, const pform_name_t&n, const list<PExpr *> &parms)
+: path_(pkg, n), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
-      int tmp_idx = 0;
-      ivl_assert(*this, parms_.size() == parms.size());
-      for (list<PExpr*>::const_iterator idx = parms.begin()
-		 ; idx != parms.end() ; ++idx)
-	    parms_[tmp_idx++] = *idx;
 }
 
 PECallFunction::PECallFunction(perm_string n, const vector<PExpr*>&parms)
@@ -261,23 +250,13 @@ PECallFunction::PECallFunction(perm_string n)
 
 // NOTE: Anachronism. Try to work all use of svector out.
 PECallFunction::PECallFunction(const pform_name_t&n, const list<PExpr *> &parms)
-: path_(n), parms_(parms.size()), is_overridden_(false)
+: path_(n), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
-      int tmp_idx = 0;
-      ivl_assert(*this, parms_.size() == parms.size());
-      for (list<PExpr*>::const_iterator idx = parms.begin()
-		 ; idx != parms.end() ; ++idx)
-	    parms_[tmp_idx++] = *idx;
 }
 
 PECallFunction::PECallFunction(perm_string n, const list<PExpr*>&parms)
-: path_(pn_from_ps(n)), parms_(parms.size()), is_overridden_(false)
+: package_(0), path_(pn_from_ps(n)), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
-      int tmp_idx = 0;
-      ivl_assert(*this, parms_.size() == parms.size());
-      for (list<PExpr*>::const_iterator idx = parms.begin()
-		 ; idx != parms.end() ; ++idx)
-	    parms_[tmp_idx++] = *idx;
 }
 
 PECallFunction::~PECallFunction()
@@ -303,14 +282,8 @@ bool PECallFunction::has_aa_term(Design*des, NetScope*scope) const
 }
 
 PEConcat::PEConcat(const list<PExpr*>&p, PExpr*r)
-: parms_(p.size()), width_modes_(SIZED, p.size()), repeat_(r)
+: parms_(p.begin(), p.end()), width_modes_(SIZED, p.size()), repeat_(r)
 {
-      int tmp_idx = 0;
-      ivl_assert(*this, parms_.size() == p.size());
-      for (list<PExpr*>::const_iterator idx = p.begin()
-		 ; idx != p.end() ; ++idx)
-	    parms_[tmp_idx++] = *idx;
-
       tested_scope_ = 0;
       repeat_count_ = 1;
 }
@@ -494,13 +467,8 @@ PENewClass::PENewClass(void)
 }
 
 PENewClass::PENewClass(const list<PExpr*>&p, data_type_t *class_type)
-: parms_(p.size()), class_type_(class_type)
+: parms_(p.begin(), p.end()), class_type_(class_type)
 {
-      size_t tmp_idx = 0;
-      for (list<PExpr*>::const_iterator cur = p.begin()
-		 ; cur != p.end() ; ++ cur) {
-	    parms_[tmp_idx++] = *cur;
-      }
 }
 
 PENewClass::~PENewClass()

--- a/PExpr.h
+++ b/PExpr.h
@@ -570,7 +570,7 @@ class PENewClass : public PExpr {
 	// New without (or with default) constructor
       explicit PENewClass ();
 	// New with constructor arguments
-      explicit PENewClass (const std::list<PExpr*>&p,
+      explicit PENewClass (const std::list<named_pexpr_t> &p,
 			   data_type_t *class_type = nullptr);
 
       ~PENewClass();
@@ -592,7 +592,7 @@ class PENewClass : public PExpr {
 					   NetExpr*obj, unsigned flags) const;
 
     private:
-      std::vector<PExpr*>parms_;
+      std::vector<named_pexpr_t> parms_;
       data_type_t *class_type_;
 };
 
@@ -895,20 +895,20 @@ class PETernary : public PExpr {
  */
 class PECallFunction : public PExpr {
     public:
-      explicit PECallFunction(const pform_name_t&n, const std::vector<PExpr *> &parms);
+      explicit PECallFunction(const pform_name_t &n, const std::vector<named_pexpr_t> &parms);
 	// Call function defined in package.
-      explicit PECallFunction(PPackage*pkg, const pform_name_t&n, const std::list<PExpr *> &parms);
+      explicit PECallFunction(PPackage *pkg, const pform_name_t &n, const std::list<named_pexpr_t> &parms);
 
 	// Used to convert a user function called as a task
-      explicit PECallFunction(PPackage*pkg, const pform_name_t&n, const std::vector<PExpr *> &parms);
+      explicit PECallFunction(PPackage *pkg, const pform_name_t &n, const std::vector<named_pexpr_t> &parms);
 
 	// Call of system function (name is not hierarchical)
-      explicit PECallFunction(perm_string n, const std::vector<PExpr *> &parms);
+      explicit PECallFunction(perm_string n, const std::vector<named_pexpr_t> &parms);
       explicit PECallFunction(perm_string n);
 
 	// std::list versions. Should be removed!
-      explicit PECallFunction(const pform_name_t&n, const std::list<PExpr *> &parms);
-      explicit PECallFunction(perm_string n, const std::list<PExpr *> &parms);
+      explicit PECallFunction(const pform_name_t &n, const std::list<named_pexpr_t> &parms);
+      explicit PECallFunction(perm_string n, const std::list<named_pexpr_t> &parms);
 
       ~PECallFunction();
 
@@ -929,7 +929,7 @@ class PECallFunction : public PExpr {
 
     private:
       pform_scoped_name_t path_;
-      std::vector<PExpr *> parms_;
+      std::vector<named_pexpr_t> parms_;
 
         // For system functions.
       bool is_overridden_;

--- a/PGate.cc
+++ b/PGate.cc
@@ -270,7 +270,7 @@ PGModule::PGModule(perm_string type, perm_string name, list<PExpr*>*pins)
 }
 
 PGModule::PGModule(perm_string type, perm_string name,
-		   named<PExpr*>*pins, unsigned npins)
+		   named_pexpr_t *pins, unsigned npins)
 : PGate(name, 0), bound_type_(0), type_(type), overrides_(0), pins_(pins),
   npins_(npins), parms_(0), nparms_(0)
 {
@@ -292,7 +292,7 @@ void PGModule::set_parameters(list<PExpr*>*o)
       overrides_ = o;
 }
 
-void PGModule::set_parameters(named<PExpr*>*pa, unsigned npa)
+void PGModule::set_parameters(named_pexpr_t *pa, unsigned npa)
 {
       ivl_assert(*this, parms_ == 0);
       ivl_assert(*this, overrides_ == 0);

--- a/PGate.h
+++ b/PGate.h
@@ -204,7 +204,7 @@ class PGModule  : public PGate {
 	// If the binding of ports is by name, this constructor takes
 	// the bindings and stores them for later elaboration.
       explicit PGModule(perm_string type, perm_string name,
-			named<PExpr*>*pins, unsigned npins);
+			named_pexpr_t *pins, unsigned npins);
 
 	// If the module type is known by design, then use this
 	// constructor.
@@ -215,7 +215,7 @@ class PGModule  : public PGate {
 	// Parameter overrides can come as an ordered list, or a set
 	// of named expressions.
       void set_parameters(std::list<PExpr*>*o);
-      void set_parameters(named<PExpr*>*pa, unsigned npa);
+      void set_parameters(named_pexpr_t *pa, unsigned npa);
 
       std::map<perm_string,PExpr*> attributes;
 
@@ -232,11 +232,11 @@ class PGModule  : public PGate {
       Module*bound_type_;
       perm_string type_;
       std::list<PExpr*>*overrides_;
-      named<PExpr*>*pins_;
+      named_pexpr_t *pins_;
       unsigned npins_;
 
 	// These members support parameter override by name
-      named<PExpr*>*parms_;
+      named_pexpr_t *parms_;
       unsigned nparms_;
 
       friend class delayed_elaborate_scope_mod_instances;

--- a/PSpec.cc
+++ b/PSpec.cc
@@ -19,10 +19,11 @@
 
 # include  "PSpec.h"
 
-PSpecPath::PSpecPath(unsigned src_cnt, unsigned dst_cnt, char polarity,
-                     bool full_flag)
+PSpecPath::PSpecPath(const std::list<perm_string> &src_list,
+		     const std::list<perm_string> &dst_list,
+		     char polarity, bool full_flag)
 : conditional(false), condition(0), edge(0),
-  src(src_cnt), dst(dst_cnt),
+  src(src_list.begin(), src_list.end()), dst(dst_list.begin(), dst_list.end()),
   data_source_expression(0)
 {
       full_flag_ = full_flag;

--- a/PSpec.h
+++ b/PSpec.h
@@ -22,6 +22,7 @@
 # include  "LineInfo.h"
 # include  "StringHeap.h"
 # include  <vector>
+# include  <list>
 
 class PExpr;
 
@@ -56,8 +57,9 @@ class PExpr;
 class PSpecPath  : public LineInfo {
 
     public:
-      PSpecPath(unsigned src_cnt, unsigned dst_cnt, char polarity,
-                bool full_flag);
+      PSpecPath(const std::list<perm_string> &src_list,
+	        const std::list<perm_string> &dst_list,
+		char polarity, bool full_flag);
       ~PSpecPath();
 
       void elaborate(class Design*des, class NetScope*scope) const;

--- a/PTask.h
+++ b/PTask.h
@@ -63,7 +63,8 @@ class PTaskFunc : public PScope, public PNamedItem {
 	// default value expressions, if any.
       void elaborate_sig_ports_(Design*des, NetScope*scope,
 				std::vector<NetNet*>&ports,
-				std::vector<NetExpr*>&pdefs) const;
+				std::vector<NetExpr*> &pdefs,
+				std::vector<perm_string> &port_names) const;
 
       void dump_ports_(std::ostream&out, unsigned ind) const;
 

--- a/Statement.cc
+++ b/Statement.cc
@@ -166,17 +166,17 @@ PNamedItem::SymbolType PBlock::symbol_type() const
       return BLOCK;
 }
 
-PCallTask::PCallTask(const pform_name_t&n, const list<PExpr*>&p)
+PCallTask::PCallTask(const pform_name_t &n, const list<named_pexpr_t> &p)
 : package_(0), path_(n), parms_(p.begin(), p.end())
 {
 }
 
-PCallTask::PCallTask(PPackage*pkg, const pform_name_t&n, const list<PExpr*>&p)
+PCallTask::PCallTask(PPackage *pkg, const pform_name_t &n, const list<named_pexpr_t> &p)
 : package_(pkg), path_(n), parms_(p.begin(), p.end())
 {
 }
 
-PCallTask::PCallTask(perm_string n, const list<PExpr*>&p)
+PCallTask::PCallTask(perm_string n, const list<named_pexpr_t> &p)
 : package_(0), parms_(p.begin(), p.end())
 {
       path_.push_back(name_component_t(n));
@@ -216,8 +216,13 @@ PCAssign::~PCAssign()
       delete expr_;
 }
 
-PChainConstructor::PChainConstructor(const list<PExpr*>&parms)
+PChainConstructor::PChainConstructor(const list<named_pexpr_t> &parms)
 : parms_(parms.begin(), parms.end())
+{
+}
+
+PChainConstructor::PChainConstructor(const vector<named_pexpr_t> &parms)
+: parms_(parms)
 {
 }
 

--- a/Statement.cc
+++ b/Statement.cc
@@ -167,36 +167,18 @@ PNamedItem::SymbolType PBlock::symbol_type() const
 }
 
 PCallTask::PCallTask(const pform_name_t&n, const list<PExpr*>&p)
-: package_(0), path_(n), parms_(p.size())
+: package_(0), path_(n), parms_(p.begin(), p.end())
 {
-      list<PExpr*>::const_iterator cur = p.begin();
-      for (size_t idx = 0 ; idx < parms_.size() ; idx += 1) {
-	    parms_[idx] = *cur;
-	    ++cur;
-      }
-      ivl_assert(*this, cur == p.end());
 }
 
 PCallTask::PCallTask(PPackage*pkg, const pform_name_t&n, const list<PExpr*>&p)
-: package_(pkg), path_(n), parms_(p.size())
+: package_(pkg), path_(n), parms_(p.begin(), p.end())
 {
-      list<PExpr*>::const_iterator cur = p.begin();
-      for (size_t idx = 0 ; idx < parms_.size() ; idx += 1) {
-	    parms_[idx] = *cur;
-	    ++cur;
-      }
-      ivl_assert(*this, cur == p.end());
 }
 
 PCallTask::PCallTask(perm_string n, const list<PExpr*>&p)
-: package_(0), parms_(p.size())
+: package_(0), parms_(p.begin(), p.end())
 {
-      list<PExpr*>::const_iterator cur = p.begin();
-      for (size_t idx = 0 ; idx < parms_.size() ; idx += 1) {
-	    parms_[idx] = *cur;
-	    ++cur;
-      }
-      ivl_assert(*this, cur == p.end());
       path_.push_back(name_component_t(n));
 }
 
@@ -235,14 +217,8 @@ PCAssign::~PCAssign()
 }
 
 PChainConstructor::PChainConstructor(const list<PExpr*>&parms)
-: parms_(parms.size())
+: parms_(parms.begin(), parms.end())
 {
-      list<PExpr*>::const_iterator cur = parms.begin();
-      for (size_t idx = 0 ; idx < parms_.size() ; idx += 1) {
-	    parms_[idx] = *cur;
-	    ++cur;
-      }
-      ivl_assert(*this, cur == parms.end());
 }
 
 PChainConstructor::~PChainConstructor()
@@ -350,12 +326,8 @@ PForce::~PForce()
 }
 
 PForeach::PForeach(perm_string av, const list<perm_string>&ix, Statement*s)
-: array_var_(av), index_vars_(ix.size()), statement_(s)
+: array_var_(av), index_vars_(ix.begin(), ix.end()), statement_(s)
 {
-      size_t idx = 0;
-      for (list<perm_string>::const_iterator cur = ix.begin()
-		 ; cur != ix.end() ; ++cur)
-	    index_vars_[idx++] = *cur;
 }
 
 PForeach::~PForeach()

--- a/Statement.h
+++ b/Statement.h
@@ -223,9 +223,9 @@ class PBreak : public Statement {
 class PCallTask  : public Statement {
 
     public:
-      explicit PCallTask(PPackage*pkg, const pform_name_t&n, const std::list<PExpr*>&parms);
-      explicit PCallTask(const pform_name_t&n, const std::list<PExpr*>&parms);
-      explicit PCallTask(perm_string n, const std::list<PExpr*>&parms);
+      explicit PCallTask(PPackage *pkg, const pform_name_t &n, const std::list<named_pexpr_t> &parms);
+      explicit PCallTask(const pform_name_t &n, const std::list<named_pexpr_t> &parms);
+      explicit PCallTask(perm_string n, const std::list<named_pexpr_t> &parms);
       ~PCallTask();
 
       const pform_name_t& path() const;
@@ -253,11 +253,13 @@ class PCallTask  : public Statement {
       NetProc*elaborate_sys_task_method_(Design*des, NetScope*scope,
 					 NetNet*net,
 					 perm_string method_name,
-					 const char*sys_task_name) const;
+					 const char *sys_task_name,
+				         const std::vector<perm_string> &parm_names = {}) const;
       NetProc*elaborate_queue_method_(Design*des, NetScope*scope,
 				      NetNet*net,
 				      perm_string method_name,
-				      const char*sys_task_name) const;
+				      const char *sys_task_name,
+				      const std::vector<perm_string> &parm_names) const;
       NetProc*elaborate_method_func_(NetScope*scope,
 				     NetNet*net,
 				     ivl_type_t type,
@@ -267,7 +269,7 @@ class PCallTask  : public Statement {
 
       PPackage*package_;
       pform_name_t path_;
-      std::vector<PExpr*> parms_;
+      std::vector<named_pexpr_t> parms_;
       bool void_cast_ = false;
 };
 
@@ -320,17 +322,18 @@ class PCAssign  : public Statement {
  */
 class PChainConstructor : public Statement {
     public:
-      explicit PChainConstructor(const std::list<PExpr*>&parms);
+      explicit PChainConstructor(const std::list<named_pexpr_t> &parms);
+      explicit PChainConstructor(const std::vector<named_pexpr_t> &parms);
       ~PChainConstructor();
 
       virtual NetProc* elaborate(Design*des, NetScope*scope) const;
       virtual void dump(std::ostream&out, unsigned ind) const;
 
-      inline const std::vector<PExpr*>& chain_args(void) const
+      inline const std::vector<named_pexpr_t>& chain_args(void) const
       { return parms_; }
 
     private:
-      std::vector<PExpr*> parms_;
+      std::vector<named_pexpr_t> parms_;
 };
 
 class PCondit  : public Statement {

--- a/design_dump.cc
+++ b/design_dump.cc
@@ -206,6 +206,18 @@ ostream& operator << (ostream&fd, NetCaseCmp::kind_t that)
       return fd;
 }
 
+static std::ostream& operator << (std::ostream &out, const std::vector<NetExpr*> &exprs)
+{
+      for (size_t idx = 0; idx < exprs.size(); idx++) {
+	    if (idx != 0)
+		  out << ", ";
+	    if (exprs[idx])
+		  out << *exprs[idx];
+      }
+
+      return out;
+}
+
 ostream& ivl_type_s::debug_dump(ostream&o) const
 {
       o << typeid(*this).name();
@@ -1650,17 +1662,7 @@ void NetSTask::dump(ostream&o, unsigned ind) const
       o << setw(ind) << "" << name_;
 
       if (! parms_.empty()) {
-	    o << "(";
-	    if (parms_[0])
-		  parms_[0]->dump(o);
-
-	    for (unsigned idx = 1 ;  idx < parms_.size() ;  idx += 1) {
-		  o << ", ";
-		  if (parms_[idx])
-			parms_[idx]->dump(o);
-	    }
-
-	    o << ")";
+	    o << "(" << parms_ << ")";
       }
       o << ";" << endl;
 }
@@ -1702,15 +1704,7 @@ void NetEAccess::dump(ostream&o) const
 
 void NetEArrayPattern::dump(ostream&fd) const
 {
-      fd << "'{";
-      if (items_.size() >= 1) {
-	    if (items_[0]) fd << *items_[0];
-      }
-      for (size_t idx = 1 ; idx < items_.size() ; idx += 1) {
-	    fd << ", ";
-	    if (items_[idx]) fd << *items_[idx];
-      }
-      fd << "}";
+      fd << "'{" << items_ << "}";
 }
 
 void NetEBinary::dump(ostream&o) const
@@ -1814,18 +1808,7 @@ void NetEConcat::dump(ostream&o) const
       if (repeat_ != 1)
             o << repeat_;
 
-      if (parms_[0])
-	    o << "{" << *parms_[0];
-      else
-	    o << "{";
-
-      for (unsigned idx = 1 ;  idx < parms_.size() ;  idx += 1) {
-	    if (parms_[idx])
-		  o << ", " << *parms_[idx];
-	    else
-		  o << ", ";
-      }
-      o << "}";
+      o << "{" << parms_ << "}";
 }
 
 void NetEConst::dump(ostream&o) const
@@ -1965,15 +1948,7 @@ void NetETernary::dump(ostream&o) const
 
 void NetEUFunc::dump(ostream&o) const
 {
-      o << scope_path(func_) << "(";
-      if (! parms_.empty()) {
-	    parms_[0]->dump(o);
-	    for (unsigned idx = 1 ;  idx < parms_.size() ;  idx += 1) {
-		  o << ", ";
-		  parms_[idx]->dump(o);
-	    }
-      }
-      o << ")";
+      o << scope_path(func_) << "(" << parms_ << ")";
 }
 
 void NetEUnary::dump(ostream&o) const

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -688,7 +688,8 @@ void PFunction::elaborate_sig(Design*des, NetScope*scope) const
 
       vector<NetNet*>ports;
       vector<NetExpr*>pdef;
-      elaborate_sig_ports_(des, scope, ports, pdef);
+      vector<perm_string> port_names;
+      elaborate_sig_ports_(des, scope, ports, pdef, port_names);
 
       NetFuncDef*def = new NetFuncDef(scope, ret_sig, ports, pdef);
 
@@ -722,7 +723,8 @@ void PTask::elaborate_sig(Design*des, NetScope*scope) const
 
       vector<NetNet*>ports;
       vector<NetExpr*>pdefs;
-      elaborate_sig_ports_(des, scope, ports, pdefs);
+      vector<perm_string> port_names;
+      elaborate_sig_ports_(des, scope, ports, pdefs, port_names);
       NetTaskDef*def = new NetTaskDef(scope, ports, pdefs);
       scope->set_task_def(def);
 
@@ -732,11 +734,14 @@ void PTask::elaborate_sig(Design*des, NetScope*scope) const
 }
 
 void PTaskFunc::elaborate_sig_ports_(Design*des, NetScope*scope,
-				     vector<NetNet*>&ports, vector<NetExpr*>&pdefs) const
+				     vector<NetNet*> &ports,
+				     vector<NetExpr*> &pdefs,
+				     vector<perm_string> &port_names) const
 {
       if (ports_ == 0) {
 	    ports.clear();
 	    pdefs.clear();
+	    port_names.clear();
 
 	      /* Make sure the function has at least one input
 		 port. If it fails this test, print an error
@@ -755,6 +760,7 @@ void PTaskFunc::elaborate_sig_ports_(Design*des, NetScope*scope,
 
       ports.resize(ports_->size());
       pdefs.resize(ports_->size());
+      port_names.resize(ports_->size());
 
       for (size_t idx = 0 ; idx < ports_->size() ; idx += 1) {
 
@@ -817,6 +823,7 @@ void PTaskFunc::elaborate_sig_ports_(Design*des, NetScope*scope,
 	    }
 
 	    ports[idx] = tmp;
+	    port_names[idx] = port_name;
 	    pdefs[idx] = tmp_def;
 	    if (scope->type()==NetScope::FUNC && tmp->port_type()!=NetNet::PINPUT) {
 		  cerr << tmp->get_fileline() << ": error: "

--- a/ivtest/ivltests/sv_named_arg_base1.v
+++ b/ivtest/ivltests/sv_named_arg_base1.v
@@ -1,0 +1,25 @@
+// Check that binding task arguments by name is supported.
+
+module test;
+
+  class B;
+    integer val;
+
+    function new(integer a, integer b);
+      val = a + b * 10;
+    endfunction
+  endclass
+
+  class C extends B(.b(2), .a(1));
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    if (c.val == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base2.v
+++ b/ivtest/ivltests/sv_named_arg_base2.v
@@ -1,0 +1,26 @@
+// Check that binding task arguments by name is supported and that a mix of
+// positional and named arguments is supported.
+
+module test;
+
+  class B;
+    integer val;
+
+    function new(integer a, integer b, integer c);
+      val = a + b * 10 + c * 100;
+    endfunction
+  endclass
+
+  class C extends B(1, .c(3), .b(2));
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    if (c.val == 321) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base3.v
+++ b/ivtest/ivltests/sv_named_arg_base3.v
@@ -1,0 +1,27 @@
+// Check that binding task arguments by name is supported and that an empty
+// value can be bound to the name, in which case the default argument value
+// should be used.
+
+module test;
+
+  class B;
+    integer val;
+
+    function new(integer a, integer b = 2);
+      val = a + b * 10;
+    endfunction
+  endclass
+
+  class C extends B(.a(1), .b());
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    if (c.val == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base_fail1.v
+++ b/ivtest/ivltests/sv_named_arg_base_fail1.v
@@ -1,0 +1,21 @@
+// Check that an error is reported when trying to bind an argument by nae that
+// does not exist
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B(.b(2), .c(1)); // This should fail. `c` is not an arugment
+                                   // of the base constructor.
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base_fail2.v
+++ b/ivtest/ivltests/sv_named_arg_base_fail2.v
@@ -1,0 +1,21 @@
+// Check that an error is reported when trying to bind the same argument by name
+// multiple times.
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B(.a(1), .a(2)); // This should fail. `a` is provided twice
+                                   // as a named argument.
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base_fail3.v
+++ b/ivtest/ivltests/sv_named_arg_base_fail3.v
@@ -1,0 +1,21 @@
+// Check that an error is reported when trying to bind an argument by name that
+// is also provided as a positional argument.
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B(1, .a(2)); // This should fail. `a` is provided both as a
+                               // positional and named argument.
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base_fail4.v
+++ b/ivtest/ivltests/sv_named_arg_base_fail4.v
@@ -1,0 +1,21 @@
+// Check that an error is reported trying to provide a positional argument to a
+// function after a named argument.
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B(.a(2), 1); // This should fail. Positional arguments must
+                               // precede named arguments.
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_base_fail5.v
+++ b/ivtest/ivltests/sv_named_arg_base_fail5.v
@@ -1,0 +1,20 @@
+// Check that an error is reported when binding an empty value to an argument by
+// name and the argument does not have a default value.
+
+module test;
+
+  class B;
+    function new(integer a);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B(.a()); // This should fail. `a` has no default value.
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained1.v
+++ b/ivtest/ivltests/sv_named_arg_chained1.v
@@ -1,0 +1,28 @@
+// Check that binding task arguments by name is supported.
+
+module test;
+
+  class B;
+    integer val;
+
+    function new(integer a, integer b);
+      val = a + b * 10;
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(.b(2), .a(1));
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    if (c.val == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained2.v
+++ b/ivtest/ivltests/sv_named_arg_chained2.v
@@ -1,0 +1,29 @@
+// Check that binding task arguments by name is supported and that a mix of
+// positional and named arguments is supported.
+
+module test;
+
+  class B;
+    integer val;
+
+    function new(integer a, integer b, integer c);
+      val = a + b * 10 + c * 100;
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(1, .c(3), .b(2));
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    if (c.val == 321) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained3.v
+++ b/ivtest/ivltests/sv_named_arg_chained3.v
@@ -1,0 +1,30 @@
+// Check that binding task arguments by name is supported and that an empty
+// value can be bound to the name, in which case the default argument value
+// should be used.
+
+module test;
+
+  class B;
+    integer val;
+
+    function new(integer a, integer b = 2);
+      val = a + b * 10;
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(.a(1), .b());
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+    if (c.val == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained_fail1.v
+++ b/ivtest/ivltests/sv_named_arg_chained_fail1.v
@@ -1,0 +1,24 @@
+// Check that an error is reported when trying to bind an argument by nae that
+// does not exist
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(.b(2), .c(1)); // This should fail. `c` is not an arugment of
+                               // the base constructor.
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained_fail2.v
+++ b/ivtest/ivltests/sv_named_arg_chained_fail2.v
@@ -1,0 +1,24 @@
+// Check that an error is reported when trying to bind the same argument by name
+// multiple times.
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(.a(1), .a(2)); // This should fail. `a` is provided twice as a
+                               // named argument.
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained_fail3.v
+++ b/ivtest/ivltests/sv_named_arg_chained_fail3.v
@@ -1,0 +1,24 @@
+// Check that an error is reported when trying to bind an argument by name that
+// is also provided as a positional argument.
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(1, .a(2)); // This should fail. `a` is provided both as a
+                           // positional and named argument.
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained_fail4.v
+++ b/ivtest/ivltests/sv_named_arg_chained_fail4.v
@@ -1,0 +1,24 @@
+// Check that an error is reported trying to provide a positional argument to a
+// function after a named argument.
+
+module test;
+
+  class B;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(.a(2), 1); // This should fail. Positional arguments must
+                           // precede named arguments.
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_chained_fail5.v
+++ b/ivtest/ivltests/sv_named_arg_chained_fail5.v
@@ -1,0 +1,23 @@
+// Check that an error is reported when binding an empty value to an argument by
+// name and the argument does not have a default value.
+
+module test;
+
+  class B;
+    function new(integer a);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  class C extends B;
+    function new;
+      super.new(.a()); // This should fail. `a` has no default value.
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new;
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func1.v
+++ b/ivtest/ivltests/sv_named_arg_func1.v
@@ -1,0 +1,19 @@
+// Check that binding task arguments by name is supported.
+
+module test;
+
+  function integer f(integer a, integer b);
+   return a + b * 10;
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(.b(2), .a(1));
+    if (x == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+   end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func2.v
+++ b/ivtest/ivltests/sv_named_arg_func2.v
@@ -1,0 +1,20 @@
+// Check that binding task arguments by name is supported and that a mix of
+// positional and named arguments is supported.
+
+module test;
+
+  function integer f(integer a, integer b, integer c);
+    return a + b * 10 + c * 100;
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(1, .c(3), .b(2));
+    if (x == 321) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func3.v
+++ b/ivtest/ivltests/sv_named_arg_func3.v
@@ -1,0 +1,21 @@
+// Check that binding task arguments by name is supported and that an empty
+// value can be bound to the name, in which case the default argument value
+// should be used.
+
+module test;
+
+  function integer f(integer a, integer b = 2);
+    return a + b * 10;
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(.a(1), .b());
+    if (x == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func_fail1.v
+++ b/ivtest/ivltests/sv_named_arg_func_fail1.v
@@ -1,0 +1,15 @@
+// Check that an error is reported when trying to bind an argument by nae that
+// does not exist
+
+module test;
+
+  function f(integer a, integer b);
+    $display("FAILED");
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(.b(2), .c(1)); // This should fail. `c` is not an arugment of `f`.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func_fail2.v
+++ b/ivtest/ivltests/sv_named_arg_func_fail2.v
@@ -1,0 +1,16 @@
+// Check that an error is reported when trying to bind the same argument by name
+// multiple times.
+
+module test;
+
+  function f(integer a, integer b);
+    $display("FAILED");
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(.a(1), .a(2)); // This should fail. `a` is provided twice as a named
+                         // argument.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func_fail3.v
+++ b/ivtest/ivltests/sv_named_arg_func_fail3.v
@@ -1,0 +1,16 @@
+// Check that an error is reported when trying to bind an argument by name that
+// is also provided as a positional argument.
+
+module test;
+
+  function f(integer a, integer b);
+    $display("FAILED");
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(1, .a(2)); // This should fail. `a` is provided both as a positional
+                     // and named argument.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func_fail4.v
+++ b/ivtest/ivltests/sv_named_arg_func_fail4.v
@@ -1,0 +1,16 @@
+// Check that an error is reported trying to provide a positional argument to a
+// function after a named argument.
+
+module test;
+
+  function f(integer a, integer b);
+    $display("FAILED");
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(.a(2), 1); // This should fail. Positional arguments must precede
+                     // named arguments.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_func_fail5.v
+++ b/ivtest/ivltests/sv_named_arg_func_fail5.v
@@ -1,0 +1,15 @@
+// Check that an error is reported when binding an empty value to an argument by
+// name and the argument does not have a default value.
+
+module test;
+
+  function f(integer a);
+    $display("FAILED");
+  endfunction
+
+  initial begin
+    integer x;
+    x = f(.a()); // This should fail. `a` has no default value.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new1.v
+++ b/ivtest/ivltests/sv_named_arg_new1.v
@@ -1,0 +1,22 @@
+// Check that binding task arguments by name is supported.
+
+module test;
+
+  class C;
+    integer val;
+
+    function new(integer a, integer b);
+      val = a + b * 10;
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(.b(2), .a(1));
+    if (c.val == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new2.v
+++ b/ivtest/ivltests/sv_named_arg_new2.v
@@ -1,0 +1,23 @@
+// Check that binding task arguments by name is supported and that a mix of
+// positional and named arguments is supported.
+
+module test;
+
+  class C;
+    integer val;
+
+    function new(integer a, integer b, integer c);
+      val = a + b * 10 + c * 100;
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(1, .c(3), .b(2));
+    if (c.val == 321) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new3.v
+++ b/ivtest/ivltests/sv_named_arg_new3.v
@@ -1,0 +1,24 @@
+// Check that binding task arguments by name is supported and that an empty
+// value can be bound to the name, in which case the default argument value
+// should be used.
+
+module test;
+
+  class C;
+    integer val;
+
+    function new(integer a, integer b = 2);
+      val = a + b * 10;
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(.a(1), .b());
+    if (c.val == 21) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new_fail1.v
+++ b/ivtest/ivltests/sv_named_arg_new_fail1.v
@@ -1,0 +1,18 @@
+// Check that an error is reported when trying to bind an argument by nae that
+// does not exist
+
+module test;
+
+  class C;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(.b(2), .c(1)); // This should fail. `c` is not an arugment of the
+                           // constructor.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new_fail2.v
+++ b/ivtest/ivltests/sv_named_arg_new_fail2.v
@@ -1,0 +1,18 @@
+// Check that an error is reported when trying to bind the same argument by name
+// multiple times.
+
+module test;
+
+  class C;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(.a(1), .a(2)); // This should fail. `a` is provided twice as a named
+                           // argument.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new_fail3.v
+++ b/ivtest/ivltests/sv_named_arg_new_fail3.v
@@ -1,0 +1,18 @@
+// Check that an error is reported when trying to bind an argument by name that
+// is also provided as a positional argument.
+
+module test;
+
+  class C;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(1, .a(2)); // This should fail. `a` is provided both as a positional
+                       // and named argument.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new_fail4.v
+++ b/ivtest/ivltests/sv_named_arg_new_fail4.v
@@ -1,0 +1,18 @@
+// Check that an error is reported trying to provide a positional argument to a
+// function after a named argument.
+
+module test;
+
+  class C;
+    function new(integer a, integer b);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(.a(2), 1); // This should fail. Positional arguments must precede
+                       // named arguments.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_new_fail5.v
+++ b/ivtest/ivltests/sv_named_arg_new_fail5.v
@@ -1,0 +1,17 @@
+// Check that an error is reported when binding an empty value to an argument by
+// name and the argument does not have a default value.
+
+module test;
+
+  class C;
+    function new(integer a);
+      $display("FAILED");
+    endfunction
+  endclass
+
+  initial begin
+    C c;
+    c = new(.a()); // This should fail. `a` has no default value.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task1.v
+++ b/ivtest/ivltests/sv_named_arg_task1.v
@@ -1,0 +1,17 @@
+// Check that binding task arguments by name is supported.
+
+module test;
+
+  task t(integer a, integer b);
+    if (a == 1 && b == 2) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    t(.b(2), .a(1));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task2.v
+++ b/ivtest/ivltests/sv_named_arg_task2.v
@@ -1,0 +1,18 @@
+// Check that binding task arguments by name is supported and that a mix of
+// positional and named arguments is supported.
+
+module test;
+
+  task t(integer a, integer b, integer c);
+    if (a == 1 && b == 2 && c == 3) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    t(1, .c(3), .b(2));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task3.v
+++ b/ivtest/ivltests/sv_named_arg_task3.v
@@ -1,0 +1,19 @@
+// Check that binding task arguments by name is supported and that an empty
+// value can be bound to the name, in which case the default argument value
+// should be used.
+
+module test;
+
+  task t(integer a, integer b = 2);
+    if (a == 1 && b == 2) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  endtask
+
+  initial begin
+    t(.a(1), .b());
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task_fail1.v
+++ b/ivtest/ivltests/sv_named_arg_task_fail1.v
@@ -1,0 +1,14 @@
+// Check that an error is reported when trying to bind an argument by nae that
+// does not exist
+
+module test;
+
+  task t(integer a, integer b);
+    $display("FAILED");
+  endtask
+
+  initial begin
+    t(.b(2), .c(1));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task_fail2.v
+++ b/ivtest/ivltests/sv_named_arg_task_fail2.v
@@ -1,0 +1,14 @@
+// Check that an error is reported when trying to bind the same argument by name
+// multiple times.
+
+module test;
+
+  task t(integer a, integer b);
+    $display("FAILED");
+  endtask
+
+  initial begin
+    t(.a(1), .a(2));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task_fail3.v
+++ b/ivtest/ivltests/sv_named_arg_task_fail3.v
@@ -1,0 +1,14 @@
+// Check that an error is reported when trying to bind an argument by name that
+// is also provided as a positional argument.
+
+module test;
+
+  task t(integer a, integer b);
+    $display("FAILED");
+  endtask
+
+  initial begin
+    t(1, .a(2));
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task_fail4.v
+++ b/ivtest/ivltests/sv_named_arg_task_fail4.v
@@ -1,0 +1,15 @@
+// Check that an error is reported trying to provide a positional argument to a
+// task after a named argument.
+
+module test;
+
+  task t(integer a, integer b);
+    $display("FAILED");
+  endtask
+
+  initial begin
+    t(.a(2), 1); // This should fail. Positional arguments must precede
+                 // named arguments.
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_named_arg_task_fail5.v
+++ b/ivtest/ivltests/sv_named_arg_task_fail5.v
@@ -1,0 +1,14 @@
+// Check that an error is reported when binding an empty value to an argument by
+// name and the argument does not have a default value.
+
+module test;
+
+  task t(integer a);
+    $display("FAILED");
+  endtask
+
+  initial begin
+    t(.a()); // This should fail. `a` has no default value.
+  end
+
+endmodule

--- a/ivtest/vvp_tests/sv_named_arg_base1.json
+++ b/ivtest/vvp_tests/sv_named_arg_base1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_base1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base2.json
+++ b/ivtest/vvp_tests/sv_named_arg_base2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_base2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base3.json
+++ b/ivtest/vvp_tests/sv_named_arg_base3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_base3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base_fail1.json
+++ b/ivtest/vvp_tests/sv_named_arg_base_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_base_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base_fail2.json
+++ b/ivtest/vvp_tests/sv_named_arg_base_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_base_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base_fail3.json
+++ b/ivtest/vvp_tests/sv_named_arg_base_fail3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_base_fail3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base_fail4.json
+++ b/ivtest/vvp_tests/sv_named_arg_base_fail4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_base_fail4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_base_fail5.json
+++ b/ivtest/vvp_tests/sv_named_arg_base_fail5.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_base_fail5.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained1.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_chained1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained2.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_chained2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained3.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_chained3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained_fail1.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_chained_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained_fail2.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_chained_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained_fail3.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained_fail3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_chained_fail3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained_fail4.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained_fail4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_chained_fail4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_chained_fail5.json
+++ b/ivtest/vvp_tests/sv_named_arg_chained_fail5.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_chained_fail5.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func1.json
+++ b/ivtest/vvp_tests/sv_named_arg_func1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_func1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func2.json
+++ b/ivtest/vvp_tests/sv_named_arg_func2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_func2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func3.json
+++ b/ivtest/vvp_tests/sv_named_arg_func3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_func3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func_fail1.json
+++ b/ivtest/vvp_tests/sv_named_arg_func_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_func_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func_fail2.json
+++ b/ivtest/vvp_tests/sv_named_arg_func_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_func_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func_fail3.json
+++ b/ivtest/vvp_tests/sv_named_arg_func_fail3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_func_fail3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func_fail4.json
+++ b/ivtest/vvp_tests/sv_named_arg_func_fail4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_func_fail4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_func_fail5.json
+++ b/ivtest/vvp_tests/sv_named_arg_func_fail5.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_func_fail5.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new1.json
+++ b/ivtest/vvp_tests/sv_named_arg_new1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_new1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new2.json
+++ b/ivtest/vvp_tests/sv_named_arg_new2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_new2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new3.json
+++ b/ivtest/vvp_tests/sv_named_arg_new3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_new3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new_fail1.json
+++ b/ivtest/vvp_tests/sv_named_arg_new_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_new_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new_fail2.json
+++ b/ivtest/vvp_tests/sv_named_arg_new_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_new_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new_fail3.json
+++ b/ivtest/vvp_tests/sv_named_arg_new_fail3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_new_fail3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new_fail4.json
+++ b/ivtest/vvp_tests/sv_named_arg_new_fail4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_new_fail4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_new_fail5.json
+++ b/ivtest/vvp_tests/sv_named_arg_new_fail5.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_new_fail5.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task1.json
+++ b/ivtest/vvp_tests/sv_named_arg_task1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_task1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task2.json
+++ b/ivtest/vvp_tests/sv_named_arg_task2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_task2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task3.json
+++ b/ivtest/vvp_tests/sv_named_arg_task3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_named_arg_task3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task_fail1.json
+++ b/ivtest/vvp_tests/sv_named_arg_task_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_task_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task_fail2.json
+++ b/ivtest/vvp_tests/sv_named_arg_task_fail2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_task_fail2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task_fail3.json
+++ b/ivtest/vvp_tests/sv_named_arg_task_fail3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_task_fail3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task_fail4.json
+++ b/ivtest/vvp_tests/sv_named_arg_task_fail4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_task_fail4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_named_arg_task_fail5.json
+++ b/ivtest/vvp_tests/sv_named_arg_task_fail5.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_named_arg_task_fail5.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/map_named_args.cc
+++ b/map_named_args.cc
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2023 Lars-Peter Clausen <lars@metafoo.de>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "PExpr.h"
+#include "ivl_assert.h"
+#include "map_named_args.h"
+#include "netlist.h"
+
+#include <iostream>
+
+std::vector<PExpr*> map_named_args(Design *des,
+			           const std::vector<perm_string> &names,
+			           const std::vector<named_pexpr_t> &parms)
+{
+      std::vector<PExpr*> args(names.size());
+
+      bool has_named = false;
+      for (size_t i = 0; i < parms.size(); i++) {
+	    if (parms[i].name.nil()) {
+		  if (!parms[i].parm)
+			continue;
+
+		  if (has_named) {
+		      std::cerr << parms[i].get_fileline() << ": error: "
+		           << "Positional argument must preceded "
+			   << "named arguments."
+			   << std::endl;
+		  } else if (i < args.size()) {
+			args[i] = parms[i].parm;
+		  }
+
+		  continue;
+	    }
+	    has_named = true;
+
+	    bool found = false;
+	    for (size_t j = 0; j < names.size(); j++) {
+		  if (names[j] == parms[i].name) {
+			if (args[j]) {
+			      std::cerr << parms[i].get_fileline() << ": error: "
+			           << "Argument `"
+				   << parms[i].name
+				   << "` has already been specified."
+				   << std::endl;
+			      des->errors++;
+			} else {
+			      args[j] = parms[i].parm;
+			}
+			found = true;
+			break;
+		  }
+	    }
+	    if (!found) {
+		  std::cerr << parms[i].get_fileline() << ": error: "
+		       << "No argument called `"
+		       << parms[i].name << "`."
+		       << std::endl;
+		  des->errors++;
+	    }
+      }
+
+      return args;
+}
+
+std::vector<PExpr*> map_named_args(Design *des, NetBaseDef *def,
+				   const std::vector<named_pexpr_t> &parms,
+				   unsigned int off)
+{
+      std::vector<perm_string> names;
+
+      for (size_t j = off; j < def->port_count(); j++)
+	    names.push_back(def->port(j)->name());
+
+      return map_named_args(des, names, parms);
+}

--- a/map_named_args.h
+++ b/map_named_args.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 Lars-Peter Clausen <lars@metafoo.de>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef MAP_NAMED_ARGS_H
+#define MAP_NAMED_ARGS_H
+
+#include <vector>
+#include "pform_types.h"
+
+class PExpr;
+class Design;
+class NetBaseDef;
+
+std::vector<PExpr*> map_named_args(Design *des,
+			           const std::vector<perm_string> &names,
+			           const std::vector<named_pexpr_t> &parms);
+
+std::vector<PExpr*> map_named_args(Design *des, NetBaseDef *def,
+			           const std::vector<named_pexpr_t> &parms,
+				   unsigned int off);
+
+#endif

--- a/named.h
+++ b/named.h
@@ -20,13 +20,14 @@
  */
 
 # include  "StringHeap.h"
+# include  "libmisc/LineInfo.h"
 
 /*
  * There are lots of places where names are attached to objects. This
  * simple template expresses the lot.
  */
 
-template <class T> struct named {
+template <class T> struct named : public LineInfo {
       perm_string name;
       T parm;
 };

--- a/netlist.cc
+++ b/netlist.cc
@@ -579,16 +579,10 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
 : NetObj(s, n, calculate_count(unpacked)),
     type_(t), port_type_(NOT_A_PORT),
     local_flag_(false), net_type_(use_net_type),
-    discipline_(0), unpacked_dims_(unpacked.size()),
+    discipline_(0), unpacked_dims_(unpacked.begin(), unpacked.end()),
     eref_count_(0), lref_count_(0)
 {
       calculate_slice_widths_from_packed_dims_();
-      size_t idx = 0;
-      for (list<netrange_t>::const_iterator cur = unpacked.begin()
-		 ; cur != unpacked.end() ; ++cur, idx += 1) {
-	    unpacked_dims_[idx] = *cur;
-      }
-      ivl_assert(*this, idx == unpacked_dims_.size());
 
       ivl_assert(*this, s);
       if (pin_count() == 0) {

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1046,6 +1046,9 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 NetExpr* elab_sys_task_arg(Design*des, NetScope*scope, perm_string name,
                            unsigned arg_idx, PExpr*pe, bool need_const)
 {
+      if (!pe)
+	    return nullptr;
+
       PExpr::width_mode_t mode = PExpr::SIZED;
       pe->test_width(des, scope, mode);
 

--- a/parse.y
+++ b/parse.y
@@ -455,9 +455,6 @@ Module::port_t *module_declare_port(const YYLTYPE&loc, char *id,
       std::list<PLet::let_port_t*>*let_port_lst;
       PLet::let_port_t*let_port_itm;
 
-      named_number_t* named_number;
-      std::list<named_number_t>* named_numbers;
-
       named_pexpr_t*named_pexpr;
       std::list<named_pexpr_t>*named_pexprs;
       struct parmvalue_t*parmvalue;

--- a/pform.cc
+++ b/pform.cc
@@ -927,7 +927,7 @@ typedef_t* pform_test_type_identifier(const struct vlltype&loc, const char*txt)
 
 PECallFunction* pform_make_call_function(const struct vlltype&loc,
 					 const pform_name_t&name,
-					 const list<PExpr*>&parms)
+					 const list<named_pexpr_t> &parms)
 {
       if (gn_system_verilog())
 	    check_potential_imports(loc, name.front().name, true);
@@ -939,7 +939,7 @@ PECallFunction* pform_make_call_function(const struct vlltype&loc,
 
 PCallTask* pform_make_call_task(const struct vlltype&loc,
 				const pform_name_t&name,
-				const list<PExpr*>&parms)
+				const list<named_pexpr_t> &parms)
 {
       if (gn_system_verilog())
 	    check_potential_imports(loc, name.front().name, true);
@@ -1732,7 +1732,7 @@ void pform_endgenerate(bool end_conditional)
 
 void pform_make_elab_task(const struct vlltype&li,
                           perm_string name,
-                          const list<PExpr*>&params)
+                          const list<named_pexpr_t> &params)
 {
       PCallTask*elab_task = new PCallTask(name, params);
       FILE_NAME(elab_task, li);

--- a/pform.cc
+++ b/pform.cc
@@ -2278,7 +2278,7 @@ static void pform_make_modgate(perm_string type,
 
       if (overrides && overrides->by_name) {
 	    unsigned cnt = overrides->by_name->size();
-	    named<PExpr*>*byname = new named<PExpr*>[cnt];
+	    named_pexpr_t *byname = new named_pexpr_t[cnt];
 
 	    list<named_pexpr_t>::iterator by_name_cur = overrides->by_name->begin();
 	    for (unsigned idx = 0 ;  idx < cnt ;  idx += 1, ++ by_name_cur) {
@@ -2311,7 +2311,7 @@ static void pform_make_modgate(perm_string type,
 			       std::list<named_pexpr_t>*attr)
 {
       unsigned npins = bind->size();
-      named<PExpr*>*pins = new named<PExpr*>[npins];
+      named_pexpr_t *pins = new named_pexpr_t[npins];
       list<named_pexpr_t>::iterator bind_cur = bind->begin();
       for (unsigned idx = 0 ;  idx < npins ;  idx += 1,  ++bind_cur) {
 	    pins[idx].name = bind_cur->name;
@@ -2325,7 +2325,7 @@ static void pform_make_modgate(perm_string type,
 
       if (overrides && overrides->by_name) {
 	    unsigned cnt = overrides->by_name->size();
-	    named<PExpr*>*byname = new named<PExpr*>[cnt];
+	    named_pexpr_t *byname = new named_pexpr_t[cnt];
 
 	    list<named_pexpr_t>::iterator by_name_cur = overrides->by_name->begin();
 	    for (unsigned idx = 0 ;  idx < cnt ;  idx += 1,  ++by_name_cur) {

--- a/pform.cc
+++ b/pform.cc
@@ -2280,11 +2280,8 @@ static void pform_make_modgate(perm_string type,
 	    unsigned cnt = overrides->by_name->size();
 	    named_pexpr_t *byname = new named_pexpr_t[cnt];
 
-	    list<named_pexpr_t>::iterator by_name_cur = overrides->by_name->begin();
-	    for (unsigned idx = 0 ;  idx < cnt ;  idx += 1, ++ by_name_cur) {
-		  byname[idx].name = by_name_cur->name;
-		  byname[idx].parm = by_name_cur->parm;
-	    }
+	    std::copy(overrides->by_name->begin(), overrides->by_name->end(),
+		      byname);
 
 	    cur->set_parameters(byname, cnt);
 
@@ -2312,12 +2309,10 @@ static void pform_make_modgate(perm_string type,
 {
       unsigned npins = bind->size();
       named_pexpr_t *pins = new named_pexpr_t[npins];
-      list<named_pexpr_t>::iterator bind_cur = bind->begin();
-      for (unsigned idx = 0 ;  idx < npins ;  idx += 1,  ++bind_cur) {
-	    pins[idx].name = bind_cur->name;
-	    pins[idx].parm = bind_cur->parm;
-            pform_declare_implicit_nets(bind_cur->parm);
-      }
+      for (const auto &bind_cur : *bind)
+            pform_declare_implicit_nets(bind_cur.parm);
+
+      std::copy(bind->begin(), bind->end(), pins);
 
       PGModule*cur = new PGModule(type, name, pins, npins);
       cur->set_line(li);
@@ -2327,11 +2322,8 @@ static void pform_make_modgate(perm_string type,
 	    unsigned cnt = overrides->by_name->size();
 	    named_pexpr_t *byname = new named_pexpr_t[cnt];
 
-	    list<named_pexpr_t>::iterator by_name_cur = overrides->by_name->begin();
-	    for (unsigned idx = 0 ;  idx < cnt ;  idx += 1,  ++by_name_cur) {
-		  byname[idx].name = by_name_cur->name;
-		  byname[idx].parm = by_name_cur->parm;
-	    }
+	    std::copy(overrides->by_name->begin(), overrides->by_name->end(),
+		      byname);
 
 	    cur->set_parameters(byname, cnt);
 

--- a/pform.cc
+++ b/pform.cc
@@ -3053,23 +3053,10 @@ extern PSpecPath* pform_make_specify_path(const struct vlltype&li,
 					  list<perm_string>*src, char pol,
 					  bool full_flag, list<perm_string>*dst)
 {
-      PSpecPath*path = new PSpecPath(src->size(), dst->size(), pol, full_flag);
+      PSpecPath*path = new PSpecPath(*src, *dst, pol, full_flag);
       FILE_NAME(path, li);
 
-      unsigned idx;
-      list<perm_string>::const_iterator cur;
-
-      idx = 0;
-      for (idx = 0, cur = src->begin() ;  cur != src->end() ;  ++ idx, ++ cur) {
-	    path->src[idx] = *cur;
-      }
-      ivl_assert(li, idx == path->src.size());
       delete src;
-
-      for (idx = 0, cur = dst->begin() ;  cur != dst->end() ;  ++ idx, ++ cur) {
-	    path->dst[idx] = *cur;
-      }
-      ivl_assert(li, idx == path->dst.size());
       delete dst;
 
       return path;

--- a/pform.h
+++ b/pform.h
@@ -173,7 +173,7 @@ extern void pform_endmodule(const char*, bool inside_celldefine,
 extern void pform_start_class_declaration(const struct vlltype&loc,
 					  class_type_t*type,
 					  data_type_t*base_type,
-					  std::list<PExpr*>*base_exprs,
+					  std::list<named_pexpr_t> *base_args,
 					  bool virtual_class);
 extern void pform_class_property(const struct vlltype&loc,
 				 property_qualifier_t pq,
@@ -307,7 +307,7 @@ bool pform_error_in_generate(const vlltype&loc, const char *type);
 
 extern void pform_make_elab_task(const struct vlltype&li,
                                  perm_string name,
-                                 const std::list<PExpr*>&params);
+                                 const std::list<named_pexpr_t> &params);
 
 extern void pform_set_typedef(const struct vlltype&loc, perm_string name,
 			      data_type_t*data_type,
@@ -322,10 +322,10 @@ extern void pform_set_type_referenced(const struct vlltype&loc, const char*name)
  */
 extern PECallFunction* pform_make_call_function(const struct vlltype&loc,
 						const pform_name_t&name,
-						const std::list<PExpr*>&parms);
+						const std::list<named_pexpr_t> &parms);
 extern PCallTask* pform_make_call_task(const struct vlltype&loc,
 				       const pform_name_t&name,
-				       const std::list<PExpr*>&parms);
+				       const std::list<named_pexpr_t> &parms);
 
 extern void pform_make_foreach_declarations(const struct vlltype&loc,
 					    std::list<perm_string>*loop_vars);

--- a/pform_analog.cc
+++ b/pform_analog.cc
@@ -46,12 +46,12 @@ void pform_make_analog_behavior(const struct vlltype&loc, ivl_process_type_t pt,
 PExpr* pform_make_branch_probe_expression(const struct vlltype&loc,
 					  char*name, char*n1, char*n2)
 {
-      vector<PExpr*> parms (2);
-      parms[0] = new PEIdent(lex_strings.make(n1));
-      FILE_NAME(parms[0], loc);
+      vector<named_pexpr_t> parms (2);
+      parms[0].parm = new PEIdent(lex_strings.make(n1));
+      FILE_NAME(parms[0].parm, loc);
 
-      parms[1] = new PEIdent(lex_strings.make(n2));
-      FILE_NAME(parms[1], loc);
+      parms[1].parm = new PEIdent(lex_strings.make(n2));
+      FILE_NAME(parms[1].parm, loc);
 
       PECallFunction*res = new PECallFunction(lex_strings.make(name), parms);
       FILE_NAME(res, loc);
@@ -61,9 +61,9 @@ PExpr* pform_make_branch_probe_expression(const struct vlltype&loc,
 PExpr* pform_make_branch_probe_expression(const struct vlltype&loc,
 					  char*name, char*branch_name)
 {
-      vector<PExpr*> parms (1);
-      parms[0] = new PEIdent(lex_strings.make(branch_name));
-      FILE_NAME(parms[0], loc);
+      vector<named_pexpr_t> parms (1);
+      parms[0].parm = new PEIdent(lex_strings.make(branch_name));
+      FILE_NAME(parms[0].parm, loc);
 
       PECallFunction*res = new PECallFunction(lex_strings.make(name), parms);
       FILE_NAME(res, loc);

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -177,6 +177,35 @@ std::ostream& operator << (std::ostream&out, ivl_dis_domain_t dom)
       return out;
 }
 
+static std::ostream& operator << (std::ostream &out, const std::vector<PExpr*> &exprs)
+{
+      for (size_t idx = 0; idx < exprs.size(); idx++) {
+	    if (idx != 0)
+		  out << ", ";
+	    if (exprs[idx])
+		  exprs[idx]->dump(out);
+      }
+
+      return out;
+}
+
+static std::ostream& operator << (std::ostream &out,
+			          const std::vector<named_pexpr_t> &exprs)
+{
+      for (size_t idx = 0; idx < exprs.size(); idx++) {
+	    if (idx != 0)
+		  out << ", ";
+	    if (!exprs[idx].name.nil())
+		  out << "." << exprs[idx].name << "(";
+	    if (exprs[idx].parm)
+		  exprs[idx].parm->dump(out);
+	    if (!exprs[idx].name.nil())
+		  out << ")";
+      }
+
+      return out;
+}
+
 void data_type_t::pform_dump(ostream&out, unsigned indent) const
 {
       out << setw(indent) << "" << typeid(*this).name() << endl;
@@ -380,15 +409,7 @@ void PExpr::dump(ostream&out) const
 
 void PEAssignPattern::dump(ostream&out) const
 {
-      out << "'{";
-      if (parms_.size() > 0) {
-	    parms_[0]->dump(out);
-	    for (size_t idx = 1 ; idx < parms_.size() ; idx += 1) {
-		  out << ", ";
-		  parms_[idx]->dump(out);
-	    }
-      }
-      out << "}";
+      out << "'{" << parms_ << "}";
 }
 
 void PEConcat::dump(ostream&out) const
@@ -401,30 +422,14 @@ void PEConcat::dump(ostream&out) const
 	    return;
       }
 
-      out << "{";
-      if (parms_[0]) out << *parms_[0];
-      for (unsigned idx = 1 ;  idx < parms_.size() ;  idx += 1) {
-	    out << ", ";
-	    if (parms_[idx]) out << *parms_[idx];
-      }
-
-      out << "}";
+      out << "{" << parms_ << "}";
 
       if (repeat_) out << "}";
 }
 
 void PECallFunction::dump(ostream &out) const
 {
-      out << path_ << "(";
-
-      if (! parms_.empty()) {
-	    if (parms_[0]) parms_[0]->dump(out);
-	    for (unsigned idx = 1; idx < parms_.size(); ++idx) {
-		  out << ", ";
-		  if (parms_[idx]) parms_[idx]->dump(out);
-	    }
-      }
-      out << ")";
+      out << path_ << "(" << parms_ << ")";
 }
 
 void PECastSize::dump(ostream &out) const
@@ -487,15 +492,7 @@ void PENewArray::dump(ostream&out) const
 
 void PENewClass::dump(ostream&out) const
 {
-      out << "class_new(";
-      if (parms_.size() > 0) {
-	    parms_[0]->dump(out);
-	    for (size_t idx = 1 ; idx < parms_.size() ; idx += 1) {
-		  out << ", ";
-		  if (parms_[idx]) parms_[idx]->dump(out);
-	    }
-      }
-      out << ")";
+      out << "class_new(" << parms_ << ")";
 }
 
 void PENewCopy::dump(ostream&out) const
@@ -830,14 +827,7 @@ void PGModule::dump(ostream&out, unsigned ind) const
 	// If parameters are overridden by name, dump them.
       if (parms_) {
 	    assert(overrides_ == 0);
-	    out << "#(";
-	    for (unsigned idx = 0 ;  idx < nparms_ ;  idx += 1) {
-                  if (idx > 0) out << ", ";
-		  out << "." << parms_[idx].name << "(";
-                  if (parms_[idx].parm) out << *parms_[idx].parm;
-                  out << ")";
-	    }
-	    out << ") ";
+	    out << "#(" << parms_ << ") ";
       }
 
       out << get_name();
@@ -940,16 +930,7 @@ void PCallTask::dump(ostream&out, unsigned ind) const
       out << setw(ind) << "" << path_;
 
       if (! parms_.empty()) {
-	    out << "(";
-	    if (parms_[0])
-		  out << *parms_[0];
-
-	    for (unsigned idx = 1 ;  idx < parms_.size() ;  idx += 1) {
-		  out << ", ";
-		  if (parms_[idx])
-			out << *parms_[idx];
-	    }
-	    out << ")";
+	    out << "(" << parms_ << ")";
       }
 
       out << "; /* " << get_fileline() << " */" << endl;
@@ -1017,15 +998,7 @@ void PCase::dump(ostream&out, unsigned ind) const
 
 void PChainConstructor::dump(ostream&out, unsigned ind) const
 {
-      out << setw(ind) << "" << "super.new(";
-      if (parms_.size() > 0) {
-	    if (parms_[0]) out << *parms_[0];
-      }
-      for (size_t idx = 1 ; idx < parms_.size() ; idx += 1) {
-	    out << ", ";
-	    if (parms_[idx]) out << *parms_[idx];
-      }
-      out << ");" << endl;
+      out << setw(ind) << "" << "super.new(" << parms_ << ")" <<endl;
 }
 
 void PCondit::dump(ostream&out, unsigned ind) const

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -345,15 +345,7 @@ void class_type_t::pform_dump(ostream&out, unsigned indent) const
 
       if (base_type) out << " extends <type>";
       if (! base_args.empty()) {
-	    out << " (";
-	    for (list<PExpr*>::const_iterator cur = base_args.begin()
-		       ; cur != base_args.end() ; ++cur) {
-		  const PExpr*curp = *cur;
-		  if (cur != base_args.begin())
-			out << ", ";
-		  curp->dump(out);
-	    }
-	    out << ")";
+	    out << " (" << base_args << ")";
       }
 
       out << " {";

--- a/pform_pclass.cc
+++ b/pform_pclass.cc
@@ -43,7 +43,7 @@ static PClass*pform_cur_class = 0;
 void pform_start_class_declaration(const struct vlltype&loc,
 				   class_type_t*type,
 				   data_type_t*base_type,
-				   list<PExpr*>*base_exprs,
+				   list<named_pexpr_t> *base_args,
 				   bool virtual_class)
 {
       PClass*class_scope = pform_push_class_scope(loc, type->name);
@@ -55,13 +55,12 @@ void pform_start_class_declaration(const struct vlltype&loc,
       type->base_type.reset(base_type);
       type->virtual_class = virtual_class;
 
+
       ivl_assert(loc, type->base_args.empty());
-      if (base_exprs) {
-	    for (list<PExpr*>::iterator cur = base_exprs->begin()
-		       ; cur != base_exprs->end() ; ++ cur) {
-		  type->base_args.push_back(*cur);
-	    }
-	    delete base_exprs;
+      if (base_args) {
+	    type->base_args.insert(type->base_args.begin(), base_args->begin(),
+			           base_args->end());
+	    delete base_args;
       }
 }
 

--- a/pform_types.h
+++ b/pform_types.h
@@ -377,7 +377,7 @@ struct class_type_t : public data_type_t {
 	// hierarchy. If there are arguments to the base class, then
 	// put them in the base_args vector.
       std::unique_ptr<data_type_t> base_type;
-      std::list<PExpr*>base_args;
+      std::vector<named_pexpr_t> base_args;
 
       bool virtual_class;
 

--- a/pform_types.h
+++ b/pform_types.h
@@ -47,7 +47,6 @@ class PWire;
 class Statement;
 class netclass_t;
 class netenum_t;
-typedef named<verinum> named_number_t;
 typedef named<PExpr*> named_pexpr_t;
 
 /*


### PR DESCRIPTION
In addition to providing positional arguments for task and functions
SystemVerilog allows to bind arguments by name. This is similar to how
module ports can be bound by name.

```SystemVerilog
task t(int a, int b); ... endtask
...
t(.b(1), .a(2));
```

Extend the parser and elaboration stage to be able to handle this. During
elaboration the named argument list is transformed into a purely positional
list so that later stages like synthesis do not have to care about the
names.

For system functions and tasks all arguments must be unnamed, otherwise an
error will be reported.

In addition to functions and tasks arguments can also be bound by name for
the various different ways of invoking a class constructor.

Resolves #233