### PR TITLE
Using C++11 threads instead of pthread

### DIFF
--- a/vpi/vcd_priv2.cc
+++ b/vpi/vcd_priv2.cc
@@ -23,6 +23,7 @@
 # include  <string>
 # include  <pthread.h>
 # include  <cstdlib>
+# include  <cstdint>
 # include  <cstring>
 # include  <cassert>
 


### PR DESCRIPTION
I have ported vvp (and related shared libraries) to MSVC. To do that, I decided to remove the dependency from pthread and use the threading support offered by C++11.

I think it makes sense to have this also in the main repository.