### PR TITLE
Typos in regress-sv.list

### DIFF
--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -71,8 +71,8 @@ always_comb		normal,-g2005-sv	ivltests
 always_comb_fail	CE,-g2005-sv		ivltests
 always_comb_fail3	CE,-g2005-sv		ivltests
 always_comb_fail4	CE,-g2005-sv		ivltests
-always_comb_no_sens	nornal,-g2005-sv	ivltests gold=always_comb_no_sens.gold
-always_comb_rfunc	nornal,-g2005-sv	ivltests
+always_comb_no_sens	normal,-g2005-sv	ivltests gold=always_comb_no_sens.gold
+always_comb_rfunc	normal,-g2005-sv	ivltests
 always_comb_trig	normal,-g2005-sv	ivltests
 always_comb_void_func	normal,-g2005-sv	ivltests
 always_comb_warn	normal,-g2005-sv	ivltests gold=always_comb_warn.gold

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -818,11 +818,11 @@ sv_timeunit_prec_fail1	CE,-g2005-sv,-u,\
   ./ivltests/sv_timeunit_prec_fail1b.v,\
   ./ivltests/sv_timeunit_prec_fail1c.v,\
   ./ivltests/sv_timeunit_prec_fail1d.v,\
-  ./ivltests/sv_timeunit_prec_fail1e.v,		ivltests gold=sv_timeunit_prec_fail1.gold
+  ./ivltests/sv_timeunit_prec_fail1e.v		ivltests gold=sv_timeunit_prec_fail1.gold
 sv_timeunit_prec_fail2	CE,-g2009,-u,\
   ./ivltests/sv_timeunit_prec_fail2a.v,\
   ./ivltests/sv_timeunit_prec_fail2b.v,\
-  ./ivltests/sv_timeunit_prec_fail2c.v,		ivltests gold=sv_timeunit_prec_fail2.gold
+  ./ivltests/sv_timeunit_prec_fail2c.v		ivltests gold=sv_timeunit_prec_fail2.gold
 sv_type_param1		normal,-g2005-sv	ivltests
 sv_type_param2		normal,-g2005-sv	ivltests
 sv_type_param3		normal,-g2005-sv	ivltests


### PR DESCRIPTION
Just some minor typos I stumbled upon in `regress-sv.list`.