### PR TITLE
Handle invalid vector slice base expressions

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -5994,6 +5994,8 @@ NetExpr* PEIdent::elaborate_expr_net_idx_up_(Design*des, NetScope*scope,
 	    return 0;
 
       NetExpr*base = calculate_up_do_base_(des, scope, need_const);
+      if (!base)
+	    return nullptr;
 
 	// Use the part select width already calculated by test_width().
       unsigned long wid = min_width_;
@@ -6141,6 +6143,8 @@ NetExpr* PEIdent::elaborate_expr_net_idx_do_(Design*des, NetScope*scope,
 	    return 0;
 
       NetExpr*base = calculate_up_do_base_(des, scope, need_const);
+      if (!base)
+	    return nullptr;
 
 	// Use the part select width already calculated by test_width().
       unsigned long wid = min_width_;

--- a/ivtest/ivltests/partsel_invalid_idx1.v
+++ b/ivtest/ivltests/partsel_invalid_idx1.v
@@ -1,0 +1,14 @@
+// Check that a non-existent index into a vector results in an elaboration error.
+
+module test;
+
+  reg [31:0] a;
+  wire b;
+
+  assign b = a[does_not_exist]; // Error: Invalid index
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_invalid_idx2.v
+++ b/ivtest/ivltests/partsel_invalid_idx2.v
@@ -1,0 +1,14 @@
+// Check that a non-existent index into a vector results in an elaboration error.
+
+module test;
+
+  reg [31:0] a;
+  wire [1:0] b;
+
+  assign b = a[does_not_exist+:2]; // Error: Invalid base index
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_invalid_idx3.v
+++ b/ivtest/ivltests/partsel_invalid_idx3.v
@@ -1,0 +1,14 @@
+// Check that a non-existent index into a vector results in an elaboration error.
+
+module test;
+
+  reg [31:0] a;
+  wire [1:0] b;
+
+  assign b = a[does_not_exist-:2]; // Error: Invalid base index
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_invalid_idx4.v
+++ b/ivtest/ivltests/partsel_invalid_idx4.v
@@ -1,0 +1,15 @@
+// Check that a non-existent index into a parameter results in an elaboration error.
+
+module test;
+
+  parameter [31:0] P = 'h0;
+
+  wire x;
+
+  assign x = P[does_not_exist]; // Error: Invalid index
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_invalid_idx5.v
+++ b/ivtest/ivltests/partsel_invalid_idx5.v
@@ -1,0 +1,15 @@
+// Check that a non-existent index into a parameter results in an elaboration error.
+
+module test;
+
+  parameter [31:0] P = 'h0;
+
+  wire [1:0] x;
+
+  assign x = P[does_not_exist+:2]; // Error: Invalid base index
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_invalid_idx6.v
+++ b/ivtest/ivltests/partsel_invalid_idx6.v
@@ -1,0 +1,15 @@
+// Check that a non-existent index into a parameter results in an elaboration error.
+
+module test;
+
+  parameter [31:0] P = 'h0;
+
+  wire [1:0] x;
+
+  assign x = P[does_not_exist-:2]; // Error: Invalid base index
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -86,6 +86,12 @@ module_ordered_list2		vvp_tests/module_ordered_list2.json
 module_port_array1		vvp_tests/module_port_array1.json
 module_port_array_init1		vvp_tests/module_port_array_init1.json
 non-polymorphic-abs		vvp_tests/non-polymorphic-abs.json
+partsel_invalid_idx1		vvp_tests/partsel_invalid_idx1.json
+partsel_invalid_idx2		vvp_tests/partsel_invalid_idx2.json
+partsel_invalid_idx3		vvp_tests/partsel_invalid_idx3.json
+partsel_invalid_idx4		vvp_tests/partsel_invalid_idx4.json
+partsel_invalid_idx5		vvp_tests/partsel_invalid_idx5.json
+partsel_invalid_idx6		vvp_tests/partsel_invalid_idx6.json
 param_test3			vvp_tests/param_test3.json
 param-width			vvp_tests/param-width.json
 param-width-vlog95		vvp_tests/param-width-vlog95.json

--- a/ivtest/vvp_tests/partsel_invalid_idx1.json
+++ b/ivtest/vvp_tests/partsel_invalid_idx1.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_invalid_idx1.v"
+}

--- a/ivtest/vvp_tests/partsel_invalid_idx2.json
+++ b/ivtest/vvp_tests/partsel_invalid_idx2.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_invalid_idx2.v"
+}

--- a/ivtest/vvp_tests/partsel_invalid_idx3.json
+++ b/ivtest/vvp_tests/partsel_invalid_idx3.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_invalid_idx3.v"
+}

--- a/ivtest/vvp_tests/partsel_invalid_idx4.json
+++ b/ivtest/vvp_tests/partsel_invalid_idx4.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_invalid_idx4.v"
+}

--- a/ivtest/vvp_tests/partsel_invalid_idx5.json
+++ b/ivtest/vvp_tests/partsel_invalid_idx5.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_invalid_idx5.v"
+}

--- a/ivtest/vvp_tests/partsel_invalid_idx6.json
+++ b/ivtest/vvp_tests/partsel_invalid_idx6.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_invalid_idx6.v"
+}


### PR DESCRIPTION
The elaboration of the base expression of a vector slice index can fail and return a nullptr. Currently this results in a nullptr deref. Handle that case by exiting the function early.

Resolves #1036.