### PR TITLE
 Detect reversed part select on inner dimensions

### DIFF
--- a/ivtest/ivltests/partsel_reversed_idx1.v
+++ b/ivtest/ivltests/partsel_reversed_idx1.v
@@ -1,0 +1,14 @@
+// Check that an inverted part select in a continuous assign is reported as an
+// error.
+
+module test;
+
+  reg [1:0] x;
+
+  assign x[0:1] = 2'b00; // Error: Part select indices swapped
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_reversed_idx2.v
+++ b/ivtest/ivltests/partsel_reversed_idx2.v
@@ -1,0 +1,14 @@
+// Check that an inverted part select on an inner dimension in a continuous
+// assign is reported as an error.
+
+module test;
+
+  reg [1:0][1:0] x;
+
+  assign x[0:1] = 2'b00; // Error: Part select indices swapped
+
+  initial begin
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_reversed_idx3.v
+++ b/ivtest/ivltests/partsel_reversed_idx3.v
@@ -1,0 +1,14 @@
+// Check that an inverted part select in a procedural assign is reported as an
+// error.
+
+module test;
+
+  reg [1:0] x;
+
+  initial begin
+    x[0:1] = 2'b00; // Error: Part select indices swapped
+
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_reversed_idx4.v
+++ b/ivtest/ivltests/partsel_reversed_idx4.v
@@ -1,0 +1,14 @@
+// Check that an inverted part select on an inner dimension in a procedural
+// assign is reported as an error.
+
+module test;
+
+  reg [1:0][1:0] x;
+
+  initial begin
+    x[0:1] = 2'b00; // Error: Part select indices swapped
+
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_reversed_idx5.v
+++ b/ivtest/ivltests/partsel_reversed_idx5.v
@@ -1,0 +1,14 @@
+// Check that an inverted part select in an expression is reported as an error.
+
+module test;
+
+  reg [1:0] x;
+  reg [1:0] y;
+
+  initial begin
+    y = x[0:1]; // Error: Part select indices swapped
+
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/partsel_reversed_idx6.v
+++ b/ivtest/ivltests/partsel_reversed_idx6.v
@@ -1,0 +1,15 @@
+// Check that an inverted part select on an inner dimension in an expression is
+// reported as an error.
+
+module test;
+
+  reg [1:0][1:0] x;
+  reg [1:0] y;
+
+  initial begin
+    y = x[0:1]; // Error: Part select indices swapped
+
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -94,6 +94,12 @@ partsel_invalid_idx3		vvp_tests/partsel_invalid_idx3.json
 partsel_invalid_idx4		vvp_tests/partsel_invalid_idx4.json
 partsel_invalid_idx5		vvp_tests/partsel_invalid_idx5.json
 partsel_invalid_idx6		vvp_tests/partsel_invalid_idx6.json
+partsel_reversed_idx1		vvp_tests/partsel_reversed_idx1.json
+partsel_reversed_idx2		vvp_tests/partsel_reversed_idx2.json
+partsel_reversed_idx3		vvp_tests/partsel_reversed_idx3.json
+partsel_reversed_idx4		vvp_tests/partsel_reversed_idx4.json
+partsel_reversed_idx5		vvp_tests/partsel_reversed_idx5.json
+partsel_reversed_idx6		vvp_tests/partsel_reversed_idx6.json
 param_test3			vvp_tests/param_test3.json
 param-width			vvp_tests/param-width.json
 param-width-vlog95		vvp_tests/param-width-vlog95.json

--- a/ivtest/vvp_tests/partsel_reversed_idx1.json
+++ b/ivtest/vvp_tests/partsel_reversed_idx1.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_reversed_idx1.v"
+}

--- a/ivtest/vvp_tests/partsel_reversed_idx2.json
+++ b/ivtest/vvp_tests/partsel_reversed_idx2.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_reversed_idx2.v"
+}

--- a/ivtest/vvp_tests/partsel_reversed_idx3.json
+++ b/ivtest/vvp_tests/partsel_reversed_idx3.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_reversed_idx3.v"
+}

--- a/ivtest/vvp_tests/partsel_reversed_idx4.json
+++ b/ivtest/vvp_tests/partsel_reversed_idx4.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_reversed_idx4.v"
+}

--- a/ivtest/vvp_tests/partsel_reversed_idx5.json
+++ b/ivtest/vvp_tests/partsel_reversed_idx5.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_reversed_idx5.v"
+}

--- a/ivtest/vvp_tests/partsel_reversed_idx6.json
+++ b/ivtest/vvp_tests/partsel_reversed_idx6.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "partsel_reversed_idx6.v"
+}


### PR DESCRIPTION
The order of the indices of a part select need to match the order in which
the dimension of a packed array has been declared. E.g. if the msb is less
than the lsb in the declaration it also has to be for the part select.

If the order of the part select is the opposite of the declaration this is
an error. This works as expected for part selects on the most outer
dimensions.

But for inner dimensions the current implementation just swaps the msb and
lsb of the part select if they are in the wrong order.

Refactor this so that an error is reported for both the outer and inner
dimensions.