### PR TITLE
Update pr1008.v test to $finish

### DIFF
--- a/ivtest/ivltests/pr1008.v
+++ b/ivtest/ivltests/pr1008.v
@@ -10,13 +10,17 @@ reg a;
 reg b;
 
 initial begin
-   $monitor("b = %b", b);
+    $monitor("b = %b", b);
     #1;
     a = 1;
     #2;
     a = 0;
     #2;
     a = 1;
+`ifdef VERILATOR
+    #3;
+    $finish;  // Always @* in Verilator isn't input-sensitive, loops forever
+`endif
 end
 
 /* This generated the error:


### PR DESCRIPTION
This updates pr1008.v test to add a `$finish`.

This is because this test is part of the sv-test suite, and without it, as written, it causes Verilator to run this test forever, because Verilator schedules this assignment every cycle, instead of in an IEEE-compliant event-sensitive way.   I realize that's an IEEE-compliance bug with Verilator, but not something Verilator plans on changing due to performance concerns in other cases.

I thought it's worth trying this pull to avoid consuming sv-test's CPU time spinning until a timeout every night.

As far as I can tell this is the only remaining hang in Verilator running the ivtest suite (the final other remaining one was a bug fixed today).

I don't think this changes the intent of the test as was written, but I completely understand if you want to reject this ;)
