### PR TITLE
vvp: Add parser rule for unsigned 2-state net arrays

### DIFF
--- a/ivtest/ivltests/sv_array_cassign8.v
+++ b/ivtest/ivltests/sv_array_cassign8.v
@@ -1,0 +1,30 @@
+// Check that continuous assignments to 2-state arrays are supported.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(expr, val) do \
+    if (expr !== val) begin \
+      $display("FAILED(%0d): `%s`, expected %0d, got %0d", `__LINE__, `"expr`", val, expr); \
+      failed = 1'b1; \
+    end \
+  while (0)
+
+  int a1[0:1];
+  bit [31:0] a2[0:1];
+
+  assign a1[0] = -10;
+  assign a2[0] = 20;
+
+  initial begin
+    #0
+    `check(a1[0], -10);
+    `check(a2[0], 20);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -62,6 +62,7 @@ sv_array_assign_fail1	vvp_tests/sv_array_assign_fail1.json
 sv_array_assign_fail2	vvp_tests/sv_array_assign_fail2.json
 sv_array_cassign6		vvp_tests/sv_array_cassign6.json
 sv_array_cassign7		vvp_tests/sv_array_cassign7.json
+sv_array_cassign8		vvp_tests/sv_array_cassign8.json
 sv_automatic_2state		vvp_tests/sv_automatic_2state.json
 sv_chained_constructor1		vvp_tests/sv_chained_constructor1.json
 sv_chained_constructor2		vvp_tests/sv_chained_constructor2.json

--- a/ivtest/vvp_tests/sv_array_cassign8.json
+++ b/ivtest/vvp_tests/sv_array_cassign8.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_array_cassign8.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/vvp/parse.y
+++ b/vvp/parse.y
@@ -827,6 +827,10 @@ statement
     symbols_net ';'
       { compile_netw($1, $3, $4, $6, $7, vpiLogicVar, true, $9.cnt, $9.vect); }
 
+  | T_LABEL K_NET_2U T_SYMBOL T_NUMBER ',' signed_t_number signed_t_number ','
+    symbols_net ';'
+      { compile_netw($1, $3, $4, $6, $7, vpiIntVar, false, $9.cnt, $9.vect); }
+
   | T_LABEL K_NET_2S T_SYMBOL T_NUMBER ',' signed_t_number signed_t_number ','
     symbols_net ';'
       { compile_netw($1, $3, $4, $6, $7, vpiIntVar, true, $9.cnt, $9.vect); }


### PR DESCRIPTION
vvp is missing a parser rule for unsigned 2-state net arrays. E.g.

```SystemVerilog
  bit a[0:1];
  assign a[0] = 1'b0;
```

will synthesize fine, but when running it with vvp cause a syntax error.

Resolves #1005