### PR TITLE
Fix drive strength in net declaration parsing

### DIFF
--- a/ivtest/ivltests/drive_strength4.v
+++ b/ivtest/ivltests/drive_strength4.v
@@ -1,0 +1,62 @@
+// Check that drive strength can be specified between the net type and the data
+// type in a net declaration and that vector gate arrays resolve strengths
+// correctly.
+
+module test;
+
+  reg [7:0] pullval;
+  wire (weak0, weak1) [7:0] value = pullval;
+
+  reg [7:0] en0;
+  reg [7:0] en1;
+  reg failed = 1'b0;
+
+  `define check(expr, val) \
+    if ((expr) !== (val)) begin \
+      $display("FAILED(%0d): `%s`, expected %0h, got %0h", `__LINE__, \
+               `"expr`", (val), (expr)); \
+      failed = 1'b1; \
+    end
+
+  buf (highz0, strong1) drive0 [7:0] (value, en0);
+  not (strong0, highz1) drive1 [7:0] (value, en1);
+
+  initial begin
+    en0 = 8'h00;
+    en1 = 8'h00;
+
+    pullval = 8'hff;
+    #1 `check(value, 8'hff)
+
+    pullval = 8'h00;
+    #1 `check(value, 8'h00)
+
+    en0 = 8'haa;
+    pullval = 8'hff;
+    #1 `check(value, 8'hff)
+
+    pullval = 8'h00;
+    #1 `check(value, 8'haa)
+
+    en0 = 8'h00;
+    en1 = 8'hff;
+    pullval = 8'hff;
+    #1 `check(value, 8'h00)
+
+    pullval = 8'h00;
+    #1 `check(value, 8'h00)
+
+    en0 = 8'hff;
+    en1 = 8'hff;
+    pullval = 8'hff;
+    #1 `check(value, 8'hxx)
+
+    pullval = 8'h00;
+    #1 `check(value, 8'hxx)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -118,6 +118,7 @@ dffsynth8			vvp_tests/dffsynth8.json
 dffsynth9			vvp_tests/dffsynth9.json
 dffsynth10			vvp_tests/dffsynth10.json
 dffsynth11			vvp_tests/dffsynth11.json
+drive_strength4			vvp_tests/drive_strength4.json
 dumpfile			vvp_tests/dumpfile.json
 early_sig_elab1			vvp_tests/early_sig_elab1.json
 early_sig_elab2			vvp_tests/early_sig_elab2.json

--- a/ivtest/vvp_tests/drive_strength4.json
+++ b/ivtest/vvp_tests/drive_strength4.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "normal",
+    "source" : "drive_strength4.v"
+}

--- a/parse.y
+++ b/parse.y
@@ -4954,14 +4954,14 @@ module_item
   /* This form doesn't have the range, but does have strengths. This
      gives strength to the assignment drivers. */
 
-  | attribute_list_opt net_type data_type_or_implicit drive_strength net_decl_assigns ';'
-      { data_type_t*data_type = $3;
-        pform_check_net_data_type(@2, $2, $3);
+  | attribute_list_opt net_type drive_strength data_type_or_implicit net_decl_assigns ';'
+      { data_type_t*data_type = $4;
+        pform_check_net_data_type(@2, $2, $4);
 	if (data_type == 0) {
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
 	      FILE_NAME(data_type, @2);
 	}
-	pform_makewire(@2, 0, $4, $5, $2, data_type, $1);
+	pform_makewire(@2, 0, $3, $5, $2, data_type, $1);
 	delete $1;
       }
 


### PR DESCRIPTION
The drive strength of a net must be declared between the net type and the data type. E.g.
```SystemVerilog
    wire (weak0, strong1) [7:0] x;
```
The current implementation expects the drive strength after the data type. Update the parser to fix this.