### PR TITLE
vvp: create libvvp as versioned library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
   mac:
     strategy:
       fail-fast: false
-    # matrix:
-    #   libvvp: [false, true]
-    #   suffix: [false, true]
+      matrix:
+        libvvp: [true]
+        suffix: [true]
     runs-on: macos-15-intel
     name: 🍏 macOS${{ matrix.libvvp && ' +libvvp' || '' }}${{ matrix.suffix && ' +suffix' || '' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,11 @@ jobs:
   mac:
     strategy:
       fail-fast: false
+    # matrix:
+    #   libvvp: [false, true]
+    #   suffix: [false, true]
     runs-on: macos-15-intel
-    name: '🍏 macOS'
+    name: 🍏 macOS${{ matrix.libvvp && ' +libvvp' || '' }}${{ matrix.suffix && ' +suffix' || '' }}
     steps:
 
     - uses: actions/checkout@v6
@@ -27,8 +30,15 @@ jobs:
     - name: Build, check and install
       run: |
         export PATH="/usr/local/opt/bison/bin:$PATH"
+        CONFIG_OPTS="--enable-libveriuser"
+        if [ "${{ matrix.libvvp }}" = "true" ]; then
+            CONFIG_OPTS="$CONFIG_OPTS --enable-libvvp"
+        fi
+        if [ "${{ matrix.suffix }}" = "true" ]; then
+            CONFIG_OPTS="$CONFIG_OPTS --enable-suffix"
+        fi
         autoconf
-        ./configure --enable-libveriuser
+        ./configure $CONFIG_OPTS
         make -j$(nproc) check
         sudo make install
 
@@ -41,12 +51,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
-          '22.04',
-          '24.04'
-        ]
+        os: ['22.04', '24.04']
+        # libvvp: [false, true]
+        # suffix: [false, true]
     runs-on: ubuntu-${{ matrix.os }}
-    name: '🐧 Ubuntu ${{ matrix.os }}'
+    name: 🐧 Ubuntu ${{ matrix.os }}${{ matrix.libvvp && ' +libvvp' || '' }}${{ matrix.suffix && ' +suffix' || '' }}
     steps:
 
     - uses: actions/checkout@v6
@@ -62,8 +71,15 @@ jobs:
 
     - name: Build, check and install
       run: |
+        CONFIG_OPTS="--enable-libveriuser"
+        if [ "${{ matrix.libvvp }}" = "true" ]; then
+            CONFIG_OPTS="$CONFIG_OPTS --enable-libvvp"
+        fi
+        if [ "${{ matrix.suffix }}" = "true" ]; then
+            CONFIG_OPTS="$CONFIG_OPTS --enable-suffix"
+        fi
         autoconf
-        ./configure --enable-libveriuser
+        ./configure $CONFIG_OPTS
         make -j$(nproc) check
         sudo make install
 
@@ -82,11 +98,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        msystem: [MINGW64, UCRT64, CLANG64]
+        # libvvp: [false, true]
+        # suffix: [false, true]
         include:
           - { msystem: MINGW64, env: x86_64 }
           - { msystem: UCRT64,  env: ucrt-x86_64 }
           - { msystem: CLANG64, env: clang-x86_64 }
-    name: 🟪 ${{ matrix.msystem}}
+    name: 🟪 ${{ matrix.msystem }}${{ matrix.libvvp && ' +libvvp' || '' }}${{ matrix.suffix && ' +suffix' || '' }}
     defaults:
       run:
         shell: msys2 {0}
@@ -116,9 +135,17 @@ jobs:
     - name: Build and check
       run: |
         cd msys2
+        CONFIG_OPTS=""
         if [ ${{ matrix.msystem }} != "CLANG64" ] ; then
-            export IVL_CONFIG_OPTIONS="--enable-libveriuser"
+            CONFIG_OPTS="$CONFIG_OPTS --enable-libveriuser"
         fi
+        if [ "${{ matrix.libvvp }}" = "true" ] ; then
+            CONFIG_OPTS="$CONFIG_OPTS --enable-libvvp"
+        fi
+        if [ "${{ matrix.suffix }}" = "true" ]; then
+            CONFIG_OPTS="$CONFIG_OPTS --enable-suffix"
+        fi
+        export IVL_CONFIG_OPTIONS="$CONFIG_OPTS"
         makepkg-mingw --noconfirm --noprogressbar -sCLf
 
     - name: Install
@@ -130,5 +157,5 @@ jobs:
 
     - uses: actions/upload-artifact@v7
       with:
-        name: ${{ matrix.msystem }}
+        name: 🟪 ${{ matrix.msystem }}${{ matrix.libvvp && ' +libvvp' || '' }}
         path: msys2/*.zst

--- a/Makefile.in
+++ b/Makefile.in
@@ -145,20 +145,8 @@ endif
 check: all
 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) $@ && ) true
 	test -r check.conf || cp $(srcdir)/check.conf .
-	driver/iverilog -B. -BMvpi -BPivlpp -tcheck -ocheck.vvp $(srcdir)/examples/hello.vl
-ifeq (@WIN32@,yes)
-ifeq (@install_suffix@,)
-	vvp/vvp -M- -M./vpi ./check.vvp | grep 'Hello, World'
-else
-	# On Windows if we have a suffix we must run the vvp part of
-	# the test with a suffix since it was built/linked that way.
-	ln vvp/vvp.exe vvp/vvp$(suffix).exe
-	vvp/vvp$(suffix) -M- -M./vpi ./check.vvp | grep 'Hello, World'
-	rm vvp/vvp$(suffix).exe
-endif
-else
-	$(ENV_VVP) vvp/vvp -M- -M./vpi ./check.vvp | grep 'Hello, World'
-endif
+	driver/iverilog@EXEEXT@ -B. -BMvpi -BPivlpp -tcheck -ocheck.vvp $(srcdir)/examples/hello.vl
+	$(ENV_VVP) vvp/vvp$(suffix)@EXEEXT@ -M- -M./vpi ./check.vvp | grep 'Hello, World'
 
 check-installed check-installed-vpi check-installed-vvp check-installed-vvp-py:
 	$(MAKE) -C ivtest $@

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,9 @@ m4_define([VER_MAJOR], [14])
 m4_define([VER_MINOR], [0])
 m4_define([VER_EXTRA], [devel])
 
+dnl define libvvp ABI version
+m4_define([LIBVVP_SOVERSION], [1])
+
 AC_INIT([iverilog], [VER_MAJOR.VER_MINOR (VER_EXTRA)])
 AC_SUBST([VERSION_MAJOR], [VER_MAJOR])
 AC_SUBST([VERSION_MINOR], [VER_MINOR])
@@ -14,6 +17,11 @@ AC_SUBST([VERSION_EXTRA], [" (VER_EXTRA)"])
 AC_SUBST([VERSION], ["VER_MAJOR.VER_MINOR (VER_EXTRA)"])
 # used in res.rc
 AC_SUBST([PRODUCTVERSION], ["VER_MAJOR,VER_MINOR,0,0"])
+
+# setup libvvp soversion, which depends on abi not package version
+AC_SUBST([LIBVVP_SOVERSION], [LIBVVP_SOVERSION])
+# setup libvvp version
+AC_SUBST([LIBVVP_VERSION], [LIBVVP_SOVERSION.VER_MAJOR.VER_MINOR])
 
 AC_CONFIG_SRCDIR([netlist.h])
 # Need a stamp file like the other header files
@@ -209,7 +217,14 @@ AC_FUNC_FSEEKO
 # Build VVP as a library and stub
 AC_ARG_ENABLE([libvvp],
     [AS_HELP_STRING([--enable-libvvp], [build VVP as a shared library])],
-    [AC_SUBST(LIBVVP, yes)],[])
+    [enable_libvvp=yes],
+    [enable_libvvp=no])
+
+AC_SUBST([LIBVVP], [$enable_libvvp])
+
+AS_IF([test "x$enable_libvvp" = "xyes"],
+    [AC_MSG_NOTICE([Building with libvvp support enabled])],
+    [AC_MSG_NOTICE([Building with libvvp support disabled])])
 
 AC_ARG_ENABLE([libveriuser],
     [AS_HELP_STRING([--enable-libveriuser], [include support for PLI 1 (deprecated)])],
@@ -434,6 +449,7 @@ AC_CONFIG_FILES([
     vhdlpp/Makefile
     vpi/Makefile
     vvp/Makefile
+    vvp/libvvp.pc
     vvp/vvp.man
 ])
 AC_OUTPUT

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -61,7 +61,7 @@ CPPFLAGS = $(INCLUDE_PATH) @CPPFLAGS@ @DEFS@ -DICARUS_VPI_CONST=const
 CFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CC@ @CFLAGS@
 CXXFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CXX@ @CXXFLAGS@
 LDFLAGS = @rdynamic@ @LDFLAGS@
-LIBS = @LIBS@ @EXTRALIBS@
+LIBS = @LIBS@ @EXTRALIBS@ @DLLIB@
 
 ifeq (@WIN32@,yes)
 SLDIR=$(bindir)
@@ -70,8 +70,6 @@ else
 SLDIR=$(libdir)
 SLEXT=so
 endif
-
-dllib=@DLLIB@
 
 MDIR1 = -DMODULE_DIR1='"$(libdir)/ivl$(suffix)"'
 
@@ -153,10 +151,10 @@ ifeq (@WIN32@,yes)
 # cocotb to build VPI modules without using our vpi_user.h and libvpi.a.
 # The .def file controls what is exported.
 vvp@EXEEXT@: main.o $O $(srcdir)/vvp.def
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ $(LDFLAGS) $(srcdir)/vvp.def main.o $O $(dllib) $(LIBS)
+	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ $(LDFLAGS) $(srcdir)/vvp.def main.o $O $(LIBS)
 else
 vvp@EXEEXT@: $O main.o
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o $O $(LIBS) $(dllib)
+	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o $O $(LIBS)
 endif
 endif
 

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -73,22 +73,24 @@ endif
 
 MDIR1 = -DMODULE_DIR1='"$(libdir)/ivl$(suffix)"'
 
-VPI = vpi_modules.o vpi_bit.o vpi_callback.o vpi_cobject.o vpi_const.o vpi_darray.o \
-      vpi_event.o vpi_iter.o vpi_mcd.o \
-      vpi_priv.o vpi_scope.o vpi_real.o vpi_signal.o vpi_string.o vpi_tasks.o vpi_time.o \
-      vpi_vthr_vector.o vpip_bin.o vpip_hex.o vpip_oct.o \
-      vpip_to_dec.o vpip_format.o vvp_vpi.o
+CORE_OBJ = lib_main.o \
+           parse.o parse_misc.o lexor.o arith.o array_common.o array.o bufif.o compile.o \
+           concat.o dff.o class_type.o enum_type.o extend.o file_line.o latch.o npmos.o part.o \
+           permaheap.o reduce.o resolv.o \
+           sfunc.o stop.o \
+           substitute.o \
+           symbols.o ufunc.o codes.o vthread.o schedule.o \
+           statistics.o tables.o udp.o vvp_island.o vvp_net.o vvp_net_sig.o \
+           vvp_object.o vvp_cobject.o vvp_darray.o event.o logic.o delay.o \
+           words.o island_tran.o
 
-O = lib_main.o \
-    parse.o parse_misc.o lexor.o arith.o array_common.o array.o bufif.o compile.o \
-    concat.o dff.o class_type.o enum_type.o extend.o file_line.o latch.o npmos.o part.o \
-    permaheap.o reduce.o resolv.o \
-    sfunc.o stop.o \
-    substitute.o \
-    symbols.o ufunc.o codes.o vthread.o schedule.o \
-    statistics.o tables.o udp.o vvp_island.o vvp_net.o vvp_net_sig.o \
-    vvp_object.o vvp_cobject.o vvp_darray.o event.o logic.o delay.o \
-    words.o island_tran.o $(VPI)
+VPI_OBJ = vpi_modules.o vpi_bit.o vpi_callback.o vpi_cobject.o vpi_const.o vpi_darray.o \
+          vpi_event.o vpi_iter.o vpi_mcd.o \
+          vpi_priv.o vpi_scope.o vpi_real.o vpi_signal.o vpi_string.o vpi_tasks.o vpi_time.o \
+          vpi_vthr_vector.o vpip_bin.o vpip_hex.o vpip_oct.o \
+          vpip_to_dec.o vpip_format.o vvp_vpi.o
+
+LIB_OBJ = $(CORE_OBJ) $(VPI_OBJ)
 
 all: dep vvp@EXEEXT@ vvp.man
 
@@ -115,7 +117,7 @@ distclean: clean
 	rm -f Makefile config.log
 	rm -f stamp-config-h config.h
 
-cppcheck: $(O:.o=.cc) draw_tt.c
+cppcheck: $(LIB_OBJ:.o=.cc) draw_tt.c
 	cppcheck --enable=all --std=c99 --std=c++11 -f \
 	         --check-level=exhaustive \
 	         --suppressions-list=$(srcdir)/../cppcheck-global.sup \
@@ -143,18 +145,18 @@ CPPFLAGS+= -fpic
 vvp@EXEEXT@: main.o $(srcdir)/vvp.def libvvp$(suffix).$(SLEXT)
 	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o -L. $(LDFLAGS) -lvvp$(suffix) $(LIBS)
 
-libvvp$(suffix).$(SLEXT): $O
-	$(CXX) -shared $(LDFLAGS) -o libvvp$(suffix).$(SLEXT) $O $(LIBS) $(dllib)
+libvvp$(suffix).$(SLEXT): $LIB_OBJ
+	$(CXX) -shared $(LDFLAGS) -o libvvp$(suffix).$(SLEXT) $LIB_OBJ $(LIBS) $(dllib)
 else
 ifeq (@WIN32@,yes)
 # To support cocotb, we export the VPI functions directly. This allows
 # cocotb to build VPI modules without using our vpi_user.h and libvpi.a.
 # The .def file controls what is exported.
-vvp@EXEEXT@: main.o $O $(srcdir)/vvp.def
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ $(LDFLAGS) $(srcdir)/vvp.def main.o $O $(LIBS)
+vvp@EXEEXT@: main.o $LIB_OBJ $(srcdir)/vvp.def
+	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ $(LDFLAGS) $(srcdir)/vvp.def main.o $LIB_OBJ $(LIBS)
 else
-vvp@EXEEXT@: $O main.o
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o $O $(LIBS)
+vvp@EXEEXT@: $LIB_OBJ main.o
+	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o $LIB_OBJ $(LIBS)
 endif
 endif
 
@@ -243,4 +245,4 @@ ifeq (@LIBVVP@,yes)
 	rm -f "$(DESTDIR)$(ivl_includedir)/libvvp.h"
 endif
 
--include $(patsubst %.o, dep/%.d, $O)
+-include $(patsubst %.o, dep/%.d, $LIB_OBJ)

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -23,6 +23,7 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 srcdir = @srcdir@
 datarootdir = @datarootdir@
+abs_builddir = @abs_builddir@
 
 VPATH = $(srcdir)
 
@@ -30,6 +31,8 @@ bindir = @bindir@
 libdir = @libdir@
 man1dir = @mandir@/man1
 docdir = @docdir@
+pkgconfigdir = @libdir@/pkgconfig
+
 # This is actually the directory where we install our own header files.
 # It is a little different from the generic includedir.
 ivl_includedir = @includedir@/iverilog$(suffix)
@@ -58,17 +61,80 @@ INCLUDE_PATH = -I. -I.. -I$(srcdir) -I$(srcdir)/..
 endif
 
 CPPFLAGS = $(INCLUDE_PATH) @CPPFLAGS@ @DEFS@ -DICARUS_VPI_CONST=const
-CFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CC@ @CFLAGS@
-CXXFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CXX@ @CXXFLAGS@
-LDFLAGS = @rdynamic@ @LDFLAGS@
+CFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CC@ @CFLAGS@ @PICFLAG@
+CXXFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CXX@ @CXXFLAGS@ @PICFLAG@
+LDFLAGS = @rdynamic@ @LDFLAGS@ @PICFLAG@
 LIBS = @LIBS@ @EXTRALIBS@ @DLLIB@
 
-ifeq (@WIN32@,yes)
+LIBVVP_VERSION = @LIBVVP_VERSION@
+LIBVVP_SOVERSION = @LIBVVP_SOVERSION@
+LIBBASENAME=vvp$(suffix)
+LDFLAGS_SHARED = @rdynamic@ @shared@ @LDFLAGS@
+
+ifeq (@MINGW32@,yes)
 SLDIR=$(bindir)
 SLEXT=dll
+IMPEXT=dll.a
+LIBPREFIX=lib
+LIBNAME=$(LIBPREFIX)$(LIBBASENAME)
+LIBSONAME=$(LIBNAME).$(SLEXT).$(LIBVVP_SOVERSION)
+LIBREALNAME=$(LIBNAME).$(SLEXT).$(LIBVVP_VERSION)
+LIBLINKNAME=$(LIBNAME).$(SLEXT)
+LIBTARGET=$(LIBNAME)-$(LIBVVP_SOVERSION).$(SLEXT)
+LIBBUILD=$(LIBTARGET)
+LIBLINKFLAGS=-Wl,--out-implib,$(LIBNAME).$(IMPEXT) -Wl,--no-undefined
+LIBPOSTBUILD=@true
+LIBINSTALL=$(LIBTARGET)
+LIBDEVELINSTALL=$(LIBNAME).$(IMPEXT)
+else ifeq (@WIN32@,yes)
+SLDIR=$(bindir)
+SLEXT=dll
+IMPEXT=lib
+LIBPREFIX=
+LIBNAME=$(LIBPREFIX)$(LIBBASENAME)
+LIBSONAME=$(LIBNAME).$(SLEXT).$(LIBVVP_SOVERSION)
+LIBREALNAME=$(LIBNAME).$(SLEXT).$(LIBVVP_VERSION)
+LIBLINKNAME=$(LIBNAME).$(SLEXT)
+LIBTARGET=$(LIBLINKNAME)
+LIBBUILD=$(LIBLINKNAME)
+LIBLINKFLAGS=
+LIBPOSTBUILD=@true
+LIBINSTALL=$(LIBTARGET)
+LIBDEVELINSTALL=
+else ifneq (,$(findstring darwin,@host_os@))
+SLDIR=$(libdir)
+SLEXT=dylib
+LIBPREFIX=lib
+LIBNAME=$(LIBPREFIX)$(LIBBASENAME)
+LIBSONAME=$(LIBNAME).$(LIBVVP_SOVERSION).$(SLEXT)
+LIBREALNAME=$(LIBNAME).$(LIBVVP_VERSION).$(SLEXT)
+LIBLINKNAME=$(LIBNAME).$(SLEXT)
+LIBTARGET=$(LIBREALNAME)
+LIBBUILD=$(LIBTARGET)
+LDFLAGS_SHARED=-dynamiclib
+LIBLINKFLAGS= \
+  -Wl,-install_name,$(libdir)/$(LIBSONAME) \
+  -Wl,-compatibility_version,$(LIBVVP_SOVERSION) \
+  -Wl,-current_version,$(LIBVVP_VERSION)
+LIBPOSTBUILD= \
+  ln -sf $(LIBREALNAME) $(LIBSONAME) && \
+  ln -sf $(LIBSONAME) $(LIBLINKNAME)
+LIBINSTALL=$(LIBTARGET)
+LIBDEVELINSTALL=
 else
 SLDIR=$(libdir)
 SLEXT=so
+LIBPREFIX=lib
+LIBNAME=$(LIBPREFIX)$(LIBBASENAME)
+LIBSONAME=$(LIBNAME).$(SLEXT).$(LIBVVP_SOVERSION)
+LIBREALNAME=$(LIBNAME).$(SLEXT).$(LIBVVP_VERSION)
+LIBLINKNAME=$(LIBNAME).$(SLEXT)
+LIBTARGET=$(LIBREALNAME)
+LIBBUILD=$(LIBLINKNAME)
+LIBLINKFLAGS=-Wl,-soname,$(LIBSONAME)
+LIBPOSTBUILD=ln -sf $(LIBREALNAME) $(LIBSONAME) && ln -sf $(LIBSONAME) $(LIBLINKNAME)
+LIBINSTALL=$(LIBTARGET)
+LIBDEVELINSTALL=
 endif
 
 MDIR1 = -DMODULE_DIR1='"$(libdir)/ivl$(suffix)"'
@@ -91,27 +157,37 @@ VPI_OBJ = vpi_modules.o vpi_bit.o vpi_callback.o vpi_cobject.o vpi_const.o vpi_d
           vpip_to_dec.o vpip_format.o vvp_vpi.o
 
 LIB_OBJ = $(CORE_OBJ) $(VPI_OBJ)
+LIB_CLEAN = $(LIBNAME)*.$(SLEXT)* libvvp.pc
+
+VVP_OBJ = main.o
+VVP_CLEAN = vvp@EXEEXT@
+ifeq (@WIN32@,yes)
+# To support cocotb, we export the VPI functions directly. This allows
+# cocotb to build VPI modules without using our vpi_user.h and libvpi.a.
+# The .def file controls what is exported.
+VVP_OBJ += $(srcdir)/vvp.def
+endif
+ifeq (@LIBVVP@,yes)
+VVP_LDFLAGS = -lvvp$(suffix)
+VVP_DEPS = $(LIBBUILD)
+else
+VVP_OBJ += $(LIB_OBJ)
+endif
+ifneq (@install_suffix@,)
+VVP_POSTBUILD = ln -sf vvp@EXEEXT@ vvp$(suffix)@EXEEXT@
+VVP_CLEAN += vvp$(suffix)@EXEEXT@
+endif
 
 all: dep vvp@EXEEXT@ vvp.man
 
+# ENV_VVP sets LD_LIBRARY_PATH by default to run vvp from the build tree
 check: all
-ifeq (@WIN32@,yes)
-ifeq (@install_suffix@,)
-	./vvp -M../vpi $(srcdir)/examples/hello.vvp | grep 'Hello, World.'
-else
-	# On Windows if we have a suffix we must run the vvp test with
-	# a suffix since it was built/linked that way.
-	ln vvp.exe vvp$(suffix).exe
-	./vvp$(suffix) -M../vpi $(srcdir)/examples/hello.vvp | grep 'Hello, World.'
-	rm -f vvp$(suffix).exe
-endif
-else
-	$(ENV_VVP) ./vvp -M../vpi $(srcdir)/examples/hello.vvp | grep 'Hello, World.'
-endif
+	$(ENV_VVP) ./vvp$(suffix)@EXEEXT@ -M../vpi $(srcdir)/examples/hello.vvp | grep 'Hello, World.'
 
 clean:
-	rm -f *.o *~ parse.cc parse.h lexor.cc tables.cc libvvp$(suffix).$(SLEXT)
-	rm -rf dep vvp@EXEEXT@ parse.output vvp.man vvp.ps vvp.pdf vvp.exp
+	rm -f *.o *~ parse.cc parse.h lexor.cc tables.cc $(LIB_CLEAN)
+	rm -f $(VVP_CLEAN) parse.output vvp.man vvp.ps vvp.pdf vvp.exp
+	rm -rf dep
 
 distclean: clean
 	rm -f Makefile config.log
@@ -136,29 +212,14 @@ dep:
 	mkdir dep
 
 ifeq (@LIBVVP@,yes)
-
-CPPFLAGS+= -fpic
-
-# To avoid setting LD_LIBRARY_PATH when running vvp from the build tree,
-# add option -Wl,-rpath=`pwd` to the CXX command below.
-
-vvp@EXEEXT@: main.o $(srcdir)/vvp.def libvvp$(suffix).$(SLEXT)
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o -L. $(LDFLAGS) -lvvp$(suffix) $(LIBS)
-
-libvvp$(suffix).$(SLEXT): $LIB_OBJ
-	$(CXX) -shared $(LDFLAGS) -o libvvp$(suffix).$(SLEXT) $LIB_OBJ $(LIBS) $(dllib)
-else
-ifeq (@WIN32@,yes)
-# To support cocotb, we export the VPI functions directly. This allows
-# cocotb to build VPI modules without using our vpi_user.h and libvpi.a.
-# The .def file controls what is exported.
-vvp@EXEEXT@: main.o $LIB_OBJ $(srcdir)/vvp.def
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ $(LDFLAGS) $(srcdir)/vvp.def main.o $LIB_OBJ $(LIBS)
-else
-vvp@EXEEXT@: $LIB_OBJ main.o
-	$(CXX) $(LDFLAGS) -o vvp@EXEEXT@ main.o $LIB_OBJ $(LIBS)
+$(LIBBUILD): $(LIB_OBJ)
+	$(CXX) $(LDFLAGS_SHARED) $(LIBLINKFLAGS) -o $(LIBTARGET) $^ $(LIBS)
+	$(LIBPOSTBUILD)
 endif
-endif
+
+vvp@EXEEXT@: $(VVP_OBJ) $(VVP_DEPS)
+	$(CXX) $(LDFLAGS) -o $@ $(VVP_OBJ) -L. $(VVP_LDFLAGS) $(LIBS)
+	$(VVP_POSTBUILD)
 
 %.o: %.cc config.h | dep
 	$(CXX) $(CPPFLAGS) -DIVL_SUFFIX='"$(suffix)"' $(MDIR1) $(MDIR2) $(CXXFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
@@ -211,7 +272,7 @@ stamp-config-h: $(srcdir)/config.h.in ../config.status
 	cd ..; ./config.status --header=vvp/config.h
 config.h: stamp-config-h
 
-install: all installdirs installfiles
+install: all installdirs installfiles installpkgconfig
 
 F = ./vvp@EXEEXT@ $(srcdir)/libvvp.h $(INSTALL_DOC)
 
@@ -224,24 +285,46 @@ installpdf: vvp.pdf installdirs
 installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
 ifeq (@LIBVVP@,yes)
-	$(INSTALL_PROGRAM) ./libvvp$(suffix).$(SLEXT) "$(DESTDIR)$(SLDIR)/libvvp$(suffix).$(SLEXT)"
+	$(INSTALL_PROGRAM) ./$(LIBINSTALL) "$(DESTDIR)$(SLDIR)/$(LIBINSTALL)"
+ifeq (@WIN32@,yes)
+ifneq ($(LIBDEVELINSTALL),)
+	$(INSTALL_PROGRAM) ./$(LIBDEVELINSTALL) "$(DESTDIR)$(libdir)/$(LIBDEVELINSTALL)"
+endif
+else
+	# Install real library
+	ln -sf $(LIBREALNAME) "$(DESTDIR)$(SLDIR)/$(LIBSONAME)"
+	ln -sf $(LIBSONAME) "$(DESTDIR)$(SLDIR)/$(LIBLINKNAME)"
+endif
 	$(INSTALL_DATA) $(srcdir)/libvvp.h "$(DESTDIR)$(ivl_includedir)/libvvp.h"
 endif
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" \
-		"$(DESTDIR)$(includedir)" \
+		"$(DESTDIR)$(ivl_includedir)" \
 		"$(DESTDIR)$(libdir)" \
 		"$(DESTDIR)$(docdir)" \
 		"$(DESTDIR)$(man1dir)"
 
+installpkgconfig:
+	$(INSTALL) -d "$(DESTDIR)$(pkgconfigdir)"
+	$(INSTALL_DATA) libvvp.pc "$(DESTDIR)$(pkgconfigdir)/libvvp$(suffix).pc"
 
 uninstall: $(UNINSTALL32)
 	rm -f "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
 	rm -f "$(DESTDIR)$(man1dir)/vvp$(suffix).1" \
 	      "$(DESTDIR)$(docdir)/vvp$(suffix).pdf"
 ifeq (@LIBVVP@,yes)
-	rm -f "$(DESTDIR)$(SLDIR)/libvvp$(suffix).$(SLEXT)"
+	rm -f "$(DESTDIR)$(SLDIR)/$(LIBINSTALL)"
+ifeq (@WIN32@,yes)
+ifneq ($(LIBDEVELINSTALL),)
+	rm -f "$(DESTDIR)$(libdir)/$(LIBDEVELINSTALL)"
+endif
+else
+	rm -f "$(DESTDIR)$(SLDIR)/$(LIBLINKNAME)"
+	rm -f "$(DESTDIR)$(SLDIR)/$(LIBSONAME)"
+	rm -f "$(DESTDIR)$(SLDIR)/$(LIBREALNAME)"
+endif
+	rm -f "$(DESTDIR)$(pkgconfigdir)/libvvp$(suffix).pc"
 	rm -f "$(DESTDIR)$(ivl_includedir)/libvvp.h"
 endif
 

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -230,6 +230,7 @@ endif
 
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" \
+		"$(DESTDIR)$(includedir)" \
 		"$(DESTDIR)$(libdir)" \
 		"$(DESTDIR)$(docdir)" \
 		"$(DESTDIR)$(man1dir)"

--- a/vvp/libvvp.pc.in
+++ b/vvp/libvvp.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libvvp@install_suffix@
+Version: @VERSION_MAJOR@.@VERSION_MINOR@
+Description: Icarus Verilog VVP runtime library
+Libs: -L${libdir} -lvvp@install_suffix@
+Cflags: -I${includedir}/iverilog@install_suffix@


### PR DESCRIPTION
With these changes, the vvp library can be compiled as a shared library on Unix-like operating systems and on Windows using the MINGW compiler.

The build support for Windows has been tested with the openSUSE MinGW project (see https://build.opensuse.org/project/show/windows:mingw:win64)

Since this library is required by ngspice, a merge request was created at (https://sourceforge.net/p/ngspice/ngspice/merge-requests/49/) to allow the library to be used directly, which simplifies the packaging process. The patch was built and tested on openSUSE Leap with gcc and on the openSUSE MinGW project with a gcc cross-compiler for Windows. 

Fixes #1319 

Depends on #1328,  #1329, #1331, #1339, #1340
