### PR TITLE
Add CPPFLAGS & LDFLAGS for building version.exe & draw_tt build targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -244,7 +244,7 @@ iverilog-vpi: $(srcdir)/iverilog-vpi.sh Makefile
 endif
 
 version.exe: $(srcdir)/version.c $(srcdir)/version_base.h version_tag.h
-	$(BUILDCC) $(CFLAGS) -o version.exe -I. -I$(srcdir) $(srcdir)/version.c
+	$(BUILDCC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o version.exe -I. -I$(srcdir) $(srcdir)/version.c
 
 %.o: %.cc config.h
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -175,7 +175,7 @@ endif
 	mv $*.d dep/$*.d
 
 tables.cc: $(srcdir)/draw_tt.c
-	$(BUILDCC) $(CFLAGS) -o draw_tt$(BUILDEXT) $(srcdir)/draw_tt.c
+	$(BUILDCC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o draw_tt$(BUILDEXT) $(srcdir)/draw_tt.c
 	./draw_tt$(BUILDEXT) > tables.cc
 	rm draw_tt$(BUILDEXT)
 


### PR DESCRIPTION
Those are needed to be able to add security hardening buold flags by
downstream package maintainers
