### PR TITLE
Escaped Identifiers should conform to IEEE 1800

### DIFF
--- a/lexor.lex
+++ b/lexor.lex
@@ -431,10 +431,17 @@ TU [munpf]
   }
 
 
-\\[^ \t\b\f\r\n]+         {
+a\\[^ \t\b\f\r\n]+[ \t\b\f\r\n] {
       assert(yylloc.lexical_pos != UINT_MAX);
       yylloc.lexical_pos += 1;
-      yylval.text = strdupnew(yytext+1);
+      // Extract identifier name from escaped identifier according to IEEE Std 1800-2023
+      // Format: \ {any_printable_ASCII_character_except_white_space} white_space
+      // The identifier name excludes both the leading \ and trailing whitespace
+      size_t len = strlen(yytext);
+      char* escaped_name = new char[len - 1];  // len-2 chars + null terminator
+      strncpy(escaped_name, yytext + 1, len - 2);  // Skip leading \ and trailing whitespace
+      escaped_name[len - 2] = '\0';
+      yylval.text = escaped_name;
       if (gn_system_verilog()) {
 	    if (PPackage*pkg = pform_test_package_identifier(yylval.text)) {
 		  delete[]yylval.text;


### PR DESCRIPTION
- update identifier extraction to conform to IEEE Verilog/SV Standard for proper handling of leading backslashes and trailing whitespace
This tightly follows the IEEE 1800 Standard.
for the dff.sv:
```
// This file is public domain, it can be freely copied without restrictions.
// SPDX-License-Identifier: CC0-1.0

`timescale 1us/1us

module dff (
  input logic clk, d,
  input logic _reset_n,  // starts with underscore hence needs __getitem__ access
  output logic q,
  output logic \!special!\  // escaped identifier hence needs __getitem__ access
);

always @(posedge clk) begin
  if (!_reset_n) begin
    q <= 1'b0;
    \!special!\ <= 1'b0;
  end else begin
    q <= d;
    \!special!\ <= ~d;  // invert d for the special signal
  end
end
endmodule
```
we get:
```python
-> import pdb; pdb.set_trace()
(Pdb) dir(dut)
['!special!\\', '__abstractmethods__', '__bool__', '__class__', '__class_getitem__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__firstlineno__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__getitem__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__module__', '__ne__', '__new__', '__orig_bases__', '__parameters__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slots__', '__static_attributes__', '__str__', '__subclasshook__', '__weakref__', '_abc_impl', '_child_path', '_def_file', '_def_name', '_discover_all', '_discovered', '_get', '_get_handle_by_key', '_handle', '_id', '_items', '_keys', '_log', '_name', '_path', '_reset_n', '_sub_handle_key', '_sub_handles', '_type', '_values', 'clk', 'd', 'q']
```