### PR TITLE
Fix test error with --enable-libvvp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -81,6 +81,7 @@ BUILDCC = @CC_FOR_BUILD@
 BUILDEXT = @BUILD_EXEEXT@
 CC = @CC@
 CXX = @CXX@
+ENV_VVP=@ENV_VVP@
 INSTALL = @INSTALL@
 INSTALL_SCRIPT = @INSTALL_SCRIPT@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
@@ -159,7 +160,7 @@ else
 	rm vvp/vvp$(suffix).exe
 endif
 else
-	vvp/vvp -M- -M./vpi ./check.vvp | grep 'Hello, World'
+	$(ENV_VVP) vvp/vvp -M- -M./vpi ./check.vvp | grep 'Hello, World'
 endif
 
 clean:

--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,24 @@ case "${host}" in
 	;;
 esac
 
+# Setup test environment for running vvp from build directory
+VVP_BUILDDIR="$(pwd)/vvp"
+case "$host_os" in
+  linux*)
+    ENV_VVP="LD_LIBRARY_PATH=$VVP_BUILDDIR"
+    ;;
+  darwin*)
+    ENV_VVP="DYLD_LIBRARY_PATH=$VVP_BUILDDIR"
+    ;;
+  *)
+    # Since the libvvp DLL is located in the same directory as the
+    # vvp executable, no action is required here
+    ENV_VVP=""
+    ;;
+esac
+AC_SUBST([ENV_VVP])
+
+
 # Do some more operating system specific setup. We put the file64_support
 # define in a substitution instead of simply a define because there
 # are source files (namely lxt support files) that don't include any

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -41,6 +41,7 @@ HOSTCFLAGS = @WARNING_FLAGS@ @WARNING_FLAGS_CC@ @CFLAGS@
 BUILDCC = @CC_FOR_BUILD@
 BUILDEXT = @BUILD_EXEEXT@
 CXX = @CXX@
+ENV_VVP=@ENV_VVP@
 INSTALL = @INSTALL@
 INSTALL_SCRIPT = @INSTALL_SCRIPT@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
@@ -105,7 +106,7 @@ else
 	rm -f vvp$(suffix).exe
 endif
 else
-	./vvp -M../vpi $(srcdir)/examples/hello.vvp | grep 'Hello, World.'
+	$(ENV_VVP) ./vvp -M../vpi $(srcdir)/examples/hello.vvp | grep 'Hello, World.'
 endif
 
 clean:


### PR DESCRIPTION
When running `make check` on a UNIX-like operating system with the specified `configure` option, `vvp` was unable to find the required shared library.

This commit ensures that the runtime linker can locate the library.

This fixes issue #1313.