### PR TITLE
vvp: Fix logic class property initialization

### DIFF
--- a/ivtest/ivltests/sv_class_prop_logic.v
+++ b/ivtest/ivltests/sv_class_prop_logic.v
@@ -1,0 +1,28 @@
+// Check that logic class properties are initialized to 'x.
+
+module test;
+
+   bit failed = 1'b0;
+
+  `define check(val, exp) do \
+    if (val != exp) begin \
+      $display("FAILED(%0d). '%s' expected %d, got %d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  class C;
+    logic [31:0] x;
+  endclass
+
+  C c;
+
+  initial begin
+    c = new;
+    `check(c.x, 32'hxx);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -222,6 +222,7 @@ sv_chained_constructor2		vvp_tests/sv_chained_constructor2.json
 sv_chained_constructor3		vvp_tests/sv_chained_constructor3.json
 sv_chained_constructor4		vvp_tests/sv_chained_constructor4.json
 sv_chained_constructor5		vvp_tests/sv_chained_constructor5.json
+sv_class_prop_logic		vvp_tests/sv_class_prop_logic.json
 sv_const1			vvp_tests/sv_const1.json
 sv_const2			vvp_tests/sv_const2.json
 sv_const3			vvp_tests/sv_const3.json

--- a/ivtest/vvp_tests/sv_class_prop_logic.json
+++ b/ivtest/vvp_tests/sv_class_prop_logic.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_class_prop_logic.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/vvp/class_type.cc
+++ b/vvp/class_type.cc
@@ -175,7 +175,7 @@ class property_logic : public class_property_t {
 
     public:
       void construct(char*buf) const
-      { new (buf+offset_) vvp_vector4_t (0, wid_); }
+      { new (buf+offset_) vvp_vector4_t (wid_); }
 
       void destruct(char*buf) const
       { vvp_vector4_t*tmp = reinterpret_cast<vvp_vector4_t*>(buf+offset_);


### PR DESCRIPTION
Logic type class properties use the wrong constructor resulting in a default value of a vector with 0 width. Switch to the right constructor to fix this.
