### PR TITLE
Return '0 for out-of-bounds access on 2-state queues and dynamic arrays.

### DIFF
--- a/ivtest/ivltests/sv_queue_vec.v
+++ b/ivtest/ivltests/sv_queue_vec.v
@@ -1,7 +1,7 @@
 module top;
-  int q_tst [$];
-  int q_tmp [$];
-  int elem;
+  integer q_tst [$];
+  integer q_tmp [$];
+  integer elem;
   integer idx;
   bit passed;
 

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -126,7 +126,6 @@ sv_darray_nest1			NI			ivltests
 sv_darray_nest2			NI			ivltests
 sv_darray_nest3			NI			ivltests
 sv_darray_nest4			NI			ivltests
-sv_darray_oob_vec2		NI			ivltests
 sv_deferred_assert1		NI			ivltests
 sv_deferred_assert2		NI			ivltests
 sv_deferred_assume1		NI			ivltests
@@ -135,4 +134,3 @@ sv_queue_nest1			NI			ivltests
 sv_queue_nest2			NI			ivltests
 sv_queue_nest3			NI			ivltests
 sv_queue_nest4			NI			ivltests
-sv_queue_oob_vec2		NI			ivltests

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -664,6 +664,7 @@ sv_darray_decl_assign	normal,-g2009		ivltests
 sv_darray_function	normal,-g2009		ivltests
 sv_darray_oob_real	normal,-g2009		ivltests
 sv_darray_oob_string	normal,-g2009		ivltests
+sv_darray_oob_vec2	normal,-g2009		ivltests
 sv_darray_oob_vec4	normal,-g2009		ivltests
 sv_darray_signed	normal,-g2009		ivltests
 sv_darray_word_size	normal,-g2005-sv	ivltests
@@ -784,6 +785,7 @@ sv_queue_function1	normal,-g2009		ivltests
 sv_queue_function2	normal,-g2009		ivltests
 sv_queue_oob_real	normal,-g2009		ivltests
 sv_queue_oob_string	normal,-g2009		ivltests
+sv_queue_oob_vec2	normal,-g2009		ivltests
 sv_queue_oob_vec4	normal,-g2009		ivltests
 sv_queue_parray		normal,-g2009,-pfileline=1	ivltests gold=sv_queue_parray.gold
 sv_queue_parray_bounded	normal,-g2009,-pfileline=1	ivltests gold=sv_queue_parray_bounded.gold

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -957,6 +957,8 @@ static void draw_select_vec4(ivl_expr_t expr)
 	    assert(base);
 	    draw_eval_expr_into_integer(base, 3);
 	    fprintf(vvp_out, "    %%load/dar/vec4 v%p_0;\n", sig);
+	    if (ivl_expr_value(expr) == IVL_VT_BOOL)
+		  fprintf(vvp_out, "    %%cast2;\n");
 
 	    return;
       }


### PR DESCRIPTION
vvp does not track whether the values stored in a dynamic array or queue are 2-state or 4-state. Internally the data is always stored as 4-state.

To make sure that the read value is actually 2-state do a cast for 2-state reads.

E.g. performing an out-of-bounds access on a 2-state dynamic array or queue will yield `'X` while it should return `'0`.

There is one test that relies on the incorrect behavior. Update the test to use a 4-state instead of 2-state base type.