### PR TITLE
Small cleanups around netrange_t

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -217,7 +217,7 @@ class PEAssignPattern : public PExpr {
       NetExpr* elaborate_expr_packed_(Design *des, NetScope *scope,
 				      ivl_variable_type_t base_type,
 				      unsigned int width,
-				      const std::vector<netrange_t> &dims,
+				      const netranges_t &dims,
 				      unsigned int cur_dim,
 				      bool need_const) const;
       NetExpr* elaborate_expr_struct_(Design *des, NetScope *scope,
@@ -228,7 +228,7 @@ class PEAssignPattern : public PExpr {
 				     bool need_const, bool up) const;
       NetExpr* elaborate_expr_uarray_(Design *des, NetScope *scope,
 				      const netuarray_t *uarray_type,
-				      const std::vector<netrange_t> &dims,
+				      const netranges_t &dims,
 				      unsigned int cur_dim,
 				      bool need_const) const;
 

--- a/PWire.h
+++ b/PWire.h
@@ -134,10 +134,10 @@ class PWire : public PNamedItem {
       PWire& operator= (const PWire&);
 
       ivl_type_t elaborate_type(Design*des, NetScope*scope,
-			        const std::vector<netrange_t>&packed_dimensions) const;
+			        const netranges_t &packed_dimensions) const;
       ivl_type_t elaborate_darray_type(Design*des, NetScope*scope,
 				       const char *darray_type,
-				       const std::vector<netrange_t>&packed_dimensions)
+				       const netranges_t &packed_dimensions)
 				       const;
 };
 

--- a/Statement.h
+++ b/Statement.h
@@ -499,7 +499,7 @@ class PForeach : public Statement {
 
     private:
       NetProc* elaborate_static_array_(Design*des, NetScope*scope,
-				       const std::vector<netrange_t>&dims) const;
+				       const netranges_t&dims) const;
 
     private:
       perm_string array_var_;

--- a/design_dump.cc
+++ b/design_dump.cc
@@ -409,15 +409,6 @@ static inline ostream&operator<<(ostream&out, const netrange_t&that)
       return out;
 }
 
