### PR TITLE
Use `-undefined dynamic_lookup` for linking loadable modules on MacOS

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -123,11 +123,11 @@ case "${host}" in
         ;;
 
      *-*-darwin1.[0123])
-        shared="-bundle -undefined suppress"
+        shared="-bundle -undefined dynamic_lookup"
         ;;
 
      *-*-darwin*)
-        shared="-bundle -undefined suppress -flat_namespace"
+        shared="-bundle -undefined dynamic_lookup -flat_namespace"
         ;;
 
      *-*-solaris*)


### PR DESCRIPTION
Newer version of the linker on MacOS provide a deprecation warning when using the `-undefined` flag with the `suppress` value. This is cause CI to fail to do logs not matching when building VPI modules.

Switch to using the `dynamic_lookup` value for the flag instead, which resolves the warning and is the behavior we want when loading the module.