### PR TITLE
Implement $width timing check (only vvp for now)

### DIFF
--- a/vpi/sdf_lexor.lex
+++ b/vpi/sdf_lexor.lex
@@ -45,8 +45,6 @@ static int yywrap(void)
 %}
 
 %x CCOMMENT
-%x COND_EDGE_ID
-%x EDGE_ID
 
 %%
 
@@ -64,16 +62,15 @@ static int yywrap(void)
   /* Count lines so that the parser can assign line numbers. */
 \n { sdflloc.first_line += 1; }
 
-  /* The other edge identifiers. */
-<COND_EDGE_ID,EDGE_ID>"01"    {return K_01; }
-<COND_EDGE_ID,EDGE_ID>"10"    {return K_10; }
-<COND_EDGE_ID,EDGE_ID>"0"[zZ] {return K_0Z; }
-<COND_EDGE_ID,EDGE_ID>[zZ]"1" {return K_Z1; }
-<COND_EDGE_ID,EDGE_ID>"1"[zZ] {return K_1Z; }
-<COND_EDGE_ID,EDGE_ID>[zZ]"0" {return K_Z0; }
-<COND_EDGE_ID,EDGE_ID>[pP][oO][sS][eE][dD][gG][eE] {return K_POSEDGE; }
-<COND_EDGE_ID,EDGE_ID>[nN][eE][gG][eE][dD][gG][eE] {return K_NEGEDGE; }
-<COND_EDGE_ID>[cC][oO][nN][dD] {return K_COND; }
+  /* The edge identifiers. */
+"posedge" { return K_POSEDGE; }
+"negedge" { return K_NEGEDGE; }
+"01" {return K_01; }
+"10" {return K_10; }
+"0z" {return K_0Z; }
+"z1" {return K_Z1; }
+"1z" {return K_1Z; }
+"z0" {return K_Z0; }
 
   /* Integer values */
 [0-9]+ {
@@ -164,17 +161,6 @@ static struct {
       { "WIDTH",        K_WIDTH },
       { 0, IDENTIFIER }
 };
-
-void start_edge_id(unsigned cond)
-{
-      if (cond) BEGIN(COND_EDGE_ID);
-      else BEGIN(EDGE_ID);
-}
-
-void stop_edge_id(void)
-{
-      BEGIN(0);
-}
 
 static int lookup_keyword(const char*text)
 {

--- a/vpi/sdf_parse_priv.h
+++ b/vpi/sdf_parse_priv.h
@@ -30,7 +30,4 @@ extern const char*sdf_parse_path;
 /* Hierarchy separator character to use. */
 extern char sdf_use_hchar;
 
-extern void start_edge_id(unsigned cond);
-extern void stop_edge_id(void);
-
 #endif /* IVL_sdf_parse_priv_h */

--- a/vpi/sdf_priv.h
+++ b/vpi/sdf_priv.h
@@ -54,6 +54,15 @@ struct port_with_edge_s {
       char*string_val;
 };
 
+// The reference and data signals of timing checks
+// can have logical condition expressions and edges
+// associated with them.
+struct port_tchk_s {
+  int   vpi_edge;
+  char* condition;
+  char* signal;
+};
+
 struct interconnect_port_s {
       char* name;
       bool has_index;
@@ -71,6 +80,10 @@ extern void sdf_interconnect_delays(struct interconnect_port_s port1,
                                     struct interconnect_port_s port2,
                                     const struct sdf_delval_list_s*delval_list,
                                     const int sdf_lineno);
+
+extern void sdf_tchk_width_limits(struct port_tchk_s ref_event,
+                                  struct sdf_delay_s limit,
+                                  const int sdf_lineno);
 
 #endif /* IVL_sdf_priv_h */
 

--- a/vpi_user.h
+++ b/vpi_user.h
@@ -299,6 +299,8 @@ typedef struct t_vpi_delay  {
 #define vpiSysFuncCall 56
 #define vpiSysTaskCall 57
 #define vpiTask        59
+#define vpiTchk        61
+#define vpiTchkTerm    62
 #define vpiTimeVar     63
 #define vpiUdpDefn     66
 #define vpiUserSystf   67
@@ -309,6 +311,9 @@ typedef struct t_vpi_delay  {
 #define vpiRightRange  83
 #define vpiScope       84
 #define vpiSysTfCall   85
+#define vpiTchkDataTerm 86
+#define vpiTchkNotifier 87
+#define vpiTchkRefTerm  88
 #define vpiArgument    89
 #define vpiBit         90
 #define vpiInternalScope 92
@@ -376,6 +381,19 @@ typedef struct t_vpi_delay  {
 #   define vpiPosedge      (vpiEdgex1|vpiEdge01|vpiEdge0x)
 #   define vpiNegedge      (vpiEdgex0|vpiEdge10|vpiEdge1x)
 #   define vpiAnyEdge      (vpiPosedge|vpiNegedge)
+#define vpiTchkType      38
+#   define vpiSetup       1
+#   define vpiHold        2
+#   define vpiPeriod      3
+#   define vpiWidth       4
+#   define vpiSkew        5
+#   define vpiRecovery    6
+#   define vpiNoChange    7
+#   define vpiSetupHold   8
+#   define vpiFullskew    9
+#   define vpiRecrem      10
+#   define vpiRemoval     11
+#   define vpiTimeskew    12
 #define vpiConstType 40
 #   define vpiDecConst    1
 #   define vpiRealConst   2

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -67,7 +67,7 @@ MDIR1 = -DMODULE_DIR1='"$(libdir)/ivl$(suffix)"'
 VPI = vpi_modules.o vpi_bit.o vpi_callback.o vpi_cobject.o vpi_const.o vpi_darray.o \
       vpi_event.o vpi_iter.o vpi_mcd.o \
       vpi_priv.o vpi_scope.o vpi_real.o vpi_signal.o vpi_string.o vpi_tasks.o vpi_time.o \
-      vpi_vthr_vector.o vpip_bin.o vpip_hex.o vpip_oct.o \
+      vpi_vthr_vector.o vpi_tchk.o vpip_bin.o vpip_hex.o vpip_oct.o \
       vpip_to_dec.o vpip_format.o vvp_vpi.o
 
 O = main.o parse.o parse_misc.o lexor.o arith.o array_common.o array.o bufif.o compile.o \
@@ -78,7 +78,7 @@ O = main.o parse.o parse_misc.o lexor.o arith.o array_common.o array.o bufif.o c
     symbols.o ufunc.o codes.o vthread.o schedule.o \
     statistics.o tables.o udp.o vvp_island.o vvp_net.o vvp_net_sig.o \
     vvp_object.o vvp_cobject.o vvp_darray.o event.o logic.o delay.o \
-    words.o island_tran.o $(VPI)
+    words.o island_tran.o tchk.o $(VPI)
 
 all: dep vvp@EXEEXT@ vvp.man
 

--- a/vvp/compile.cc
+++ b/vvp/compile.cc
@@ -32,11 +32,14 @@
 # include  "parse_misc.h"
 # include  "statistics.h"
 # include  "schedule.h"
+# include  "event.h"
 # include  <iostream>
 # include  <list>
 # include  <cstdlib>
 # include  <cstring>
 # include  <cassert>
+# include  "vvp_net_sig.h"
+# include  "tchk.h"
 
 #ifdef __MINGW32__
 #include <windows.h>
@@ -2048,4 +2051,47 @@ void compile_island(char*label, char*type)
 	    assert(0);
 
       free(type);
+}
+
+void compile_tchk_width(char* edge, struct symb_s ref, char* condition, double limit, double threshold, char* notifier, long file_idx, long lineno )
+{
+      if (strcmp(condition, "v0x000000000000_0") != 0) {
+	    fprintf(stderr, "sorry: Conditions not implemented for timing checks\n");
+      }
+      free(condition);
+
+      edge_t tchk_edge;
+
+      if (strcmp(edge, "posedge") == 0) {
+	    tchk_edge = vvp_edge_posedge;
+      } else if (strcmp(edge, "negedge") == 0) {
+	    tchk_edge = vvp_edge_negedge;
+      } else {
+	    yyerror("invalid edge");
+	    return;
+      }
+
+      __vpiScope* scope = vpip_peek_current_scope();
+
+	// Create new net and functor
+      vvp_net_t* my_tchk_width = new vvp_net_t;
+      vvp_fun_tchk_width* obj_tchk_width = new vvp_fun_tchk_width(tchk_edge,
+                                                                  vpip_scaled_real_to_time64(limit, scope),
+                                                                  vpip_scaled_real_to_time64(threshold, scope));
+      my_tchk_width->fun = obj_tchk_width;
+
+	// Copy string because it is used twice for lookup
+	// TODO is there a better way?
+      char* ref_tmp = (char*)malloc(50);
+      strcpy(ref_tmp, ref.text);
+
+	// Connect reference signal to port 0 and create VPI object
+      input_connect(my_tchk_width, 0, ref_tmp);
+      __vpiTchkWidth* obj = (__vpiTchkWidth*)vpip_make_tchk_width(file_idx, lineno, obj_tchk_width);
+
+      // Add vpiHandles to object for later lookup
+      if (notifier) compile_vpi_lookup(&(obj->vpi_notifier_), notifier);
+      if (ref.text) compile_vpi_lookup(&(obj->vpi_reference_), ref.text);
+
+      vpip_attach_to_current_scope(obj);
 }

--- a/vvp/compile.h
+++ b/vvp/compile.h
@@ -484,6 +484,12 @@ extern void compile_scope_decl(char*typ, char*lab, char*nam, char*tnam,
 extern void compile_scope_recall(char*sym);
 
 /*
+ * The parser uses this function to compile .tchk_width statements.
+ */
+extern void compile_tchk_width(char* edge, struct symb_s ref, char* condition,
+                               double limit, double threshold, char* notifier, long file_idx, long lineno );
+
+/*
  * The parser uses this function to declare a thread. The start_sym is
  * the start instruction, and must already be defined.
  */

--- a/vvp/event.cc
+++ b/vvp/event.cc
@@ -178,42 +178,6 @@ void schedule_evctl(vvp_array_t memory, unsigned index,
       ep->last = &((*(ep->last))->next);
 }
 
-inline vvp_fun_edge::edge_t VVP_EDGE(vvp_bit4_t from, vvp_bit4_t to)
-{
-      return 1 << ((from << 2) | to);
-}
-
-const vvp_fun_edge::edge_t vvp_edge_posedge
-      = VVP_EDGE(BIT4_0,BIT4_1)
-      | VVP_EDGE(BIT4_0,BIT4_X)
-      | VVP_EDGE(BIT4_0,BIT4_Z)
-      | VVP_EDGE(BIT4_X,BIT4_1)
-      | VVP_EDGE(BIT4_Z,BIT4_1)
-      ;
-
-const vvp_fun_edge::edge_t vvp_edge_negedge
-      = VVP_EDGE(BIT4_1,BIT4_0)
-      | VVP_EDGE(BIT4_1,BIT4_X)
-      | VVP_EDGE(BIT4_1,BIT4_Z)
-      | VVP_EDGE(BIT4_X,BIT4_0)
-      | VVP_EDGE(BIT4_Z,BIT4_0)
-      ;
-
-const vvp_fun_edge::edge_t vvp_edge_edge
-      = VVP_EDGE(BIT4_0,BIT4_1)
-      | VVP_EDGE(BIT4_1,BIT4_0)
-      | VVP_EDGE(BIT4_0,BIT4_X)
-      | VVP_EDGE(BIT4_X,BIT4_0)
-      | VVP_EDGE(BIT4_0,BIT4_Z)
-      | VVP_EDGE(BIT4_Z,BIT4_0)
-      | VVP_EDGE(BIT4_X,BIT4_1)
-      | VVP_EDGE(BIT4_1,BIT4_X)
-      | VVP_EDGE(BIT4_Z,BIT4_1)
-      | VVP_EDGE(BIT4_1,BIT4_Z)
-      ;
-
-const vvp_fun_edge::edge_t vvp_edge_none    = 0;
-
 struct vvp_fun_edge_state_s : public waitable_state_s {
       vvp_fun_edge_state_s()
       {

--- a/vvp/event.h
+++ b/vvp/event.h
@@ -166,11 +166,6 @@ class vvp_fun_edge : public vvp_net_fun_t, public waitable_hooks_s {
       edge_t edge_;
 };
 
-extern const vvp_fun_edge::edge_t vvp_edge_edge;
-extern const vvp_fun_edge::edge_t vvp_edge_posedge;
-extern const vvp_fun_edge::edge_t vvp_edge_negedge;
-extern const vvp_fun_edge::edge_t vvp_edge_none;
-
 /*
  * Statically allocated vvp_fun_edge.
  */

--- a/vvp/lexor.lex
+++ b/vvp/lexor.lex
@@ -46,6 +46,11 @@ static char* strdupnew(char const *str)
 
 %}
 
+digit [0-9]
+integer {digit}+
+real ({digit}+[.]{digit}*)|({digit}*[.]{digit}+)
+exp ({integer}|{real})[eE]-?{integer}
+
 %%
 
   /* These are some special header/footer keywords. */
@@ -228,6 +233,7 @@ static char* strdupnew(char const *str)
 ".udp"         { return K_UDP; }
 ".udp/c"(omb)? { return K_UDP_C; }
 ".udp/s"(equ)? { return K_UDP_S; }
+".tchk_width" { return K_TCHK_WIDTH; }
 "-debug" { return K_DEBUG; }
 
   /* instructions start with a % character. The compiler decides what
@@ -260,6 +266,8 @@ static char* strdupnew(char const *str)
 "0x"[0-9a-fA-F]+ {
       yylval.numb = strtouint64(yytext, 0, 0);
       return T_NUMBER; }
+
+({real}|{exp}) { yylval.real = atof(yytext); return T_REAL; }
 
   /* Handle some specialized constant/literals as symbols. */
 

--- a/vvp/parse.y
+++ b/vvp/parse.y
@@ -53,6 +53,7 @@ static struct __vpiModPath*modpath_dst = 0;
       char*text;
       char **table;
       uint64_t numb;
+      double real;
       bool flag;
 
       comp_operands_t opa;
@@ -108,10 +109,14 @@ static struct __vpiModPath*modpath_dst = 0;
 %token K_ivl_version K_ivl_delay_selection
 %token K_vpi_module K_vpi_time_precision K_file_names K_file_line
 %token K_PORT_INPUT K_PORT_OUTPUT K_PORT_INOUT K_PORT_MIXED K_PORT_NODIR
+%token K_TCHK_WIDTH
+%token K_POSEDGE "posedge"
+%token K_NEGEDGE "negedge"
 
 %token <text> T_INSTR
 %token <text> T_LABEL
 %token <numb> T_NUMBER
+%token <real> T_REAL
 %token <text> T_STRING
 %token <text> T_SYMBOL
 %token <vect> T_VECTOR
@@ -714,6 +719,11 @@ statement
 	|         K_SCOPE T_SYMBOL ';'
 		{ compile_scope_recall($2); }
 
+
+  /* Timing checks */
+
+	| K_TCHK_WIDTH T_NUMBER T_NUMBER ',' T_STRING ',' symbol ',' T_SYMBOL ',' T_REAL ',' T_NUMBER ',' T_SYMBOL ';'
+		{ compile_tchk_width($5, $7, $9, $11, $13, $15, $2, $3); }
 
   /* Port information for scopes... currently this is just meta-data for VPI queries */
 

--- a/vvp/tchk.cc
+++ b/vvp/tchk.cc
@@ -27,6 +27,9 @@
 
 #include <iostream>
 
+// Trigger cbTchkViolation
+extern void vpiTchkViolation(vpiHandle tchk);
+
 vvp_fun_tchk_width::vvp_fun_tchk_width(edge_t start_edge, vvp_time64_t limit, vvp_time64_t threshold)
 : bit_(BIT4_X), start_edge_(start_edge), limit_(limit), threshold_(threshold), t1_(0), t2_(0), width_(0)
 {
@@ -136,4 +139,7 @@ void vvp_fun_tchk_width::violation()
 		  vvp_send_vec4(ptr, vvp_vector4_t(1, BIT4_0), nullptr);
 	    }
       }
+
+      // Trigger cbTchkViolation
+      vpiTchkViolation(vpi_tchk);
 }

--- a/vvp/tchk.cc
+++ b/vvp/tchk.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023 Stephen Williams (steve@icarus.com)
+ * Copyright (c) 2023 Leo Moser (leo.moser@pm.me)
+ *
+ *    This source code is free software; you can redistribute it
+ *    and/or modify it in source code form under the terms of the GNU
+ *    General Public License as published by the Free Software
+ *    Foundation; either version 2 of the License, or (at your option)
+ *    any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+# include  "tchk.h"
+
+# include  "compile.h"
+# include  "schedule.h"
+# include  "vvp_net_sig.h"
+# include  "event.h"
+
+#include <iostream>
+
+vvp_fun_tchk_width::vvp_fun_tchk_width(edge_t start_edge, vvp_time64_t limit, vvp_time64_t threshold)
+: bit_(BIT4_X), start_edge_(start_edge), limit_(limit), threshold_(threshold), t1_(0), t2_(0), width_(0)
+{
+      if (start_edge != vvp_edge_posedge && start_edge != vvp_edge_negedge) {
+	    std::cout << "tchk error: invalid reference edge" << std::endl;
+	    assert(0);
+      }
+}
+
+vvp_fun_tchk_width::~vvp_fun_tchk_width()
+{
+}
+
+void vvp_fun_tchk_width::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
+                                   vvp_context_t)
+{
+        // Port 0 is reference input
+      if (port.port() == 0) {
+
+	      // See what kind of edge this represents.
+	    edge_t mask = VVP_EDGE(bit_, bit.value(0));
+
+	      // Save the current input for the next time around.
+	    bit_ = bit.value(0);
+
+	    if (start_edge_ & mask) {
+		  t1_ = schedule_simtime();
+	    }
+
+	    if (!(start_edge_ & mask)) {
+		  t2_ = schedule_simtime();
+
+		  width_ = t2_ - t1_;
+		  if (width_ < limit_ && width_ > threshold_) {
+			violation();
+		  }
+	    }
+      }
+}
+
+void vvp_fun_tchk_width::violation()
+{
+      vpiHandle scope = vpi_tchk->vpi_handle(vpiScope);
+      char* fullname = vpi_get_str(vpiFullName, scope);
+      std::string violation_message;
+
+      assert(vpi_tchk->file_idx_ < file_names.size());
+
+      std::string time_unit("ps"); // For now let's just print everything in ps
+
+	// Build the violation message
+      violation_message += "Timing violation!\n";
+      violation_message += "\t$width( ";
+      if (start_edge_ == vvp_edge_posedge) violation_message += "posedge ";
+      else violation_message += "negedge ";
+      violation_message += vpi_get_str(vpiName, vpi_tchk->vpi_reference_);
+      violation_message += ":" + std::to_string(t1_) + " " + time_unit + ", ";
+      violation_message += std::to_string(limit_) + " " + time_unit + " : ";
+      violation_message += std::to_string(width_);
+      violation_message +=" "+time_unit+", ";
+      violation_message += std::to_string(threshold_) + " " + time_unit + ", ";
+      violation_message += vpi_get_str(vpiName, vpi_tchk->vpi_notifier_);
+      violation_message += " );\n";
+      violation_message += "\tfile_idx = ";
+      violation_message += file_names[vpi_tchk->file_idx_];
+      violation_message += " line = " + std::to_string(vpi_tchk->lineno_) + "\n";
+      violation_message += "\tScope: ";
+      violation_message += fullname;
+      violation_message += "\n";
+      violation_message += "\tTime: ";
+      violation_message += std::to_string(t2_);
+      violation_message += " "+time_unit;
+
+	// Print the violation message
+      std::cout << violation_message << std::endl;
+
+      if (vpi_tchk->vpi_notifier_) {
+
+	    __vpiSignal* vpi_notifier_sig = dynamic_cast<__vpiSignal*> (vpi_tchk->vpi_notifier_);
+
+	    if (vpi_notifier_sig == 0) {
+		  std::cout << "tchk error: notifier not a signal?" << std::endl;
+		  assert(vpi_notifier_sig);
+	    }
+
+	    vvp_vector4_t sig_value;
+
+	      // Is it a signal functor?
+	    vvp_signal_value* sig = dynamic_cast<vvp_signal_value*> (vpi_notifier_sig->node->fil);
+	    if (sig == 0) {
+		  std::cout << "tchk error: notifier not a signal?" << std::endl;
+		  assert(sig);
+	    }
+
+	      // Extract the value from the signal
+	    sig->vec4_value(sig_value);
+
+	      // If notifier is z, nothing is to do
+	    if (sig_value.value(0) == BIT4_Z) return;
+
+	      // Update notifier value
+	    if (sig_value.value(0) != BIT4_1) {
+		  vvp_net_ptr_t ptr (vpi_notifier_sig->node, 0);
+		  vvp_send_vec4(ptr, vvp_vector4_t(1, BIT4_1), nullptr);
+	    } else {
+		  vvp_net_ptr_t ptr (vpi_notifier_sig->node, 0);
+		  vvp_send_vec4(ptr, vvp_vector4_t(1, BIT4_0), nullptr);
+	    }
+      }
+}

--- a/vvp/tchk.h
+++ b/vvp/tchk.h
@@ -1,0 +1,65 @@
+#ifndef IVL_tchk_H
+#define IVL_tchk_H
+/*
+ * Copyright (c) 2023 Stephen Williams (steve@icarus.com)
+ * Copyright (c) 2023 Leo Moser (leo.moser@pm.me)
+ *
+ *    This source code is free software; you can redistribute it
+ *    and/or modify it in source code form under the terms of the GNU
+ *    General Public License as published by the Free Software
+ *    Foundation; either version 2 of the License, or (at your option)
+ *    any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+# include  <stddef.h>
+# include  "vvp_net.h"
+# include  "schedule.h"
+# include  "event.h"
+
+class __vpiTchkWidth;
+
+/*
+ * The vvp_fun_tchk_width functor implements the $width timing check
+ * The reference event is connected to port 0, the data event is the
+ * inverse of the referenc event
+ */
+class vvp_fun_tchk_width : public vvp_net_fun_t {
+
+    public:
+      typedef unsigned short edge_t;
+      explicit vvp_fun_tchk_width(edge_t start_edge, vvp_time64_t limit, vvp_time64_t threshold);
+      virtual ~vvp_fun_tchk_width();
+
+      __vpiTchkWidth* vpi_tchk;
+
+    protected:
+      void recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
+                     vvp_context_t);
+
+      vvp_bit4_t bit_;
+
+    private:
+      edge_t start_edge_;
+        // Time values already scaled for
+        // higher performance
+      vvp_time64_t limit_;
+      vvp_time64_t threshold_;
+      vvp_time64_t t1_;
+      vvp_time64_t t2_;
+      vvp_time64_t width_;
+
+      void violation();
+
+      friend __vpiTchkWidth;
+};
+
+#endif /* IVL_tchk_H */

--- a/vvp/vpi_tchk.cc
+++ b/vvp/vpi_tchk.cc
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2023 Stephen Williams (steve@icarus.com)
+ * Copyright (c) 2023 Leo Moser (leo.moser@pm.me)
+ *
+ *    This source code is free software; you can redistribute it
+ *    and/or modify it in source code form under the terms of the GNU
+ *    General Public License as published by the Free Software
+ *    Foundation; either version 2 of the License, or (at your option)
+ *    any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+# include  "tchk.h"
+
+# include  "compile.h"
+# include  "event.h"
+
+#include <iostream>
+
+__vpiTchk::__vpiTchk( __vpiScope *scope, unsigned file_idx, unsigned lineno)
+: scope_(scope), file_idx_(file_idx), lineno_(lineno)
+{
+}
+
+__vpiTchk::~__vpiTchk()
+{
+}
+
+__vpiTchkWidth::__vpiTchkWidth( __vpiScope *scope, unsigned file_idx, unsigned lineno, vvp_fun_tchk_width* fun )
+: __vpiTchk(scope, file_idx, lineno), fun_(fun)
+{
+}
+
+__vpiTchkWidth::~__vpiTchkWidth()
+{
+}
+
+int __vpiTchkWidth::vpi_get(int code) {
+
+     switch (code) {
+
+	  case vpiTchkType:
+	    return vpiWidth;
+
+	  default:
+	    fprintf(stderr, "VPI error: unknown signal_get property %d.\n",
+	            code);
+	    return vpiUndefined;
+      }
+
+};
+
+vpiHandle __vpiTchkWidth::vpi_handle(int code) {
+
+      switch (code) {
+
+	  case vpiScope:
+	    return scope_;
+
+	  case vpiTchkNotifier:
+	    return vpi_notifier_;
+
+	  case vpiTchkRefTerm:
+	    if (!vpi_tchk_ref_term_) {
+	        if (fun_->start_edge_ == vvp_edge_posedge) vpi_tchk_ref_term_ = new __vpiTchkRefTerm(vpiPosedge, vpi_reference_);
+	        else vpi_tchk_ref_term_ = new __vpiTchkRefTerm(vpiNegedge, vpi_reference_);
+	    }
+	    return vpi_tchk_ref_term_;
+
+	    // There is no data term for $width
+	  case vpiTchkDataTerm:
+	    return 0;
+      }
+
+      return 0;
+};
+
+void __vpiTchkWidth::vpi_get_delays(p_vpi_delay delays) {
+
+        // $width has one limit TODO or also threshold?
+        if (delays->no_of_delays != 1) return;
+
+        delays->da[0].real = vpip_time_to_scaled_real(fun_->limit_, scope_);
+};
+
+void __vpiTchkWidth::vpi_put_delays(p_vpi_delay delays) {
+
+        // $width has one limit TODO or also threshold?
+        if (delays->no_of_delays != 1) return;
+
+        fun_->limit_ = vpip_scaled_real_to_time64(delays->da[0].real, scope_);
+};
+
+__vpiTchkTerm::__vpiTchkTerm(int edge, vpiHandle expr)
+:  expr_(expr), edge_(edge)
+{
+}
+
+__vpiTchkTerm::~__vpiTchkTerm()
+{
+}
+
+int __vpiTchkTerm::vpi_get(int code)
+{
+      switch (code) {
+	  case vpiEdge:
+	    return edge_;
+	  default:
+	    return 0;
+      }
+}
+
+vpiHandle __vpiTchkTerm::vpi_handle(int code)
+{
+      switch (code) {
+	  case vpiExpr:
+	    return expr_;
+	  default:
+	    return nullptr;
+      }
+}
+
+__vpiTchkRefTerm::__vpiTchkRefTerm(int edge, vpiHandle expr)
+: __vpiTchkTerm(edge, expr)
+{
+}
+
+__vpiTchkRefTerm::~__vpiTchkRefTerm()
+{
+}
+
+__vpiTchkDataTerm::__vpiTchkDataTerm(int edge, vpiHandle expr)
+: __vpiTchkTerm(edge, expr)
+{
+}
+
+__vpiTchkDataTerm::~__vpiTchkDataTerm()
+{
+}
+
+vpiHandle vpip_make_tchk_width(long file_idx, long lineno, vvp_fun_tchk_width* fun)
+{
+      __vpiTchkWidth* obj = new __vpiTchkWidth(vpip_peek_current_scope(), file_idx, lineno, fun);
+      fun->vpi_tchk = obj;
+
+      return obj;
+}

--- a/vvp/vvp_net.cc
+++ b/vvp/vvp_net.cc
@@ -510,13 +510,6 @@ ostream& operator<<(ostream&out, vvp_bit4_t bit)
       return out;
 }
 
-typedef unsigned short edge_t;
-
-inline edge_t VVP_EDGE(vvp_bit4_t from, vvp_bit4_t to)
-{
-      return 1 << ((from << 2) | to);
-}
-
 const edge_t vvp_edge_posedge
       = VVP_EDGE(BIT4_0,BIT4_1)
       | VVP_EDGE(BIT4_0,BIT4_X)
@@ -532,6 +525,21 @@ const edge_t vvp_edge_negedge
       | VVP_EDGE(BIT4_X,BIT4_0)
       | VVP_EDGE(BIT4_Z,BIT4_0)
       ;
+
+const edge_t vvp_edge_edge
+      = VVP_EDGE(BIT4_0,BIT4_1)
+      | VVP_EDGE(BIT4_1,BIT4_0)
+      | VVP_EDGE(BIT4_0,BIT4_X)
+      | VVP_EDGE(BIT4_X,BIT4_0)
+      | VVP_EDGE(BIT4_0,BIT4_Z)
+      | VVP_EDGE(BIT4_Z,BIT4_0)
+      | VVP_EDGE(BIT4_X,BIT4_1)
+      | VVP_EDGE(BIT4_1,BIT4_X)
+      | VVP_EDGE(BIT4_Z,BIT4_1)
+      | VVP_EDGE(BIT4_1,BIT4_Z)
+      ;
+
+const edge_t vvp_edge_none = 0;
 
 int edge(vvp_bit4_t from, vvp_bit4_t to)
 {

--- a/vvp/vvp_net.h
+++ b/vvp/vvp_net.h
@@ -185,6 +185,19 @@ inline vvp_bit4_t operator & (vvp_bit4_t a, vvp_bit4_t b)
 extern vvp_bit4_t operator ^ (vvp_bit4_t a, vvp_bit4_t b);
 extern std::ostream& operator<< (std::ostream&o, vvp_bit4_t a);
 
+  /* Specifies edges in vvp */
+typedef unsigned short edge_t;
+
+static inline edge_t VVP_EDGE(vvp_bit4_t from, vvp_bit4_t to)
+{
+      return 1 << ((from << 2) | to);
+}
+
+extern const edge_t vvp_edge_edge;
+extern const edge_t vvp_edge_posedge;
+extern const edge_t vvp_edge_negedge;
+extern const edge_t vvp_edge_none;
+
   /* Return >0, ==0 or <0 if the from-to transition represents a
      posedge, no edge, or negedge. */
 extern int edge(vvp_bit4_t from, vvp_bit4_t to);


### PR DESCRIPTION
This PR contains my latest work on implementing the `$width` timing check. It checks that the pulse width of a signal does not fall below a limit.

It is described by a record of type `.tchk_width`, e.g.:

```
.tchk_width 3 8, "posedge", v0x55a707f6d570_0, v0x000000000000_0, 1.0, 0, v0x55a707f6d450_0;
```

The individual elements:

    .tchk_width <file_idx> <line_num>, "<starting_edge>", <reference_signal>, <condition>, <limit>, <threshold>, <notifier_signal>;

Note: The automatic insertion of such a record into the `.vvp` file is not yet implemented, for now this has been tested manually.

The following is supported:

- Both "posedge" and "negedge" as starting edge
- Violation message
- SDF annotation
- cbTchkViolation VPI callback

The following is not supported:

- Conditions

I have got some tests prepared, but I will commit them only after the record insertion works.

Since my GSoC project is coming to an end and the next few weeks will be busy for me, it may be some time before I get back to finish this, but I do intend to.

However, what has already been implemented could be reviewed in the meantime, thanks!
