### PR TITLE
add double quote escapes from pragma comments.

### DIFF
--- a/ivlpp/lexor.lex
+++ b/ivlpp/lexor.lex
@@ -268,6 +268,7 @@ keywords (line|include|define|undef|ifdef|ifndef|else|elsif|endif)
 <PCOMENT>`[a-zA-Z][a-zA-Z0-9_$]* {
     if (macro_needs_args(yytext+1)) yy_push_state(MA_START); else do_expand(0);
 }
+<PCOMENT>`\"     { fputc('\"', yyout); }
 
  /* Strings do not contain preprocessor directives or macro expansions.
   */

--- a/ivtest/ivltests/attrib_expr.v
+++ b/ivtest/ivltests/attrib_expr.v
@@ -74,6 +74,10 @@ endfunction
 
 (* attr = fn(10) *)     reg attr46;
 
+// Macro escaped
+`define A_MACRO(arg) (* attr = `"arg`" *)
+         `A_MACRO(test) reg attr47;
+
 initial begin
   $display("PASSED");
 end


### PR DESCRIPTION
This was noticed while using Vivado which does the expansion in pragma comments.

I am not sure the test is the right place to add it. Let me know if I need to update this.