### PR TITLE
Fix parallel build race with dep/ directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -252,7 +252,7 @@ endif
 version.exe: $(srcdir)/version.c $(srcdir)/version_base.h version_tag.h
 	$(BUILDCC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o version.exe -I. -I$(srcdir) $(srcdir)/version.c
 
-%.o: %.cc config.h
+%.o: %.cc config.h | dep
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
 	mv $*.d dep/$*.d
 

--- a/driver/main.c
+++ b/driver/main.c
@@ -69,6 +69,9 @@ const char HELP[] =
 # include  <libiberty.h>
 #endif
 #endif
+#ifdef __APPLE__
+# include  <mach-o/dyld.h>
+#endif
 #include  <fcntl.h>
 
 #ifdef HAVE_GETOPT_H

--- a/vhdlpp/Makefile.in
+++ b/vhdlpp/Makefile.in
@@ -104,11 +104,11 @@ dep:
 vhdlpp@EXEEXT@: $O
 	$(CXX) -o vhdlpp@EXEEXT@ $(LDFLAGS) $O $(LIBS)
 
-%.o: $(srcdir)/../libmisc/%.cc
+%.o: $(srcdir)/../libmisc/%.cc | dep
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
 	mv $*.d dep/$*.d
 
-%.o: %.cc vhdlpp_config.h
+%.o: %.cc vhdlpp_config.h | dep
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
 	mv $*.d dep/$*.d
 

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -159,11 +159,11 @@ vvp@EXEEXT@: $O main.o
 endif
 endif
 
-%.o: %.cc config.h
+%.o: %.cc config.h | dep
 	$(CXX) $(CPPFLAGS) -DIVL_SUFFIX='"$(suffix)"' $(MDIR1) $(MDIR2) $(CXXFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
 	mv $*.d dep/$*.d
 
-%.o: %.c config.h
+%.o: %.c config.h | dep
 	$(CC) $(CPPFLAGS) $(MDIR1) $(MDIR2) $(CFLAGS) @DEPENDENCY_FLAG@ -c $< -o $*.o
 	mv $*.d dep/$*.d
 


### PR DESCRIPTION
Pattern rules that move .d files into dep/ do not depend on the dep directory target, so parallel make can attempt the move before the directory exists.

Add dep as an order-only prerequisite to all affected pattern rules.

Bug: https://bugs.gentoo.org/880921
Bug: https://bugs.gentoo.org/911647
Bug: https://bugs.gentoo.org/917344
Closes: https://github.com/steveicarus/iverilog/issues/1314