### PR TITLE
Correctly calculate width of nested path identifiers

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -530,10 +530,10 @@ class PEIdent : public PExpr {
 					   unsigned expr_wid,
 					   unsigned flags) const;
 
-      unsigned test_width_method_(const symbol_search_results &sr);
-
-
       unsigned test_width_parameter_(const NetExpr *par, width_mode_t&mode);
+
+      ivl_type_t resolve_type_(Design *des, const symbol_search_results &sr,
+			       unsigned int &index_depth) const;
 
     private:
       NetNet* elaborate_lnet_common_(Design*des, NetScope*scope,

--- a/ivtest/ivltests/struct_nested1.v
+++ b/ivtest/ivltests/struct_nested1.v
@@ -1,0 +1,69 @@
+// Check that the width on a nested struct member is calculated correctly
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(expr, val) do \
+    if (expr !== val) begin \
+      $display("FAILED(%0d): `%s`, expected %0d, got %0d", `__LINE__, `"expr`", val, expr); \
+      failed = 1'b1; \
+    end \
+  while (0)
+
+  typedef enum bit [15:0] {
+    A, B
+  } E;
+
+
+  struct packed {
+    struct packed {
+      struct packed {
+        reg [7:0][3:0] x;
+        E e;
+      } s2;
+      int z;
+    } s1;
+    int y;
+  } s0;
+
+  initial begin
+
+    `check($bits(s0), 112);
+    `check($bits(s0.s1), 80);
+    `check($bits(s0.s1.s2), 48);
+    `check($bits(s0.s1.s2.x), 32);
+    `check($bits(s0.s1.s2.e), 16);
+    `check($bits(s0.s1.s2.e.next), 16);
+    `check($bits(s0.s1.s2.e.prev), 16);
+    `check($bits(s0.s1.s2.e.first), 16);
+    `check($bits(s0.s1.s2.e.last), 16);
+    `check($bits(s0.s1.s2.e.num), 32);
+
+    `check($bits(s0[0]), 1);
+    `check($bits(s0.s1[0]), 1);
+    `check($bits(s0.s1.s2[0]), 1);
+    `check($bits(s0.s1.s2.x[0]), 4);
+    `check($bits(s0.s1.s2.x[0][0]), 1);
+    `check($bits(s0.s1.s2.e[0]), 1);
+
+    `check($bits(s0[1:0]), 2);
+    `check($bits(s0.s1[1:0]), 2);
+    `check($bits(s0.s1.s2[1:0]), 2);
+    `check($bits(s0.s1.s2.x[1:0]), 8);
+    `check($bits(s0.s1.s2.x[0][1:0]), 2);
+    `check($bits(s0.s1.s2.e[1:0]), 2);
+
+    `check($bits(s0[0+:2]), 2);
+    `check($bits(s0.s1[0+:2]), 2);
+    `check($bits(s0.s1.s2[0+:2]), 2);
+    `check($bits(s0.s1.s2.x[0+:2]), 8);
+    `check($bits(s0.s1.s2.x[0][0+:2]), 2);
+    `check($bits(s0.s1.s2.e[0+:2]), 2);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -132,6 +132,7 @@ sf_onehot_fail			vvp_tests/sf_onehot_fail.json
 sf_onehot0_fail			vvp_tests/sf_onehot0_fail.json
 struct_enum_partsel		vvp_tests/struct_enum_partsel.json
 struct_field_left_right		vvp_tests/struct_field_left_right.json
+struct_nested1			vvp_tests/struct_nested1.json
 struct_packed_write_read	vvp_tests/struct_packed_write_read.json
 struct_packed_write_read2	vvp_tests/struct_packed_write_read2.json
 sv_2state_array_init_prop	vvp_tests/sv_2state_array_init_prop.json

--- a/ivtest/vvp_tests/struct_nested1.json
+++ b/ivtest/vvp_tests/struct_nested1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "struct_nested1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
The current `PEIdent::test_width()` method is only able to calculate width
of a path with up to two elements.

For more complex paths it will not be able to calculate the width. E.g.
 * Nested struct member access
 * function call of a enum member in a struct

To make nested structures work properly walk the whole path tail element
by element updating the type along the way. Also take the indices into
account and update the type if an arrays dimensions have been fully
consumed.

Resolves #704.