### PR TITLE
tgt-vvp: Remove implicit casts between vector and real

### DIFF
--- a/tgt-vvp/eval_real.c
+++ b/tgt-vvp/eval_real.c
@@ -552,18 +552,10 @@ void draw_eval_real(ivl_expr_t expr)
 	    break;
 
 	  default:
-	    if (ivl_expr_value(expr) == IVL_VT_VECTOR) {
-		  draw_eval_vec4(expr);
-		  const char*sign_flag = ivl_expr_signed(expr)? "/s" : "";
-		  fprintf(vvp_out, "    %%cvt/rv%s;\n", sign_flag);
-
-	    } else {
-		  fprintf(stderr, "vvp.tgt error: XXXX Evaluate real expression (%d)\n",
+		fprintf(stderr, "vvp.tgt error: XXXX Evaluate real expression (%d)\n",
 			  ivl_expr_type(expr));
-		  fprintf(vvp_out, " ; XXXX Evaluate real expression (%d)\n",
+		fprintf(vvp_out, " ; XXXX Evaluate real expression (%d)\n",
 			  ivl_expr_type(expr));
-		  return;
-	    }
 	    break;
       }
 

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -1356,6 +1356,9 @@ void draw_eval_vec4(ivl_expr_t expr)
 		    ivl_expr_type(expr));
       }
 
+      assert(ivl_expr_value(expr) == IVL_VT_BOOL ||
+	     ivl_expr_value(expr) == IVL_VT_VECTOR);
+
       switch (ivl_expr_type(expr)) {
 	  case IVL_EX_BINARY:
 	    draw_binary_vec4(expr);

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -565,28 +565,9 @@ static int show_stmt_assign_vector(ivl_statement_t net)
 	    get_vec_from_lval(net, slices);
       }
 
-	/* Handle the special case that the expression is a real
-	   value. Evaluate the real expression, then convert the
-	   result to a vector. Then store that vector into the
-	   l-value. */
-      if (ivl_expr_value(rval) == IVL_VT_REAL) {
-            draw_eval_real(rval);
-	      /* This is the accumulated with of the l-value of the
-		 assignment. */
-	    unsigned wid = ivl_stmt_lwidth(net);
-
-	      /* Convert a calculated real value to a vec4 value of
-		 the given width. We need to include the width of the
-		 result because real values to not have any inherit
-		 width. The real value will be popped, and a vec4
-		 value pushed. */
-	    fprintf(vvp_out, "    %%cvt/vr %u;\n", wid);
-
-      } else {
-	    unsigned wid = ivl_stmt_lwidth(net);
-	    draw_eval_vec4(rval);
-	    resize_vec4_wid(rval, wid);
-      }
+      unsigned wid = ivl_stmt_lwidth(net);
+      draw_eval_vec4(rval);
+      resize_vec4_wid(rval, wid);
 
       switch (ivl_stmt_opcode(net)) {
 	  case 0:

--- a/tgt-vvp/vvp_process.c
+++ b/tgt-vvp/vvp_process.c
@@ -546,27 +546,10 @@ static int show_stmt_assign_nb(ivl_statement_t net)
       { unsigned wid;
 	unsigned lidx;
 	unsigned cur_rbit = 0;
-	  /* Handle the special case that the expression is a real
-	     value. Evaluate the real expression, then convert the
-	     result to a vector. */
-	if (ivl_expr_value(rval) == IVL_VT_REAL) {
-	      draw_eval_real(rval);
-	        /* This is the accumulated with of the l-value of the
-		   assignment. */
-	      wid = ivl_stmt_lwidth(net);
 
-	      fprintf(vvp_out, "    %%cvt/vr %u;\n", wid);
-
-	} else {
-	      wid = ivl_stmt_lwidth(net);
-	      draw_eval_vec4(rval);
-	      if (ivl_expr_width(rval) != wid) {
-		    if (ivl_expr_signed(rval))
-			  fprintf(vvp_out, "    %%pad/s %u;\n", wid);
-		    else
-			  fprintf(vvp_out, "    %%pad/u %u;\n", wid);
-	      }
-	}
+	wid = ivl_stmt_lwidth(net);
+	draw_eval_vec4(rval);
+	resize_vec4_wid(rval, wid);
 
 	  /* Spread the r-value vector over the bits of the l-value. */
 	for (lidx = 0 ;  lidx < ivl_stmt_lvals(net) ;  lidx += 1) {


### PR DESCRIPTION
Remove implicit casts between vector and real in tgt-vvp. These are not required since any implicit cast in the source will be converted to an explicit cast in the elaboration stage.