### PR TITLE
Reject invalid casts to real

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3706,7 +3706,20 @@ NetExpr* PECastType::elaborate_expr(Design*des, NetScope*scope,
 
       NetExpr*tmp = 0;
       if (dynamic_cast<const netreal_t*>(target_type_)) {
-	    return cast_to_real(sub);
+	    switch (sub->expr_type()) {
+		case IVL_VT_REAL:
+		  return sub;
+		case IVL_VT_LOGIC:
+		case IVL_VT_BOOL:
+		  return cast_to_real(sub);
+	        default:
+		  break;
+	    }
+	    cerr << get_fileline() << " error: Expression of type `"
+		 << sub->expr_type() << "` can not be cast to target type `real`."
+		 << endl;
+	    des->errors++;
+	    return nullptr;
       } else if (dynamic_cast<const netstring_t*>(target_type_)) {
 	    if (base_->expr_type() == IVL_VT_STRING)
 		  return sub; // no conversion

--- a/ivtest/ivltests/cast_real_invalid1.v
+++ b/ivtest/ivltests/cast_real_invalid1.v
@@ -1,0 +1,12 @@
+// Check that casting a string to real generates an error.
+
+module test;
+
+  real r;
+  string s;
+
+  initial begin
+    r = real'(s); // Error: Cast from string to real not allowed
+  end
+
+endmodule

--- a/ivtest/ivltests/cast_real_invalid2.v
+++ b/ivtest/ivltests/cast_real_invalid2.v
@@ -1,0 +1,12 @@
+// Check that casting a array to real generates an error.
+
+module test;
+
+  real r;
+  real a[10];
+
+  initial begin
+    r = real'(a); // Error: Cast from array to real not allowed
+  end
+
+endmodule

--- a/ivtest/ivltests/cast_real_invalid3.v
+++ b/ivtest/ivltests/cast_real_invalid3.v
@@ -1,0 +1,12 @@
+// Check that casting a queue to real generates an error.
+
+module test;
+
+  real r;
+  real q[$];
+
+  initial begin
+    r = real'(q); // Error: Cast from queue to real not allowed
+  end
+
+endmodule

--- a/ivtest/ivltests/cast_real_invalid4.v
+++ b/ivtest/ivltests/cast_real_invalid4.v
@@ -1,0 +1,12 @@
+// Check that casting a dynamic array to real generates an error.
+
+module test;
+
+  real r;
+  real d[];
+
+  initial begin
+    r = real'(d); // Error: Cast from dynamic array to real not allowed
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -72,6 +72,10 @@ case3				vvp_tests/case3.json
 casex_synth			vvp_tests/casex_synth.json
 cast_int_ams			vvp_tests/cast_int_ams.json
 cast_int_ams-vlog95		vvp_tests/cast_int_ams-vlog95.json
+cast_real_invalid1		vvp_tests/cast_real_invalid1.json
+cast_real_invalid2		vvp_tests/cast_real_invalid2.json
+cast_real_invalid3		vvp_tests/cast_real_invalid3.json
+cast_real_invalid4		vvp_tests/cast_real_invalid4.json
 comment1			vvp_tests/comment1.json
 constfunc4_ams			vvp_tests/constfunc4_ams.json
 constfunc4_ams-vlog95		vvp_tests/constfunc4_ams-vlog95.json

--- a/ivtest/vvp_tests/cast_real_invalid1.json
+++ b/ivtest/vvp_tests/cast_real_invalid1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "cast_real_invalid1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/cast_real_invalid2.json
+++ b/ivtest/vvp_tests/cast_real_invalid2.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "cast_real_invalid2.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/cast_real_invalid3.json
+++ b/ivtest/vvp_tests/cast_real_invalid3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "cast_real_invalid3.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/cast_real_invalid4.json
+++ b/ivtest/vvp_tests/cast_real_invalid4.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "cast_real_invalid4.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
Only vector types can be cast to real. Report an error when trying to cast
a different type instead of triggering an assert later on.