### PR TITLE
Reject non-assignable unpacked array output port expressions

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -1202,6 +1202,17 @@ void elaborate_unpacked_port(Design *des, NetScope *scope, NetNet *port_net,
 			     PExpr *expr, NetNet::PortType port_type,
 			     const Module *mod, unsigned int port_idx)
 {
+      if (port_type == NetNet::POUTPUT && !dynamic_cast<PEIdent*> (expr)) {
+	    perm_string port_name = mod->get_port_name(port_idx);
+	    cerr << expr->get_fileline() << ": error: Output port expression"
+	            " must support a continuous assignment." << endl;
+	    cerr << expr->get_fileline() << ":      : Port "
+	         << port_idx + 1 << " (" << port_name << ") of "
+	         << mod->mod_name() << " is connected to " << *expr << endl;
+	    des->errors += 1;
+	    return;
+      }
+
       NetNet *expr_net = elaborate_unpacked_array(des, scope, *expr, port_net,
 						  expr);
       if (!expr_net) {

--- a/ivtest/ivltests/module_port_array_fail1.v
+++ b/ivtest/ivltests/module_port_array_fail1.v
@@ -1,0 +1,17 @@
+// Check that an output array port expression must be assignable.
+
+module M (
+  output int out [0:1]
+);
+
+  initial begin
+    out = '{3, 4};
+  end
+
+endmodule
+
+module test;
+
+  M i_m('{1, 2}); // Error: output expression is not assignable
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -151,6 +151,7 @@ mix_reset-synth			vvp_tests/mix_reset-synth.json
 module_ordered_list1		vvp_tests/module_ordered_list1.json
 module_ordered_list2		vvp_tests/module_ordered_list2.json
 module_port_array1		vvp_tests/module_port_array1.json
+module_port_array_fail1		vvp_tests/module_port_array_fail1.json
 module_port_array_init1		vvp_tests/module_port_array_init1.json
 monitor4			vvp_tests/monitor4.json
 non-polymorphic-abs		vvp_tests/non-polymorphic-abs.json

--- a/ivtest/vvp_tests/module_port_array_fail1.json
+++ b/ivtest/vvp_tests/module_port_array_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "module_port_array_fail1.v",
+    "iverilog-args" : [ "-g2009" ]
+}


### PR DESCRIPTION
Output port expressions must support continuous assignment. Assignment patterns for unpacked array output ports are currently elaborated as temporary arrays and the connection is silently discarded.

Report an error instead.