### PR TITLE
 vvp: Fix initial value propagation for 2-state non-automatic arrays

### DIFF
--- a/ivtest/ivltests/sv_2state_array_init_prop.v
+++ b/ivtest/ivltests/sv_2state_array_init_prop.v
@@ -1,0 +1,34 @@
+// Check that the initial value of a 2-state array is properly propagated
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr !== val) begin \
+      $display("FAILED(%0d): `%s`, expected %0d, got %0d", `__LINE__, `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+  bit [1:0] a[2];
+  integer i = 0;
+
+  wire [1:0] x = a[0];
+  wire [1:0] y = a[i];
+  wire [2:0] z = {1'b1, a[0]};
+  wire w = a[0][0];
+
+  initial begin
+     #1;
+    `check(a[0], 2'b00);
+    `check(x, 2'b00);
+    `check(y, 2'b00);
+    `check(z, 3'b100);
+    `check(w, 1'b0);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -48,6 +48,7 @@ pv_wr_fn_vec2			vvp_tests/pv_wr_fn_vec2.json
 pv_wr_fn_vec4			vvp_tests/pv_wr_fn_vec4.json
 struct_packed_write_read	vvp_tests/struct_packed_write_read.json
 struct_packed_write_read2	vvp_tests/struct_packed_write_read2.json
+sv_2state_array_init_prop	vvp_tests/sv_2state_array_init_prop.json
 sv_ap_uarray1			vvp_tests/sv_ap_uarray1.json
 sv_ap_uarray2			vvp_tests/sv_ap_uarray2.json
 sv_ap_uarray3			vvp_tests/sv_ap_uarray3.json

--- a/ivtest/vvp_tests/sv_2state_array_init_prop.json
+++ b/ivtest/vvp_tests/sv_2state_array_init_prop.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_2state_array_init_prop.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/vvp/array.cc
+++ b/vvp/array.cc
@@ -1261,11 +1261,15 @@ static void array_attach_port(vvp_array_t array, vvp_fun_arrayport*fun)
       array->ports_ = fun;
       if (!array->get_scope()->is_automatic()) {
               /* propagate initial values for variable arrays */
-            if (array->vals4) {
-                  vvp_vector4_t tmp(array->vals_width, BIT4_X);
+            if (!vpi_array_is_real(array)) {
+                  vvp_bit4_t init;
+                  if (array->vals4)
+                      init = BIT4_X;
+                  else
+                      init = BIT4_0;
+                  vvp_vector4_t tmp(array->vals_width, init);
                   schedule_init_propagate(fun->net_, tmp);
-            }
-            if (array->vals) {
+            } else {
                   schedule_init_propagate(fun->net_, 0.0);
             }
       }


### PR DESCRIPTION
For 2-state non-automatic arrays currently real 0.0 value is propagated as
the initial value. This will cause an assert at the downstream receivers
which expect a vector.

Make sure that the vector value 0 is propagated instead for 2-state
vectors.
