### PR TITLE
vvp: Reduce overhead of passing vvp_net_ptr_t between functions

### DIFF
--- a/vvp/vvp_net.h
+++ b/vvp/vvp_net.h
@@ -1055,7 +1055,7 @@ template <class T> class vvp_sub_pointer_t {
 	    bits_ |= port__;
       }
 
-      ~vvp_sub_pointer_t() { }
+      ~vvp_sub_pointer_t() = default;
 
       T* ptr()
       { return reinterpret_cast<T*> (bits_ & ~UINTPTR_C(3)); }


### PR DESCRIPTION
vvp_net_ptr_t uses vvp_sub_pointer_t to implement a tagged pointer with the tag containing the port number.

The size of the tagged pointer is that of a normal pointer and could easily be passed in a register when passing it as an argument to a function.

But since the vvp_sub_pointer_t type has a non-standard destructor it is instead passed on the stack with the register containing a pointer to the stack location where the value is stored.

This creates extra boiler plate code when passing a vvp_net_ptr_t to a function writing and reading the value to and from the stack.

Use the default destructor for vvp_sub_pointer_t to avoid this and have the value passed in a register.

There isn't much of a performance gain but the change is simple enough to do anyway.