### PR TITLE
configure.ac: Use C++11 with GNU Extensions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ AS_IF( [test "x$with_m32" = xyes],
     [])
 
 CFLAGS="$CTARGETFLAGS $CFLAGS"
-CXXFLAGS="$CTARGETFLAGS $CXXFLAGS -std=c++11"
+CXXFLAGS="$CTARGETFLAGS $CXXFLAGS -std=gnu++11"
 LDFLAGS="$CTARGETFLAGS $LDFLAGS"
 
 # Check that we are using either the GNU compilers or the Sun compilers


### PR DESCRIPTION
It seems the project actually relies on GNU Extensions rather than the C++11 standard alone.
Allows the project to build with GCC 5.5 which has [full C++11 support](https://gcc.gnu.org/projects/cxx-status.html#cxx11).