### PR TITLE
vvp: Remove bitsr from struct vvp_fun_part_state_s

### DIFF
--- a/vvp/part.cc
+++ b/vvp/part.cc
@@ -29,10 +29,9 @@
 using namespace std;
 
 struct vvp_fun_part_state_s {
-      vvp_fun_part_state_s() : bitsr(0.0) {}
+      vvp_fun_part_state_s() {}
 
       vvp_vector4_t bits;
-      double bitsr;
 };
 
 vvp_fun_part::vvp_fun_part(unsigned base, unsigned wid)


### PR DESCRIPTION
The part functor has no real typed state and the bitsr field of the state struct is unused. Remove it.