### PR TITLE
 Use NetReplicate to implement replication for concat

### DIFF
--- a/vvp/concat.cc
+++ b/vvp/concat.cc
@@ -234,6 +234,13 @@ void vvp_fun_repeat::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
       port.ptr()->send_vec4(val, 0);
 }
 
+void vvp_fun_repeat::recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t &bit,
+			          unsigned base, unsigned vwid,
+				  vvp_context_t context)
+{
+      recv_vec4_pv_(port, bit, base, vwid, context);
+}
+
 void compile_repeat(char*label, long width, long repeat, struct symb_s arg)
 {
       vvp_fun_repeat*fun = new vvp_fun_repeat(width, repeat);

--- a/vvp/vvp_net.h
+++ b/vvp/vvp_net.h
@@ -1450,6 +1450,9 @@ class vvp_fun_repeat  : public vvp_net_fun_t {
 
       void recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
                      vvp_context_t context);
+      void recv_vec4_pv(vvp_net_ptr_t port, const vvp_vector4_t&bit,
+			unsigned int base, unsigned int vwid,
+			vvp_context_t context) final;
 
     private:
       unsigned wid_;


### PR DESCRIPTION
Currently replication in a concatenation is implemented by simply
concatenating the input signals multiple times by the replication amount.

Replace this to use NetReplicate on the concatenation instead. In case
there is only one input vector to the concatenation the replication will directly
connect to the input vector.

This is slightly more efficient in vvp since the replication functor has
only one input while the concatenation has multiple inputs connected to the
same wire. When an update of the input occurs the replication functor will
only receive a single update, while the concatenation will receive multiple
update events, one for each replication.