### PR TITLE
ivtest: Remove outdated pr1963962 SystemVerilog mode gold file

### DIFF
--- a/ivtest/gold/pr1963962-fsv.gold
+++ b/ivtest/gold/pr1963962-fsv.gold
@@ -1,2 +1,0 @@
-VCD info: dumpfile work/dumptest.vcd opened for output.
-VCD warning: $dumpvars: Package ($unit::) is not dumpable with VCD.

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -84,7 +84,6 @@ parameter_no_default		normal			ivltests
 parameter_omit1			normal			ivltests
 parameter_omit2			normal			ivltests
 parameter_omit3			normal			ivltests
-pr1963962			normal			ivltests gold=pr1963962-fsv.gold
 pr3015421			CE			ivltests gold=pr3015421-fsv.gold
 resetall			normal,-Wtimescale	ivltests gold=resetall-fsv.gold
 scope2b				normal			ivltests


### PR DESCRIPTION
Starting with commit 96df251c955a ("Suppress unnecessary VCD/LXT/LXT2 warnings about packages.") there is no longer a warning printed that the unit scope can't be printed if it is empty.

Remove the special SystemVerilog mode gold file for the pr1963962 test that expects this warning.