### PR TITLE
tgt-vvp: Support nested lvalues for all property types

### DIFF
--- a/ivtest/ivltests/sv_class_prop_nest_darray1.v
+++ b/ivtest/ivltests/sv_class_prop_nest_darray1.v
@@ -1,0 +1,40 @@
+// Check that nested dynamic array typed class properties can be used as
+// lvalues.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  class C;
+    C c;
+    int d[];
+  endclass
+
+  initial begin
+    C c1, c2;
+    int d[];
+
+    c1 = new;
+    c1.c = new;
+    c2 = c1.c;
+
+    d = new[2];
+    d[0] = 10;
+    c1.c.d = d;
+
+    d = c2.d;
+    `check(d[0], 10);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_prop_nest_obj1.v
+++ b/ivtest/ivltests/sv_class_prop_nest_obj1.v
@@ -1,0 +1,38 @@
+// Check that nested object typed class properties can be used as lvalues.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  class C;
+    C c;
+    integer i;
+  endclass
+
+  initial begin
+    C c1, c2, c3;
+
+    c1 = new;
+    c1.c = new;
+    c2 = c1.c;
+
+    c3 = new;
+    c3.i = 10;
+    c1.c.c = c3;
+    c3 = c2.c;
+
+    `check(c3.i, 10);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_prop_nest_real1.v
+++ b/ivtest/ivltests/sv_class_prop_nest_real1.v
@@ -1,0 +1,34 @@
+// Check that nested real typed class properties can be used as lvalues.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(val, exp) do \
+    if (val != exp) begin \
+      $display("FAILED(%0d). '%s' expected %f, got %f", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  class C;
+    C c;
+    real r;
+  endclass
+
+  initial begin
+    C c1, c2;
+
+    c1 = new;
+    c1.c = new;
+    c2 = c1.c;
+
+    c1.c.r = 12.3;
+    `check(c2.r, 12.3);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_prop_nest_str1.v
+++ b/ivtest/ivltests/sv_class_prop_nest_str1.v
@@ -1,0 +1,34 @@
+// Check that nested string typed class properties can be used as lvalues.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(val, exp) do \
+    if (val != exp) begin \
+      $display("FAILED(%0d). '%s' expected %s, got %s", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  class C;
+    C c;
+    string s;
+  endclass
+
+  initial begin
+    C c1, c2;
+
+    c1 = new;
+    c1.c = new;
+    c2 = c1.c;
+
+    c1.c.s = "Hello";
+    `check(c2.s, "Hello");
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_class_prop_nest_vec1.v
+++ b/ivtest/ivltests/sv_class_prop_nest_vec1.v
@@ -1,0 +1,34 @@
+// Check that nested vector typed class properties can be used as lvalues.
+
+module test;
+
+  bit failed = 1'b0;
+
+  `define check(val, exp) do \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  while(0)
+
+  class C;
+    C c;
+    int i;
+  endclass
+
+  initial begin
+    C c1, c2;
+
+    c1 = new;
+    c1.c = new;
+    c2 = c1.c;
+
+    c1.c.i = 10;
+    `check(c2.i, 10);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -225,6 +225,11 @@ sv_chained_constructor5		vvp_tests/sv_chained_constructor5.json
 sv_class_prop_assign_op1	vvp_tests/sv_class_prop_assign_op1.json
 sv_class_prop_assign_op2	vvp_tests/sv_class_prop_assign_op2.json
 sv_class_prop_logic		vvp_tests/sv_class_prop_logic.json
+sv_class_prop_nest_darray1	vvp_tests/sv_class_prop_nest_darray1.json
+sv_class_prop_nest_obj1		vvp_tests/sv_class_prop_nest_obj1.json
+sv_class_prop_nest_real1	vvp_tests/sv_class_prop_nest_str1.json
+sv_class_prop_nest_str1		vvp_tests/sv_class_prop_nest_real1.json
+sv_class_prop_nest_vec1		vvp_tests/sv_class_prop_nest_vec1.json
 sv_const1			vvp_tests/sv_const1.json
 sv_const2			vvp_tests/sv_const2.json
 sv_const3			vvp_tests/sv_const3.json

--- a/ivtest/vvp_tests/sv_class_prop_nest_darray1.json
+++ b/ivtest/vvp_tests/sv_class_prop_nest_darray1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_class_prop_nest_darray1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_class_prop_nest_obj1.json
+++ b/ivtest/vvp_tests/sv_class_prop_nest_obj1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_class_prop_nest_obj1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_class_prop_nest_real1.json
+++ b/ivtest/vvp_tests/sv_class_prop_nest_real1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_class_prop_nest_real1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_class_prop_nest_str1.json
+++ b/ivtest/vvp_tests/sv_class_prop_nest_str1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_class_prop_nest_str1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_class_prop_nest_vec1.json
+++ b/ivtest/vvp_tests/sv_class_prop_nest_vec1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_class_prop_nest_vec1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
Currently nested lvalues are only supported for vector typed properties. Refactor the code to also support other types.
