### PR TITLE
vvp: Don't schedule initial value propagation for net array ports

### DIFF
--- a/vvp/array.cc
+++ b/vvp/array.cc
@@ -1259,7 +1259,8 @@ static void array_attach_port(vvp_array_t array, vvp_fun_arrayport*fun)
       assert(fun->next_ == 0);
       fun->next_ = array->ports_;
       array->ports_ = fun;
-      if (!array->get_scope()->is_automatic()) {
+      if (!array->get_scope()->is_automatic() &&
+          (array->vals4 || array->vals)) {
               /* propagate initial values for variable arrays */
             if (!vpi_array_is_real(array)) {
                   vvp_bit4_t init;


### PR DESCRIPTION
An initial value propagation should only be scheduled for variable array ports, but not for net array port since those do not contain any values.

This got accidentally broken when fixing support for 2-state variable array ports.

Add a check that only does the initial value propagation if the port is for a variable array.

Test case in #1014.