### PR TITLE
run_ivl.py: Properly escape `.` in regex

### DIFF
--- a/ivtest/run_ivl.py
+++ b/ivtest/run_ivl.py
@@ -33,7 +33,7 @@ def get_ivl_version () -> list:
 
     # Get the output from the "iverilog -V" command for the version string.
     text = subprocess.check_output(["iverilog", "-V"])
-    match = re.search(b'Icarus Verilog version ([0-9]+)\.([0-9]+)', text)
+    match = re.search(b'Icarus Verilog version ([0-9]+)\\.([0-9]+)', text)
     if not match:
         return None
 


### PR DESCRIPTION
To escape the `.` in the regex it needs to be prefixed with a `\`. But since the `\` is a escape character in python strings it needs to be escaped as well.

Without this some versions of python print the following warning:

      run_ivl.py:36: SyntaxWarning: invalid escape sequence '\.'
        match= re.search(b'Icarus Verilog version ([0-9]+)\.([0-9]+)', text)