### PR TITLE
Remove MINGW32 from regression test scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64 },
-          { msystem: MINGW32, arch: i686 }
+          { msystem: MINGW64, arch: x86_64 }
         ]
     name: 🟪 ${{ matrix.msystem}} · ${{ matrix.arch }}
     defaults:


### PR DESCRIPTION
The MINGW32 test is failing randomly. It is not something that we typically need anyhow, so give up and remove it.

Fixes #1050 .