### PR TITLE
Fix regression tests to not $error-fail assertions

### DIFF
--- a/ivtest/gold/sv_deferred_assert1.gold
+++ b/ivtest/gold/sv_deferred_assert1.gold
@@ -1,5 +1,4 @@
 ./ivltests/sv_deferred_assert1.v:8: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
-./ivltests/sv_deferred_assert1.v:9: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assert1.v:10: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assert1.v:11: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assert1.v:12: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.

--- a/ivtest/gold/sv_deferred_assert2.gold
+++ b/ivtest/gold/sv_deferred_assert2.gold
@@ -1,5 +1,4 @@
 ./ivltests/sv_deferred_assert2.v:8: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
-./ivltests/sv_deferred_assert2.v:9: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assert2.v:10: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assert2.v:11: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assert2.v:12: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.

--- a/ivtest/gold/sv_deferred_assume1.gold
+++ b/ivtest/gold/sv_deferred_assume1.gold
@@ -1,5 +1,4 @@
 ./ivltests/sv_deferred_assume1.v:8: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
-./ivltests/sv_deferred_assume1.v:9: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assume1.v:10: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assume1.v:11: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assume1.v:12: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.

--- a/ivtest/gold/sv_deferred_assume2.gold
+++ b/ivtest/gold/sv_deferred_assume2.gold
@@ -1,5 +1,4 @@
 ./ivltests/sv_deferred_assume2.v:8: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
-./ivltests/sv_deferred_assume2.v:9: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assume2.v:10: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assume2.v:11: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.
 ./ivltests/sv_deferred_assume2.v:12: sorry: Deferred assertions are not supported. Try -gno-assertions or -gsupported-assertions to turn this message off.

--- a/ivtest/gold/sv_immediate_assert-vlog95.gold
+++ b/ivtest/gold/sv_immediate_assert-vlog95.gold
@@ -1,11 +1,8 @@
-ERROR: vlog95.v:24: 
-       Time: 0  Scope: test
 Check 4 : this should be displayed
 Check 5 : this should be displayed
 ERROR: vlog95.v:32: 
        Time: 0  Scope: test
 Check 7 : this should be displayed
 Check 8 : this should be displayed
-ERROR: vlog95.v:38: Check 9 : this should be displayed
-       Time: 0  Scope: test
+Check 9 : this should be displayed
 Check 10 : this should be displayed

--- a/ivtest/gold/sv_immediate_assert.gold
+++ b/ivtest/gold/sv_immediate_assert.gold
@@ -1,11 +1,8 @@
-ERROR: ./ivltests/sv_immediate_assert.v:7: 
-       Time: 0  Scope: test
 Check 4 : this should be displayed
 Check 5 : this should be displayed
 ERROR: ./ivltests/sv_immediate_assert.v:11: 
        Time: 0  Scope: test
 Check 7 : this should be displayed
 Check 8 : this should be displayed
-ERROR: ./ivltests/sv_immediate_assert.v:19: Check 9 : this should be displayed
-       Time: 0  Scope: test
+Check 9 : this should be displayed
 Check 10 : this should be displayed

--- a/ivtest/gold/sv_immediate_assume-vlog95.gold
+++ b/ivtest/gold/sv_immediate_assume-vlog95.gold
@@ -1,11 +1,8 @@
-ERROR: vlog95.v:24: 
-       Time: 0  Scope: test
 Check 4 : this should be displayed
 Check 5 : this should be displayed
 ERROR: vlog95.v:32: 
        Time: 0  Scope: test
 Check 7 : this should be displayed
 Check 8 : this should be displayed
-ERROR: vlog95.v:38: Check 9 : this should be displayed
-       Time: 0  Scope: test
+Check 9 : this should be displayed
 Check 10 : this should be displayed

--- a/ivtest/gold/sv_immediate_assume.gold
+++ b/ivtest/gold/sv_immediate_assume.gold
@@ -1,11 +1,8 @@
-ERROR: ./ivltests/sv_immediate_assume.v:7: 
-       Time: 0  Scope: test
 Check 4 : this should be displayed
 Check 5 : this should be displayed
 ERROR: ./ivltests/sv_immediate_assume.v:11: 
        Time: 0  Scope: test
 Check 7 : this should be displayed
 Check 8 : this should be displayed
-ERROR: ./ivltests/sv_immediate_assume.v:19: Check 9 : this should be displayed
-       Time: 0  Scope: test
+Check 9 : this should be displayed
 Check 10 : this should be displayed

