### PR TITLE
Fix vector assignment with undefined delay

### DIFF
--- a/ivtest/ivltests/vardly_undefined_vec.v
+++ b/ivtest/ivltests/vardly_undefined_vec.v
@@ -1,0 +1,54 @@
+module test;
+  // Test that intra-assignment delay values of 'z and 'x get treated as a zero
+  // delay. Check this for different types of assignments. The assignment should
+  // not be skipped.
+
+  reg failed = 1'b0;
+
+  `define check(expr, val) \
+    if (expr !== val) begin \
+      $display("FAILED(%0d): `%s`, expected %0x, got %0x", `__LINE__, `"expr`", val, expr); \
+      failed = 1'b1; \
+    end
+
+
+  integer delay_x = 32'hx;
+  wire [31:0] delay_z;
+
+  reg [31:0] x;
+  reg [31:0] a[0:1];
+  integer i = 0, j = 0;
+
+  `define test(var) \
+    // Non-blocking \
+    var = 0; \
+    var <= #delay_x 1; \
+    #1 `check(var, 1) \
+    var = 0; \
+    var <= #delay_z 1; \
+    #1 `check(var, 1) \
+    // blocking \
+    var = 0; \
+    var = #delay_x 1; \
+    `check(var, 1) \
+    var = 0; \
+    var = #delay_z 1; \
+    `check(var, 1)
+
+  initial begin
+    `test(x)
+    `test(x[0])
+    `test(x[i])
+    `test(a[0])
+    `test(a[0][0])
+    `test(a[0][j])
+    `test(a[i])
+    `test(a[i][0])
+    `test(a[i][j])
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -266,6 +266,7 @@ vams_abs2			vvp_tests/vams_abs2.json
 vams_abs2-vlog95		vvp_tests/vams_abs2-vlog95.json
 vams_abs3			vvp_tests/vams_abs3.json
 vams_abs3-vlog95		vvp_tests/vams_abs3-vlog95.json
+vardly_undefined_vec		vvp_tests/vardly_undefined_vec.json
 va_math				vvp_tests/va_math.json
 warn_opt_sys_tf			vvp_tests/warn_opt_sys_tf.json
 wreal				vvp_tests/wreal.json

--- a/ivtest/vvp_tests/vardly_undefined_vec.json
+++ b/ivtest/vvp_tests/vardly_undefined_vec.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "normal",
+    "source"        : "vardly_undefined_vec.v"
+}

--- a/tgt-vvp/vvp_process.c
+++ b/tgt-vvp/vvp_process.c
@@ -317,14 +317,14 @@ static void assign_to_lvector(ivl_lval_t lval,
 		    // instruction to handle this case.
 		  int offset_index = allocate_word();
 		  int delay_index = allocate_word();
-		  fprintf(vvp_out, "    %%ix/load %d, %lu, 0;\n", offset_index, part_off);
 		  if (dexp) {
 			draw_eval_expr_into_integer(dexp,delay_index);
 		  } else {
 			fprintf(vvp_out, "    %%ix/load %d, %lu, %lu;\n",
 				delay_index, low_d, hig_d);
-			fprintf(vvp_out, "    %%flag_set/imm 4, 0;\n");
 		  }
+		  fprintf(vvp_out, "    %%ix/load %d, %lu, 0;\n", offset_index, part_off);
+		  fprintf(vvp_out, "    %%flag_set/imm 4, 0;\n");
 		  fprintf(vvp_out, "    %s/vec4/off/d v%p_%lu, %d, %d;\n",
 			  assign_op, sig, use_word, offset_index, delay_index);
 		  clr_word(offset_index);


### PR DESCRIPTION
Assignments with an undefined delay should be treated like assignments with
zero delay. For the most part this is implemented correctly, except for
assignments to a part of a vector where the offset inside the vector is an
immediate value. E.g.
```SystemVerilog
reg [1:0] x;
integer d = 'x;
...
x[0] <= #d 1'b1
```

Here when loading the delay into the index register flag 4 is updated, but
never cleared afterwards. As a result, if the delay is undefined, the vector
assignment will be skipped. Fix this by making sure flag 4 is always
cleared before the vector assignment instruction.