-ostream&operator<<(ostream&out, const list<netrange_t>&rlist)
-{
-      for (list<netrange_t>::const_iterator cur = rlist.begin()
-		 ; cur != rlist.end() ; ++cur) {
-	    out << *cur;
-      }
-      return out;
-}
-
 ostream&operator<<(ostream&out, const netranges_t&rlist)
 {
       for (netranges_t::const_iterator cur = rlist.begin()

--- a/design_dump.cc
+++ b/design_dump.cc
@@ -418,9 +418,9 @@ ostream&operator<<(ostream&out, const list<netrange_t>&rlist)
       return out;
 }
 
-ostream&operator<<(ostream&out, const vector<netrange_t>&rlist)
+ostream&operator<<(ostream&out, const netranges_t&rlist)
 {
-      for (vector<netrange_t>::const_iterator cur = rlist.begin()
+      for (netranges_t::const_iterator cur = rlist.begin()
 		 ; cur != rlist.end() ; ++cur) {
 	    out << *cur;
       }
@@ -1936,8 +1936,7 @@ void NetESignal::dump(ostream&o) const
 	    o << "+";
       o << name();
       if (word_) o << "[word=" << *word_ << "]";
-      vector<netrange_t>tmp = net_->net_type()->slice_dimensions();
-      o << tmp;
+      o << net_->net_type()->slice_dimensions();
 }
 
 void NetETernary::dump(ostream&o) const

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -312,7 +312,7 @@ NetExpr* PEAssignPattern::elaborate_expr_array_(Design *des, NetScope *scope,
 
 NetExpr* PEAssignPattern::elaborate_expr_uarray_(Design *des, NetScope *scope,
 						 const netuarray_t *uarray_type,
-						 const std::vector<netrange_t> &dims,
+						 const netranges_t &dims,
 						 unsigned int cur_dim,
 						 bool need_const) const
 {
@@ -381,7 +381,7 @@ NetExpr* PEAssignPattern::elaborate_expr_uarray_(Design *des, NetScope *scope,
 NetExpr* PEAssignPattern::elaborate_expr_packed_(Design *des, NetScope *scope,
 						 ivl_variable_type_t base_type,
 						 unsigned int width,
-						 const std::vector<netrange_t> &dims,
+						 const netranges_t &dims,
 						 unsigned int cur_dim,
 						 bool need_const) const
 {
@@ -2522,7 +2522,7 @@ static NetExpr* check_for_struct_members(const LineInfo*li,
 		    // kind of array cannot be a struct.
 		  if (!member_comp.index.empty()) {
 			  // These are the dimensions defined by the type
-			const vector<netrange_t>&mem_packed_dims = mem_vec->packed_dims();
+			const netranges_t&mem_packed_dims = mem_vec->packed_dims();
 
 			if (member_comp.index.size() > mem_packed_dims.size()) {
 			      cerr << li->get_fileline() << ": error: "
@@ -2594,7 +2594,7 @@ static NetExpr* check_for_struct_members(const LineInfo*li,
 		  ivl_assert(*li, !member_comp.index.empty());
 
 		    // These are the dimensions defined by the type
-		  const vector<netrange_t>&mem_packed_dims = array->static_dimensions();
+		  const netranges_t&mem_packed_dims = array->static_dimensions();
 
 		  if (member_comp.index.size() != mem_packed_dims.size()) {
 			cerr << li->get_fileline() << ": error: "
@@ -2790,7 +2790,7 @@ NetExpr* PEIdent::elaborate_expr_class_field_(Design*des, NetScope*scope,
       NetExpr *canon_index = nullptr;
       ivl_type_t tmp_type = class_type->get_prop_type(pidx);
       if (const netuarray_t *tmp_ua = dynamic_cast<const netuarray_t*>(tmp_type)) {
-	    const std::vector<netrange_t> &dims = tmp_ua->static_dimensions();
+	    const auto &dims = tmp_ua->static_dimensions();
 
 	    if (debug_elaborate) {
 		  cerr << get_fileline() << ": PEIdent::elaborate_expr_class_member_: "
@@ -5997,7 +5997,7 @@ NetExpr* PEIdent::elaborate_expr_net_idx_up_(Design*des, NetScope*scope,
 		  long lsv = base_c->value().as_long();
 		  long rel_base = 0;
 		    // Get the signal range.
-		  const vector<netrange_t>&packed = net->sig()->packed_dims();
+		  const netranges_t&packed = net->sig()->packed_dims();
 		  if (prefix_indices.size()+1 < net->sig()->packed_dims().size()) {
 			  // Here we are selecting one or more sub-arrays.
 			  // Make this work by finding the indexed sub-arrays and
@@ -6144,7 +6144,7 @@ NetExpr* PEIdent::elaborate_expr_net_idx_do_(Design*des, NetScope*scope,
 		  long lsv = base_c->value().as_long();
 		  long rel_base = 0;
 		    // Get the signal range.
-		  const vector<netrange_t>&packed = net->sig()->packed_dims();
+		  const netranges_t&packed = net->sig()->packed_dims();
 		  if (prefix_indices.size()+1 < net->sig()->packed_dims().size()) {
 			  // Here we are selecting one or more sub-arrays.
 			  // Make this work by finding the indexed sub-arrays and
@@ -6331,7 +6331,7 @@ NetExpr* PEIdent::elaborate_expr_net_bit_(Design*des, NetScope*scope,
 
 	    long msv = msc->value().as_long();
 
-	    const vector<netrange_t>& sig_packed = net->sig()->packed_dims();
+	    const netranges_t& sig_packed = net->sig()->packed_dims();
 	    if (prefix_indices.size()+2 <= sig_packed.size()) {
 		    // Special case: this is a slice of a multi-dimensional
 		    // packed array. For example:
@@ -6438,7 +6438,7 @@ NetExpr* PEIdent::elaborate_expr_net_bit_(Design*des, NetScope*scope,
 	    return res;
       }
 
-      const vector<netrange_t>& sig_packed = net->sig()->packed_dims();
+      const netranges_t& sig_packed = net->sig()->packed_dims();
       if (prefix_indices.size()+2 <= sig_packed.size()) {
 	      // Special case: this is a slice of a multi-dimensional
 	      // packed array. For example:

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -1965,9 +1965,8 @@ NetExpr* PECallFunction::elaborate_sfunc_(Design*des, NetScope*scope,
 		  use_width = 1;
 		  while (const netuarray_t *utype =
 			 dynamic_cast<const netuarray_t*>(data_type)) {
-			const vector<netrange_t> &dims = utype->static_dimensions();
-			for (size_t i = 0; i < dims.size(); i++)
-			      use_width *= dims[i].width();
+			use_width = netrange_width(utype->static_dimensions(),
+			                           use_width);
 			data_type = utype->element_type();
 		  }
 		  if (!data_type->packed()) {

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -749,7 +749,7 @@ bool PEIdent::elaborate_lval_net_part_(Design*des,
 	    }
       }
 
-      const vector<netrange_t>&packed = reg->packed_dims();
+      const netranges_t&packed = reg->packed_dims();
 
       long loff, moff;
       long wid;
@@ -874,7 +874,7 @@ bool PEIdent::elaborate_lval_net_idx_(Design*des,
 		  long lsv = base_c->value().as_long();
 		  long rel_base = 0;
 		    // Get the signal range.
-		  const vector<netrange_t>&packed = reg->packed_dims();
+		  const netranges_t&packed = reg->packed_dims();
 		  if (prefix_indices.size()+1 < reg->packed_dims().size()) {
 			  // Here we are selecting one or more sub-arrays.
 			  // Make this work by finding the indexed sub-arrays and
@@ -1114,7 +1114,7 @@ NetAssign_* PEIdent::elaborate_lval_net_class_member_(Design*des, NetScope*scope
 	    }
 
 	    if (const netuarray_t *tmp_ua = dynamic_cast<const netuarray_t*>(ptype)) {
-		  const std::vector<netrange_t> &dims = tmp_ua->static_dimensions();
+		  const auto &dims = tmp_ua->static_dimensions();
 
 		  if (debug_elaborate) {
 			cerr << get_fileline() << ": PEIdent::elaborate_lval_method_class_member_: "
@@ -1313,7 +1313,7 @@ bool PEIdent::elaborate_lval_net_packed_member_(Design*des, NetScope*scope,
 		    // kind of array cannot be a struct.
 		  if (!member_comp.index.empty()) {
 			  // These are the dimensions defined by the type
-			const vector<netrange_t>&mem_packed_dims = mem_vec->packed_dims();
+			const netranges_t&mem_packed_dims = mem_vec->packed_dims();
 
 			if (member_comp.index.size() > mem_packed_dims.size()) {
 			      cerr << get_fileline() << ": error: "
@@ -1382,7 +1382,7 @@ bool PEIdent::elaborate_lval_net_packed_member_(Design*des, NetScope*scope,
 		  ivl_assert(*this, !member_comp.index.empty());
 
 		    // These are the dimensions defined by the type
-		  const vector<netrange_t>&mem_packed_dims = array->static_dimensions();
+		  const netranges_t&mem_packed_dims = array->static_dimensions();
 
 		  if (member_comp.index.size() != mem_packed_dims.size()) {
 			cerr << get_fileline() << ": error: "

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -936,13 +936,13 @@ void PWhile::elaborate_sig(Design*des, NetScope*scope) const
 	    statement_->elaborate_sig(des, scope);
 }
 
-bool test_ranges_eeq(const vector<netrange_t>&lef, const vector<netrange_t>&rig)
+bool test_ranges_eeq(const netranges_t&lef, const netranges_t&rig)
 {
       if (lef.size() != rig.size())
 	    return false;
 
-      vector<netrange_t>::const_iterator lcur = lef.begin();
-      vector<netrange_t>::const_iterator rcur = rig.begin();
+      netranges_t::const_iterator lcur = lef.begin();
+      netranges_t::const_iterator rcur = rig.begin();
       while (lcur != lef.end()) {
 	    if (lcur->get_msb() != rcur->get_msb())
 		  return false;
@@ -957,7 +957,7 @@ bool test_ranges_eeq(const vector<netrange_t>&lef, const vector<netrange_t>&rig)
 }
 
 ivl_type_t PWire::elaborate_type(Design*des, NetScope*scope,
-			         const std::vector<netrange_t>&packed_dimensions) const
+			         const netranges_t &packed_dimensions) const
 {
       vector_type_t *vec_type = dynamic_cast<vector_type_t*>(set_data_type_.get());
       if (set_data_type_ && !vec_type) {
@@ -1028,7 +1028,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
       }
 
       unsigned wid = 1;
-      vector<netrange_t>packed_dimensions;
+      netranges_t packed_dimensions;
 
       des->errors += error_cnt_;
 
@@ -1051,7 +1051,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 	    }
 
 	    bool dimensions_ok = true;
-	    vector<netrange_t> plist, nlist;
+	    netranges_t plist, nlist;
 	    /* If they exist get the port definition MSB and LSB */
 	    if (port_set_ && !port_.empty()) {
 		  if (debug_elaborate) {

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -1175,7 +1175,7 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope) const
 	// unpacked_dimensions are empty this will just return the base type.
       type = elaborate_array_type(des, scope, *this, type, unpacked_);
 
-      list<netrange_t> unpacked_dimensions;
+      netranges_t unpacked_dimensions;
 	// If this is an unpacked array extract the base type and unpacked
 	// dimensions as these are separate properties of the NetNet.
       while (const netuarray_t *atype = dynamic_cast<const netuarray_t*>(type)) {

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -403,9 +403,8 @@ void netclass_t::elaborate_sig(Design*des, PClass*pclass)
 		       << "." << endl;
 	    }
 
-	    list<netrange_t> nil_list;
 	    /* NetNet*sig = */ new NetNet(class_scope_, cur->first, NetNet::REG,
-				    nil_list, use_type);
+					  use_type);
       }
 
       for (map<perm_string,PFunction*>::iterator cur = pclass->funcs.begin()
@@ -672,8 +671,7 @@ void PFunction::elaborate_sig(Design*des, NetScope*scope) const
 			if (return_type_)
 			      return_type_->pform_dump(cerr, 8);
 		  }
-		  list<netrange_t> ret_unpacked;
-		  ret_sig = new NetNet(scope, fname, NetNet::REG, ret_unpacked, ret_type);
+		  ret_sig = new NetNet(scope, fname, NetNet::REG, ret_type);
 
 		  ret_sig->set_line(*this);
 		  ret_sig->port_type(NetNet::POUTPUT);

--- a/elab_type.cc
+++ b/elab_type.cc
@@ -168,7 +168,7 @@ ivl_type_t enum_type_t::elaborate_type_raw(Design *des, NetScope *scope) const
 
 ivl_type_t vector_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
-      vector<netrange_t> packed;
+      netranges_t packed;
       if (pdims.get())
 	    evaluate_ranges(des, scope, this, packed, *pdims);
 
@@ -198,7 +198,7 @@ ivl_type_t string_type_t::elaborate_type_raw(Design*, NetScope*) const
 
 ivl_type_t parray_type_t::elaborate_type_raw(Design*des, NetScope*scope) const
 {
-      vector<netrange_t>packed;
+      netranges_t packed;
       if (dims.get())
 	    evaluate_ranges(des, scope, this, packed, *dims);
 
@@ -322,7 +322,7 @@ static ivl_type_t elaborate_queue_type(Design *des, NetScope *scope,
 // return the base type. Also check that we actually support the base type.
 static ivl_type_t elaborate_static_array_type(Design *des, const LineInfo &li,
 					      ivl_type_t base_type,
-					      std::vector<netrange_t> &dims)
+					      netranges_t &dims)
 {
       if (dims.empty())
 	    return base_type;
@@ -354,7 +354,7 @@ ivl_type_t elaborate_array_type(Design *des, NetScope *scope,
 			        const list<pform_range_t> &dims)
 {
       const long warn_dimension_size = 1 << 30;
-      std::vector<netrange_t> dimensions;
+      netranges_t dimensions;
       dimensions.reserve(dims.size());
 
       ivl_type_t type = base_type;

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -5414,7 +5414,7 @@ NetProc* PForeach::elaborate(Design*des, NetScope*scope) const
 		  return 0;
 	    }
 
-	    const std::vector<netrange_t>&dims = atype->static_dimensions();
+	    const netranges_t&dims = atype->static_dimensions();
 	    if (dims.size() < index_vars_.size()) {
 		  cerr << get_fileline() << ": error: "
 		       << "class " << class_scope->get_name()
@@ -5447,7 +5447,7 @@ NetProc* PForeach::elaborate(Design*des, NetScope*scope) const
 		 << " packed dimensions." << endl;
       }
 
-      std::vector<netrange_t>dims = array_sig->unpacked_dims();
+      netranges_t dims = array_sig->unpacked_dims();
       if (array_sig->packed_dimensions() > 0) {
             dims.insert(dims.end(), array_sig->packed_dims().begin(), array_sig->packed_dims().end());
       }
@@ -5523,7 +5523,7 @@ NetProc* PForeach::elaborate(Design*des, NetScope*scope) const
  * and possibly do some optimizations.
  */
 NetProc* PForeach::elaborate_static_array_(Design*des, NetScope*scope,
-					   const vector<netrange_t>&dims) const
+					   const netranges_t&dims) const
 {
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PForeach::elaborate_static_array_: "

--- a/eval_tree.cc
+++ b/eval_tree.cc
@@ -2197,12 +2197,12 @@ static bool get_array_info(const NetExpr*arg, long dim,
       if (dim > (pdims + updims)) return true;
 	/* Get the appropriate unpacked or packed dimension information. */
       if (dim > updims) {
-	    const vector<netrange_t>&dim_vals = sig->packed_dims();
+	    const netranges_t&dim_vals = sig->packed_dims();
 	    const netrange_t&range = dim_vals[dim-updims-1];
 	    left = range.get_msb();
 	    right = range.get_lsb();
       } else {
-	    const vector<netrange_t>&dim_vals = sig->unpacked_dims();
+	    const netranges_t&dim_vals = sig->unpacked_dims();
 	    const netrange_t&range = dim_vals[dim-1];
 	    left = range.get_msb();
 	    right = range.get_lsb();

--- a/expr_synth.cc
+++ b/expr_synth.cc
@@ -846,7 +846,7 @@ NetNet *NetEArrayPattern::synthesize(Design *des, NetScope *scope, NetExpr *root
       if (dim > type_dims.size())
 	    return nullptr;
 
-      std::list<netrange_t> dims(type_dims.end() - dim, type_dims.end());
+      netranges_t dims(type_dims.end() - dim, type_dims.end());
 
       if (dims.front().width() != items_.size())
 	    return nullptr;

--- a/netenum.cc
+++ b/netenum.cc
@@ -56,7 +56,7 @@ long netenum_t::packed_width() const
 	return base_type_->packed_width();
 }
 
-vector<netrange_t> netenum_t::slice_dimensions() const
+netranges_t netenum_t::slice_dimensions() const
 {
       return base_type_->slice_dimensions();
 }

--- a/netenum.h
+++ b/netenum.h
@@ -39,7 +39,7 @@ class netenum_t : public LineInfo, public ivl_type_s {
       virtual ivl_variable_type_t base_type() const;
       virtual bool packed() const;
       virtual long packed_width() const;
-      std::vector<netrange_t> slice_dimensions() const;
+      netranges_t slice_dimensions() const;
       bool get_signed() const;
       bool get_isint() const;
 

--- a/netlist.cc
+++ b/netlist.cc
@@ -563,8 +563,6 @@ void NetNet::calculate_slice_widths_from_packed_dims_(void)
       }
 }
 
-const list<netrange_t> NetNet::not_an_array;
-
 NetNet::NetNet(NetScope*s, perm_string n, Type t,
 	       const list<netrange_t>&unpacked, ivl_type_t use_net_type)
 : NetObj(s, n, calculate_count(unpacked)),

--- a/netlist.cc
+++ b/netlist.cc
@@ -819,12 +819,7 @@ bool NetNet::sb_to_slice(const list<long>&indices, long sb, long&loff, unsigned 
 
 unsigned NetNet::unpacked_count() const
 {
-      unsigned c = 1;
-      for (size_t idx = 0 ; idx < unpacked_dims_.size() ; idx += 1) {
-	    c *= unpacked_dims_[idx].width();
-      }
-
-      return c;
+      return netrange_width(unpacked_dims_);
 }
 
 void NetNet::incr_eref()

--- a/netlist.cc
+++ b/netlist.cc
@@ -537,15 +537,6 @@ static unsigned calculate_count(const list<netrange_t>&unpacked)
       return sum;
 }
 
-template <class T> static unsigned calculate_count(T*type)
-{
-      long wid = type->packed_width();
-      if (wid >= 0)
-	    return wid;
-      else
-	    return 1;
-}
-
 void NetNet::calculate_slice_widths_from_packed_dims_(void)
 {
       ivl_assert(*this, net_type_);

--- a/netlist.cc
+++ b/netlist.cc
@@ -557,7 +557,7 @@ void NetNet::calculate_slice_widths_from_packed_dims_(void)
 
       ivl_assert(*this, ! slice_wids_.empty());
       slice_wids_[0] = netrange_width(slice_dims_);
-      vector<netrange_t>::const_iterator cur = slice_dims_.begin();
+      netranges_t::const_iterator cur = slice_dims_.begin();
       for (size_t idx = 1 ; idx < slice_wids_.size() ; idx += 1, ++cur) {
 	    slice_wids_[idx] = slice_wids_[idx-1] / cur->width();
       }
@@ -775,7 +775,7 @@ long NetNet::sb_to_idx(const list<long>&indices, long sb) const
 {
       ivl_assert(*this, indices.size()+1 == packed_dims().size());
 
-      vector<netrange_t>::const_iterator pcur = packed_dims().end();
+      netranges_t::const_iterator pcur = packed_dims().end();
       -- pcur;
 
       long acc_off;
@@ -2453,14 +2453,14 @@ NetNet* NetESignal::sig()
  */
 long NetESignal::lsi() const
 {
-      const vector<netrange_t>&packed = net_->packed_dims();
+      const netranges_t&packed = net_->packed_dims();
       ivl_assert(*this, packed.size() == 1);
       return packed.back().get_lsb();
 }
 
 long NetESignal::msi() const
 {
-      const vector<netrange_t>&packed = net_->packed_dims();
+      const netranges_t&packed = net_->packed_dims();
       ivl_assert(*this, packed.size() == 1);
       return packed.back().get_msb();
 }

--- a/netlist.cc
+++ b/netlist.cc
@@ -518,19 +518,9 @@ void NetNet::initialize_dir_()
       }
 }
 
-static unsigned calculate_count(const list<netrange_t>&unpacked)
+static unsigned calculate_count(const netranges_t &unpacked)
 {
-      unsigned long sum = 1;
-      for (list<netrange_t>::const_iterator cur = unpacked.begin()
-		 ; cur != unpacked.end() ; ++cur) {
-	      // Special case: If there are any undefined dimensions,
-	      // then give up on trying to create pins for the net.
-	    if (! cur->defined())
-		  return 0;
-
-	    sum *= cur->width();
-      }
-
+      unsigned long sum = netrange_width(unpacked);
       if (sum >= UINT_MAX)
 	    return 0;
 
@@ -564,11 +554,11 @@ void NetNet::calculate_slice_widths_from_packed_dims_(void)
 }
 
 NetNet::NetNet(NetScope*s, perm_string n, Type t,
-	       const list<netrange_t>&unpacked, ivl_type_t use_net_type)
+	       const netranges_t&unpacked, ivl_type_t use_net_type)
 : NetObj(s, n, calculate_count(unpacked)),
     type_(t), port_type_(NOT_A_PORT),
     local_flag_(false), net_type_(use_net_type),
-    discipline_(0), unpacked_dims_(unpacked.begin(), unpacked.end()),
+    discipline_(0), unpacked_dims_(unpacked),
     eref_count_(0), lref_count_(0)
 {
       calculate_slice_widths_from_packed_dims_();

--- a/netlist.h
+++ b/netlist.h
@@ -723,9 +723,9 @@ class NetNet  : public NetObj, public PortType {
 	   first range in the list (front) is the left-most range in
 	   the Verilog declaration. These packed dims are compressed
 	   to represent the dimensions of all the subtypes. */
-      const std::vector<netrange_t>& packed_dims() const { return slice_dims_; }
+      const netranges_t& packed_dims() const { return slice_dims_; }
 
-      const std::vector<netrange_t>& unpacked_dims() const { return unpacked_dims_; }
+      const netranges_t& unpacked_dims() const { return unpacked_dims_; }
 
 	/* The vector_width returns the bit width of the packed array,
 	   vector or scalar that is this NetNet object.  */
@@ -813,7 +813,7 @@ class NetNet  : public NetObj, public PortType {
         // Whether the net is variable declared with the const keyword.
       bool is_const_ = false;
 
-      std::vector<netrange_t> unpacked_dims_;
+      netranges_t unpacked_dims_;
 
 	// These are the widths of the various slice depths. There is
 	// one entry in this vector for each packed dimension. The
@@ -821,7 +821,7 @@ class NetNet  : public NetObj, public PortType {
 	//
 	// For example: slice_wids_[0] is vector_width().
       void calculate_slice_widths_from_packed_dims_(void);
-      std::vector<netrange_t> slice_dims_;
+      netranges_t slice_dims_;
       std::vector<unsigned long> slice_wids_;
 
       unsigned eref_count_;

--- a/netlist.h
+++ b/netlist.h
@@ -677,7 +677,7 @@ class NetNet  : public NetObj, public PortType {
 	// This form is the more generic form of the constructor. For
 	// now, the unpacked type is not buried into an ivl_type_s object.
       explicit NetNet(NetScope*s, perm_string n, Type t,
-		      const std::list<netrange_t>&unpacked,
+		      const netranges_t &unpacked,
 		      ivl_type_t type);
 
       explicit NetNet(NetScope*s, perm_string n, Type t, ivl_type_t type);

--- a/netlist.h
+++ b/netlist.h
@@ -673,8 +673,6 @@ class NetNet  : public NetObj, public PortType {
 
       typedef PortType::Enum PortType;
 
-      static const std::list<netrange_t>not_an_array;
-
     public:
 	// This form is the more generic form of the constructor. For
 	// now, the unpacked type is not buried into an ivl_type_s object.

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -415,7 +415,7 @@ NetExpr *normalize_variable_base(NetExpr *base,
 NetExpr *normalize_variable_bit_base(const list<long>&indices, NetExpr*base,
 				     const NetNet*reg)
 {
-      const vector<netrange_t>&packed_dims = reg->packed_dims();
+      const netranges_t&packed_dims = reg->packed_dims();
       ivl_assert(*base, indices.size()+1 == packed_dims.size());
 
 	// Get the canonical offset of the slice within which we are
@@ -431,7 +431,7 @@ NetExpr *normalize_variable_part_base(const list<long>&indices, NetExpr*base,
 				      const NetNet*reg,
 				      unsigned long wid, bool is_up)
 {
-      const vector<netrange_t>&packed_dims = reg->packed_dims();
+      const netranges_t&packed_dims = reg->packed_dims();
       ivl_assert(*base, indices.size()+1 == packed_dims.size());
 
 	// Get the canonical offset of the slice within which we are
@@ -446,10 +446,10 @@ NetExpr *normalize_variable_part_base(const list<long>&indices, NetExpr*base,
 NetExpr *normalize_variable_slice_base(const list<long>&indices, NetExpr*base,
 				       const NetNet*reg, unsigned long&lwid)
 {
-      const vector<netrange_t>&packed_dims = reg->packed_dims();
+      const netranges_t&packed_dims = reg->packed_dims();
       ivl_assert(*base, indices.size() < packed_dims.size());
 
-      vector<netrange_t>::const_iterator pcur = packed_dims.end();
+      netranges_t::const_iterator pcur = packed_dims.end();
       for (size_t idx = indices.size() ; idx < packed_dims.size(); idx += 1) {
 	    -- pcur;
       }
@@ -563,8 +563,7 @@ void indices_to_expressions(Design*des, NetScope*scope,
       }
 }
 
-static void make_strides(const vector<netrange_t>&dims,
-			 vector<long>&stride)
+static void make_strides(const netranges_t&dims, vector<long>&stride)
 {
       stride[dims.size()-1] = 1;
       for (size_t idx = stride.size()-1 ; idx > 0 ; --idx) {
@@ -581,7 +580,7 @@ static void make_strides(const vector<netrange_t>&dims,
  * word. If any of the indices are out of bounds, return nil instead
  * of an expression.
  */
-static NetExpr* normalize_variable_unpacked(const vector<netrange_t>&dims, list<long>&indices)
+static NetExpr* normalize_variable_unpacked(const netranges_t&dims, list<long>&indices)
 {
 	// Make strides for each index. The stride is the distance (in
 	// words) to the next element in the canonical array.
@@ -614,17 +613,17 @@ static NetExpr* normalize_variable_unpacked(const vector<netrange_t>&dims, list<
 
 NetExpr* normalize_variable_unpacked(const NetNet*net, list<long>&indices)
 {
-      const vector<netrange_t>&dims = net->unpacked_dims();
+      const netranges_t&dims = net->unpacked_dims();
       return normalize_variable_unpacked(dims, indices);
 }
 
 NetExpr* normalize_variable_unpacked(const netsarray_t*stype, list<long>&indices)
 {
-      const vector<netrange_t>&dims = stype->static_dimensions();
+      const netranges_t&dims = stype->static_dimensions();
       return normalize_variable_unpacked(dims, indices);
 }
 
-NetExpr* normalize_variable_unpacked(const LineInfo&loc, const vector<netrange_t>&dims, list<NetExpr*>&indices)
+NetExpr* normalize_variable_unpacked(const LineInfo&loc, const netranges_t&dims, list<NetExpr*>&indices)
 {
 	// Make strides for each index. The stride is the distance (in
 	// words) to the next element in the canonical array.
@@ -711,13 +710,13 @@ NetExpr* normalize_variable_unpacked(const LineInfo&loc, const vector<netrange_t
 
 NetExpr* normalize_variable_unpacked(const NetNet*net, list<NetExpr*>&indices)
 {
-      const vector<netrange_t>&dims = net->unpacked_dims();
+      const netranges_t&dims = net->unpacked_dims();
       return normalize_variable_unpacked(*net, dims, indices);
 }
 
 NetExpr* normalize_variable_unpacked(const LineInfo&loc, const netsarray_t*stype, list<NetExpr*>&indices)
 {
-      const vector<netrange_t>&dims = stype->static_dimensions();
+      const netranges_t&dims = stype->static_dimensions();
       return normalize_variable_unpacked(loc, dims, indices);
 }
 
@@ -1159,8 +1158,7 @@ bool evaluate_range(Design*des, NetScope*scope, const LineInfo*li,
 }
 
 bool evaluate_ranges(Design*des, NetScope*scope, const LineInfo*li,
-		     vector<netrange_t>&llist,
-		     const list<pform_range_t>&rlist)
+		     netranges_t&llist, const list<pform_range_t>&rlist)
 {
       bool dimensions_ok = true;
 
@@ -1587,8 +1585,8 @@ NetExpr*collapse_array_exprs(Design*des, NetScope*scope,
 	    return *exprs.begin();
       }
 
-      const std::vector<netrange_t>&pdims = net->packed_dims();
-      std::vector<netrange_t>::const_iterator pcur = pdims.begin();
+      const netranges_t&pdims = net->packed_dims();
+      netranges_t::const_iterator pcur = pdims.begin();
 
       list<NetExpr*>::iterator ecur = exprs.begin();
       NetExpr* base = 0;
@@ -1881,7 +1879,7 @@ bool calculate_param_range(const LineInfo&line, ivl_type_t par_type,
       }
 
       ivl_assert(line, vector_type->packed());
-      const std::vector<netrange_t>& packed_dims = vector_type->packed_dims();
+      const netranges_t& packed_dims = vector_type->packed_dims();
 
       // This is a netvector_t with 0 dimensions, then the parameter was
       // declared with a statement like this:

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -397,21 +397,6 @@ NetExpr *normalize_variable_base(NetExpr *base, long msb, long lsb,
       return base;
 }
 
-/*
- * This method is how indices should work except that the base should
- * be a vector of expressions that matches the size of the dims list,
- * so that we can generate an expression based on the entire packed
- * vector. For now, we assert that there is only one set of dimensions.
- */
-NetExpr *normalize_variable_base(NetExpr *base,
-				 const list<netrange_t>&dims,
-				 unsigned long wid, bool is_up)
-{
-      ivl_assert(*base, dims.size() == 1);
-      const netrange_t&rng = dims.back();
-      return normalize_variable_base(base, rng.get_msb(), rng.get_lsb(), wid, is_up);
-}
-
 NetExpr *normalize_variable_bit_base(const list<long>&indices, NetExpr*base,
 				     const NetNet*reg)
 {

--- a/netmisc.h
+++ b/netmisc.h
@@ -220,9 +220,6 @@ extern bool calculate_part(const LineInfo*li, Design*des, NetScope*scope,
 extern NetExpr*normalize_variable_base(NetExpr *base, long msb, long lsb,
                                        unsigned long wid, bool is_up,
 				       long slice_off =0);
-extern NetExpr*normalize_variable_base(NetExpr *base,
-				       const std::list<netrange_t>&dims,
-				       unsigned long wid, bool is_up);
 
 /*
  * Calculate a canonicalizing expression for a bit select, when the

--- a/netmisc.h
+++ b/netmisc.h
@@ -418,7 +418,7 @@ extern bool evaluate_range(Design*des, NetScope*scope, const LineInfo*li,
                            long&index_l, long&index_r);
 
 extern bool evaluate_ranges(Design*des, NetScope*scope, const LineInfo*li,
-			    std::vector<netrange_t>&llist,
+			    netranges_t&llist,
 			    const std::list<pform_range_t>&rlist);
 /*
  * This procedure evaluates an expression and if the evaluation is

--- a/netparray.cc
+++ b/netparray.cc
@@ -46,13 +46,13 @@ long netparray_t::packed_width(void) const
 			    element_type()->packed_width());
 }
 
-vector<netrange_t> netparray_t::slice_dimensions() const
+netranges_t netparray_t::slice_dimensions() const
 {
-      const vector<netrange_t>&packed_dims = static_dimensions();
+      const netranges_t&packed_dims = static_dimensions();
 
-      vector<netrange_t> elem_dims = element_type()->slice_dimensions();
+      netranges_t elem_dims = element_type()->slice_dimensions();
 
-      vector<netrange_t> res (packed_dims.size() + elem_dims.size());
+      netranges_t res (packed_dims.size() + elem_dims.size());
 
       for (size_t idx = 0 ; idx < packed_dims.size() ; idx += 1)
 	    res[idx] = packed_dims[idx];
@@ -76,7 +76,7 @@ netuarray_t::~netuarray_t()
 {
 }
 
-vector<netrange_t> netuarray_t::slice_dimensions() const
+netranges_t netuarray_t::slice_dimensions() const
 {
       return static_dimensions();
 }

--- a/netparray.cc
+++ b/netparray.cc
@@ -42,14 +42,8 @@ bool netparray_t::packed(void) const
 
 long netparray_t::packed_width(void) const
 {
-      long cur_width = element_type()->packed_width();
-
-      for (vector<netrange_t>::const_iterator cur = static_dimensions().begin()
-		 ; cur != static_dimensions().end() ; ++cur) {
-	    cur_width *= cur->width();
-      }
-
-      return cur_width;
+      return netrange_width(static_dimensions(),
+			    element_type()->packed_width());
 }
 
 vector<netrange_t> netparray_t::slice_dimensions() const

--- a/netparray.h
+++ b/netparray.h
@@ -30,24 +30,22 @@
 class netsarray_t : public netarray_t {
 
     public:
-      explicit netsarray_t(const std::vector<netrange_t>&packed,
-			   ivl_type_t etype);
+      explicit netsarray_t(const netranges_t&packed, ivl_type_t etype);
       ~netsarray_t();
 
     public:
 	// Virtual methods from the ivl_type_s type...
 
     public:
-      inline const std::vector<netrange_t>& static_dimensions() const
+      inline const netranges_t& static_dimensions() const
       { return dims_; }
 
     private:
-      std::vector<netrange_t> dims_;
+      netranges_t dims_;
 
 };
 
-inline netsarray_t::netsarray_t(const std::vector<netrange_t>&pd,
-				ivl_type_t etype)
+inline netsarray_t::netsarray_t(const netranges_t&pd, ivl_type_t etype)
 : netarray_t(etype), dims_(pd)
 {
 }
@@ -58,23 +56,21 @@ inline netsarray_t::netsarray_t(const std::vector<netrange_t>&pd,
 class netparray_t : public netsarray_t {
 
     public:
-      explicit netparray_t(const std::vector<netrange_t>&packed,
-			   ivl_type_t etype);
+      explicit netparray_t(const netranges_t&packed, ivl_type_t etype);
       ~netparray_t();
 
     public:
 	// Virtual methods from the ivl_type_s type...
       bool packed(void) const;
       long packed_width(void) const;
-      std::vector<netrange_t> slice_dimensions() const;
+      netranges_t slice_dimensions() const;
 
     private:
       bool test_compatibility(ivl_type_t that) const;
       bool test_equivalence(ivl_type_t that) const;
 };
 
-inline netparray_t::netparray_t(const std::vector<netrange_t>&pd,
-				ivl_type_t etype)
+inline netparray_t::netparray_t(const netranges_t&pd, ivl_type_t etype)
 : netsarray_t(pd, etype)
 {
 }
@@ -85,20 +81,18 @@ inline netparray_t::netparray_t(const std::vector<netrange_t>&pd,
 class netuarray_t : public netsarray_t {
 
     public:
-      explicit netuarray_t(const std::vector<netrange_t>&packed,
-			   ivl_type_t etype);
+      explicit netuarray_t(const netranges_t&packed, ivl_type_t etype);
       ~netuarray_t();
 
     public:
 	// Virtual methods from the ivl_type_s type...
-      std::vector<netrange_t> slice_dimensions() const;
+      netranges_t slice_dimensions() const;
 
     private:
       bool test_equivalence(ivl_type_t that) const;
 };
 
-inline netuarray_t::netuarray_t(const std::vector<netrange_t>&pd,
-				ivl_type_t etype)
+inline netuarray_t::netuarray_t(const netranges_t&pd, ivl_type_t etype)
 : netsarray_t(pd, etype)
 {
 }

--- a/netstruct.cc
+++ b/netstruct.cc
@@ -115,9 +115,9 @@ long netstruct_t::packed_width(void) const
       return res;
 }
 
-vector<netrange_t> netstruct_t::slice_dimensions() const
+netranges_t netstruct_t::slice_dimensions() const
 {
-      vector<netrange_t> tmp;
+      netranges_t tmp;
       tmp .push_back(netrange_t(packed_width()-1, 0));
       return tmp;
 }

--- a/netstruct.h
+++ b/netstruct.h
@@ -70,7 +70,7 @@ class netstruct_t : public LineInfo, public ivl_type_s {
 	// Return the width (in bits) of the packed record, or -1 if
 	// the record is not packed.
       long packed_width() const;
-      std::vector<netrange_t> slice_dimensions() const;
+      netranges_t slice_dimensions() const;
 
 	// Return the base type of the packed record, or
 	// IVL_VT_NO_TYPE if the record is not packed.

--- a/nettypes.cc
+++ b/nettypes.cc
@@ -97,9 +97,10 @@ ivl_variable_type_t netarray_t::base_type() const
       return element_type_->base_type();
 }
 
-unsigned long netrange_width(const vector<netrange_t>&packed)
+unsigned long netrange_width(const vector<netrange_t>&packed,
+			     unsigned int base_width)
 {
-      unsigned wid = 1;
+      unsigned wid = base_width;
       for (vector<netrange_t>::const_iterator cur = packed.begin()
 		 ; cur != packed.end() ; ++cur) {
 	    unsigned use_wid = cur->width();

--- a/nettypes.cc
+++ b/nettypes.cc
@@ -42,9 +42,9 @@ long ivl_type_s::packed_width(void) const
       return 1;
 }
 
-vector<netrange_t> ivl_type_s::slice_dimensions() const
+netranges_t ivl_type_s::slice_dimensions() const
 {
-      return vector<netrange_t>();
+      return netranges_t();
 }
 
 ivl_variable_type_t ivl_type_s::base_type() const
@@ -97,11 +97,11 @@ ivl_variable_type_t netarray_t::base_type() const
       return element_type_->base_type();
 }
 
-unsigned long netrange_width(const vector<netrange_t>&packed,
+unsigned long netrange_width(const netranges_t &packed,
 			     unsigned int base_width)
 {
       unsigned wid = base_width;
-      for (vector<netrange_t>::const_iterator cur = packed.begin()
+      for (netranges_t::const_iterator cur = packed.begin()
 		 ; cur != packed.end() ; ++cur) {
 	    unsigned use_wid = cur->width();
 	    wid *= use_wid;
@@ -110,8 +110,7 @@ unsigned long netrange_width(const vector<netrange_t>&packed,
       return wid;
 }
 
-bool netrange_equivalent(const std::vector<netrange_t> &a,
-			 const std::vector<netrange_t> &b)
+bool netrange_equivalent(const netranges_t &a, const netranges_t &b)
 {
 	if (a.size() != b.size())
 		return false;
@@ -130,9 +129,8 @@ bool netrange_equivalent(const std::vector<netrange_t> &a,
  * and width of the resulting slice. In this case, the "sb" argument
  * is an extra index of the prefix.
  */
-bool prefix_to_slice(const std::vector<netrange_t>&dims,
-		     const std::list<long>&prefix, long sb,
-		     long&loff, unsigned long&lwid)
+bool prefix_to_slice(const netranges_t&dims, const std::list<long>&prefix,
+		     long sb, long&loff, unsigned long&lwid)
 {
       assert(prefix.size() < dims.size());
 
@@ -143,7 +141,7 @@ bool prefix_to_slice(const std::vector<netrange_t>&dims,
 	// this by multiplying the widths of the dims that are NOT
 	// accounted for by the prefix or sb indices.
       size_t acc_wid = 1;
-      vector<netrange_t>::const_iterator pcur = dims.end();
+      netranges_t::const_iterator pcur = dims.end();
       for (size_t idx = prefix.size()+1 ; idx < dims.size() ; idx += 1) {
 	    -- pcur;
 	    acc_wid *= pcur->width();

--- a/nettypes.h
+++ b/nettypes.h
@@ -149,7 +149,8 @@ class netrange_t {
 extern std::ostream&operator << (std::ostream&out, const std::list<netrange_t>&rlist);
 extern std::ostream&operator << (std::ostream&out, const std::vector<netrange_t>&rlist);
 
-extern unsigned long netrange_width(const std::vector<netrange_t>&dims);
+extern unsigned long netrange_width(const std::vector<netrange_t>&dims,
+				    unsigned int base_width = 1);
 extern bool netrange_equivalent(const std::vector<netrange_t> &a,
 			        const std::vector<netrange_t> &b);
 

--- a/nettypes.h
+++ b/nettypes.h
@@ -29,6 +29,8 @@
 class netrange_t;
 class LineInfo;
 
+typedef std::vector<netrange_t> netranges_t;
+
 /*
  * This is a fully abstract type that is a type that can be attached
  * to a NetNet object.
@@ -38,7 +40,7 @@ class ivl_type_s {
       virtual ~ivl_type_s() =0;
       virtual bool packed(void) const;
       virtual long packed_width(void) const;
-      virtual std::vector<netrange_t> slice_dimensions() const;
+      virtual netranges_t slice_dimensions() const;
 
 	// Some types have a base variable type. This is the bit type
 	// for packed data types, or IVL_VT_DARRAY or IVL_VT_CLASS for
@@ -67,7 +69,7 @@ class ivl_type_s {
  * Convenience functions for making ivl_type_t objects from various inputs.
  */
 extern ivl_type_t make_ivl_type(ivl_variable_type_t vt,
-				const std::vector<netrange_t>&packed_dimensions,
+				const netranges_t&packed_dimensions,
 				bool signed_flag =false, bool isint_flag =false);
 
 /*
@@ -147,12 +149,11 @@ class netrange_t {
 };
 
 extern std::ostream&operator << (std::ostream&out, const std::list<netrange_t>&rlist);
-extern std::ostream&operator << (std::ostream&out, const std::vector<netrange_t>&rlist);
+extern std::ostream&operator << (std::ostream&out, const netranges_t&rlist);
 
-extern unsigned long netrange_width(const std::vector<netrange_t>&dims,
+extern unsigned long netrange_width(const netranges_t &dims,
 				    unsigned int base_width = 1);
-extern bool netrange_equivalent(const std::vector<netrange_t> &a,
-			        const std::vector<netrange_t> &b);
+extern bool netrange_equivalent(const netranges_t &a, const netranges_t &b);
 
 /*
  * There are a few cases where we need to know about the single-level
@@ -168,7 +169,7 @@ extern bool calculate_param_range(const LineInfo&line, ivl_type_t par_type,
  * indices, and calculate the offset/width of the resulting slice into
  * the packed array.
  */
-extern bool prefix_to_slice(const std::vector<netrange_t>&dims,
+extern bool prefix_to_slice(const netranges_t&dims,
 			    const std::list<long>&prefix, long sb,
 			    long&loff, unsigned long&lwid);
 

--- a/nettypes.h
+++ b/nettypes.h
@@ -148,7 +148,6 @@ class netrange_t {
       long lsb_;
 };
 
-extern std::ostream&operator << (std::ostream&out, const std::list<netrange_t>&rlist);
 extern std::ostream&operator << (std::ostream&out, const netranges_t&rlist);
 
 extern unsigned long netrange_width(const netranges_t &dims,

--- a/netvector.cc
+++ b/netvector.cc
@@ -82,7 +82,7 @@ long netvector_t::packed_width() const
       return netrange_width(packed_dims_);
 }
 
-vector<netrange_t> netvector_t::slice_dimensions() const
+netranges_t netvector_t::slice_dimensions() const
 {
       return packed_dims_;
 }

--- a/netvector.h
+++ b/netvector.h
@@ -26,8 +26,7 @@
 class netvector_t : public ivl_type_s {
 
     public:
-      explicit netvector_t(const std::vector<netrange_t>&packed,
-			   ivl_variable_type_t type);
+      explicit netvector_t(const netranges_t&packed, ivl_variable_type_t type);
 
 	// This is a variant of the vector form. Some code processes
 	// the list of packed ranges as a list, but we will store them
@@ -60,11 +59,11 @@ class netvector_t : public ivl_type_s {
       bool get_implicit() const { return implicit_; }
 
       ivl_variable_type_t base_type() const;
-      const std::vector<netrange_t>&packed_dims() const;
+      const netranges_t&packed_dims() const;
 
       bool packed(void) const;
       long packed_width() const;
-      std::vector<netrange_t> slice_dimensions() const;
+      netranges_t slice_dimensions() const;
 
       std::ostream& debug_dump(std::ostream&) const;
 
@@ -89,20 +88,20 @@ class netvector_t : public ivl_type_s {
       bool test_equivalence(ivl_type_t that) const;
 
     private:
-      std::vector<netrange_t> packed_dims_;
+      netranges_t packed_dims_;
       ivl_variable_type_t type_;
       bool signed_    : 1;
       bool isint_     : 1;		// original type of integer
       bool implicit_  : 1;
 };
 
-inline netvector_t::netvector_t(const std::vector<netrange_t>&pd,
+inline netvector_t::netvector_t(const netranges_t &pd,
 				ivl_variable_type_t type)
 : packed_dims_(pd), type_(type), signed_(false), isint_(false), implicit_(false)
 {
 }
 
-inline const std::vector<netrange_t>& netvector_t::packed_dims() const
+inline const netranges_t& netvector_t::packed_dims() const
 {
       return packed_dims_;
 }

--- a/netvector.h
+++ b/netvector.h
@@ -28,12 +28,6 @@ class netvector_t : public ivl_type_s {
     public:
       explicit netvector_t(const netranges_t&packed, ivl_variable_type_t type);
 
-	// This is a variant of the vector form. Some code processes
-	// the list of packed ranges as a list, but we will store them
-	// as a vector in this constructor.
-      explicit netvector_t(const std::list<netrange_t>&packed,
-			   ivl_variable_type_t type);
-
 	// special case: there is a single packed dimension and we
 	// know it in the form [<msb>:<lsb>]. This step saves me
 	// creating a netrange_t for this single item.

--- a/synth2.cc
+++ b/synth2.cc
@@ -431,7 +431,7 @@ bool NetAssignBase::synth_async(Design*des, NetScope*scope,
 	    netvector_t*tmp_type = new netvector_t(tmp_data_type, lsig_width-1,0);
 
 	    NetNet*tmp = new NetNet(scope, scope->local_symbol(),
-				    NetNet::WIRE, NetNet::not_an_array, tmp_type);
+				    NetNet::WIRE, tmp_type);
 	    tmp->local_flag(true);
 	    tmp->set_line(*this);
 
@@ -465,7 +465,7 @@ bool NetAssignBase::synth_async(Design*des, NetScope*scope,
 	    netvector_t*tmp_type = new netvector_t(tmp_data_type, lsig_width-1,0);
 
 	    NetNet*tmp = new NetNet(scope, scope->local_symbol(),
-				    NetNet::WIRE, NetNet::not_an_array, tmp_type);
+				    NetNet::WIRE, tmp_type);
 	    tmp->local_flag(true);
 	    tmp->set_line(*this);
 
@@ -482,7 +482,7 @@ bool NetAssignBase::synth_async(Design*des, NetScope*scope,
 			     << " Found no isig, resorting to lsig." << endl;
 		  }
 		  isig = new NetNet(scope, scope->local_symbol(),
-				    NetNet::WIRE, NetNet::not_an_array, tmp_type);
+				    NetNet::WIRE, tmp_type);
 		  isig->local_flag(true);
 		  isig->set_line(*this);
 		  connect(isig->pin(0), nex_out.pin(ptr));
@@ -1397,7 +1397,7 @@ bool NetCondit::synth_async(Design*des, NetScope*scope,
 
 	      // Bind some temporary signals to carry pin type.
 	    NetNet*otmp = new NetNet(scope, scope->local_symbol(),
-				     NetNet::WIRE, NetNet::not_an_array, tmp_type);
+				     NetNet::WIRE, tmp_type);
 	    otmp->local_flag(true);
 	    otmp->set_line(*this);
 	    connect(mux->pin_Result(),otmp->pin(0));
@@ -1415,14 +1415,14 @@ bool NetCondit::synth_async(Design*des, NetScope*scope,
 		  NetNet*itmp = statement_input.pin(idx).nexus()->pick_any_net();
 		  if (itmp == 0) {
 			itmp = new NetNet(scope, scope->local_symbol(),
-					  NetNet::WIRE, NetNet::not_an_array, tmp_type);
+					  NetNet::WIRE, tmp_type);
 			itmp->local_flag(true);
 			itmp->set_line(*this);
 			connect(itmp->pin(0), statement_input.pin(idx));
 		  }
 
 		  NetNet*tmp = new NetNet(scope, scope->local_symbol(),
-					  NetNet::WIRE, NetNet::not_an_array, tmp_type);
+					  NetNet::WIRE, tmp_type);
 		  tmp->local_flag(true);
 		  tmp->set_line(*this);
 		  NetSubstitute*ps = new NetSubstitute(itmp, otmp, mux_lwidth, mux_off);

--- a/t-dll-api.cc
+++ b/t-dll-api.cc
@@ -3257,14 +3257,14 @@ extern "C" unsigned ivl_type_packed_width(ivl_type_t net)
 extern "C" unsigned ivl_type_packed_dimensions(ivl_type_t net)
 {
       assert(net);
-      vector<netrange_t> slice = net->slice_dimensions();
+      netranges_t slice = net->slice_dimensions();
       return slice.size();
 }
 
 extern "C" int ivl_type_packed_lsb(ivl_type_t net, unsigned dim)
 {
       assert(net);
-      vector<netrange_t> slice = net->slice_dimensions();
+      netranges_t slice = net->slice_dimensions();
       assert(dim < slice.size());
       return slice[dim].get_lsb();
 }
@@ -3272,7 +3272,7 @@ extern "C" int ivl_type_packed_lsb(ivl_type_t net, unsigned dim)
 extern "C" int ivl_type_packed_msb(ivl_type_t net, unsigned dim)
 {
       assert(net);
-      vector<netrange_t> slice = net->slice_dimensions();
+      netranges_t slice = net->slice_dimensions();
       assert(dim < slice.size());
       return slice[dim].get_msb();
 }

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -2601,7 +2601,7 @@ void dll_target::signal(const NetNet*net)
 	   ivl_signal_t object. */
 
       { size_t idx = 0;
-	vector<netrange_t>::const_iterator cur;
+	netranges_t::const_iterator cur;
 	obj->packed_dims.resize(net->packed_dims().size());
 	for (cur = net->packed_dims().begin(), idx = 0
 		   ; cur != net->packed_dims().end() ; ++cur, idx += 1) {
@@ -2717,7 +2717,7 @@ void dll_target::signal(const NetNet*net)
 	   next encounter the nexus. */
 
       if (obj->array_dimensions_ == 1) {
-	    const vector<netrange_t>& dims = net->unpacked_dims();
+	    const netranges_t& dims = net->unpacked_dims();
 	    if (dims[0].get_msb() < dims[0].get_lsb()) {
 		  obj->array_base = dims[0].get_msb();
 		  obj->array_addr_swapped = false;

--- a/t-dll.h
+++ b/t-dll.h
@@ -759,7 +759,7 @@ struct ivl_signal_s {
 
 	/* These encode the declared packed dimensions for the
 	   signal, in case they are needed by the run-time */
-      std::vector<netrange_t> packed_dims;
+      netranges_t packed_dims;
 
       perm_string name_;
       ivl_scope_t scope_;


### PR DESCRIPTION
A set of small cleanups around netrange_t, no functional changes.

- Use `NetNet` constructor that does not take a `vector<netrange_t>` for non-array nets
- Use `netrange_width()` in a few more places
- Add typedef `netranges_t` for `vector<netrange_t>`
- Replace the one place where `list<netrange_t>` is used with `netranges_t`
- Remove unused `calculate_count()` function
