### PR TITLE
Revive Action test.yml.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,23 @@ on:
       - master
   # All pull_requests trigger a retest.
   pull_request:
+  workflow_dispatch:
 
 jobs:
 
   mac:
     strategy:
       fail-fast: false
-    runs-on: macos-latest
+    runs-on: macos-12
     name: '🍏 macOS'
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
         brew install bison
-        pip3 install docopt
+        pip3 install --break-system-packages docopt
 
     - name: Build, check and install
       run: |
@@ -48,7 +49,7 @@ jobs:
     name: '🐧 Ubuntu ${{ matrix.os }}'
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -89,7 +90,7 @@ jobs:
     - run: git config --global core.autocrlf input
       shell: bash
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: msys2/setup-msys2@v2
       with:
@@ -102,7 +103,7 @@ jobs:
           python-pip
           mingw-w64-${{ matrix.arch }}-toolchain
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '>=3.5'
 
@@ -118,7 +119,7 @@ jobs:
       run: |
         ./.github/test.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.msystem }}-${{ matrix.arch }}
         path: msys2/*.zst

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cscope.*
 
 # Object files and libraries
 *.[oa]
+*.so
 
 gmon*.out
 gmon*.txt


### PR DESCRIPTION
This fixes problems found when building a Mac version of libvvp.so for testing.  A successful build can be seen attached to the source branch.

The change of runner is peculiar: it seems that  github has started using ARM runners for "macos-latest" and the Homebrew build of bison seems broken.  Evidence [here](https://github.com/gatk555/iverilog/actions/runs/9495787460/job/26168769019) until I purge the old logs.  Look at top and bottom of the "Build, check and install" section.

Description:
Fix test.yml for Mac by fixing docopt and using Macos-12 runner.
Update the versions of called Actions to prevent warnings and add "workflow_dispatch" to allow testing.
Unrelated: add "*.so" to .gitignore to hide built libvvp.so.