--- a/ivtest/ivltests/sv_deferred_assert1.v
+++ b/ivtest/ivltests/sv_deferred_assert1.v
@@ -6,7 +6,7 @@ integer i = 1;
 
 initial begin
   assert #0 (i == 1);
-  assert #0 (i == 0);
+  // fail: assert #0 (i == 0);
   assert #0 (i == 1) else $display("Check 3 : this shouldn't be displayed");
   assert #0 (i == 0) else $display("Check 4 : this should be displayed");
   assert #0 (i == 1) $display("Check 5 : this should be displayed");

--- a/ivtest/ivltests/sv_deferred_assert2.v
+++ b/ivtest/ivltests/sv_deferred_assert2.v
@@ -6,7 +6,7 @@ integer i = 1;
 
 initial begin
   assert final (i == 1);
-  assert final (i == 0);
+  // Fail: assert final (i == 0);
   assert final (i == 1) else $display("Check 3 : this shouldn't be displayed");
   assert final (i == 0) else $display("Check 4 : this should be displayed");
   assert final (i == 1) $display("Check 5 : this should be displayed");

--- a/ivtest/ivltests/sv_deferred_assume1.v
+++ b/ivtest/ivltests/sv_deferred_assume1.v
@@ -6,7 +6,7 @@ integer i = 1;
 
 initial begin
   assume #0 (i == 1);
-  assume #0 (i == 0);
+  // Fail: assume #0 (i == 0);
   assume #0 (i == 1) else $display("Check 3 : this shouldn't be displayed");
   assume #0 (i == 0) else $display("Check 4 : this should be displayed");
   assume #0 (i == 1) $display("Check 5 : this should be displayed");

--- a/ivtest/ivltests/sv_deferred_assume2.v
+++ b/ivtest/ivltests/sv_deferred_assume2.v
@@ -6,7 +6,7 @@ integer i = 1;
 
 initial begin
   assume final (i == 1);
-  assume final (i == 0);
+  // Fail: assume final (i == 0);
   assume final (i == 1) else $display("Check 3 : this shouldn't be displayed");
   assume final (i == 0) else $display("Check 4 : this should be displayed");
   assume final (i == 1) $display("Check 5 : this should be displayed");

--- a/ivtest/ivltests/sv_immediate_assert.v
+++ b/ivtest/ivltests/sv_immediate_assert.v
@@ -4,7 +4,7 @@ integer i = 1;
 
 initial begin
   assert(i == 1);
-  assert(i == 0);
+  // Fail: assert(i == 0);
   assert(i == 1) else $display("Check 3 : this shouldn't be displayed");
   assert(i == 0) else $display("Check 4 : this should be displayed");
   assert(i == 1) $display("Check 5 : this should be displayed");
@@ -15,8 +15,8 @@ initial begin
     else $display("Check 8 : this should be displayed");
 
   a_i_is_non_0 : assert(i == 0)
-    $display("Check 9 : this shouldn't be displayed");
-    else $error("Check 9 : this should be displayed");
+    $error("Check 9 : this shouldn't be displayed");
+    else $display("Check 9 : this should be displayed");
 
   a_i_is_1 : assert(i == 1)
     $display("Check 10 : this should be displayed");

--- a/ivtest/ivltests/sv_immediate_assume.v
+++ b/ivtest/ivltests/sv_immediate_assume.v
@@ -4,7 +4,7 @@ integer i = 1;
 
 initial begin
   assume(i == 1);
-  assume(i == 0);
+  // Fail: assume(i == 0);
   assume(i == 1) else $display("Check 3 : this shouldn't be displayed");
   assume(i == 0) else $display("Check 4 : this should be displayed");
   assume(i == 1) $display("Check 5 : this should be displayed");
@@ -15,8 +15,8 @@ initial begin
     else $display("Check 8 : this should be displayed");
 
   a_i_is_non_0 : assume(i == 0)
-    $display("Check 9 : this shouldn't be displayed");
-    else $error("Check 9 : this should be displayed");
+    $error("Check 9 : this shouldn't be displayed");
+    else $display("Check 9 : this should be displayed");
 
   a_i_is_1 : assume(i == 1)
     $display("Check 10 : this should be displayed");


### PR DESCRIPTION
This fixes several `assert`/`assume` tests to not $error-fail, as this causes other simulators to fail https://github.com/chipsalliance/sv-tests

If you prefer to do this differently, of feel free of course.  Alternatively let me know if prefer the tests stay as-is and I'll get them blacklisted on sv-tests.

Thanks