### PR TITLE
Allow lifetime specifier for variables declared in packages

### DIFF
--- a/ivtest/ivltests/sv_package_lifetime.v
+++ b/ivtest/ivltests/sv_package_lifetime.v
@@ -1,0 +1,40 @@
+// Check that static lifetime can be specified for variables declared in a
+// package.
+
+`define check(val, exp) \
+  if (val !== exp) begin \
+    $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, `"val`", exp, val); \
+    failed = 1'b1; \
+  end
+
+package P;
+  static int x = 1;
+  const static int y = 2;
+  var static z;
+  var static logic [3:0] w = 4'h3;
+endpackage
+
+package automatic Q;
+  int a = 4;
+  static int b = 5;
+endpackage
+
+module test;
+  import P::*;
+  import Q::*;
+
+  bit failed = 1'b0;
+
+  initial begin
+    `check(x, 1)
+    `check(y, 2)
+    `check(z, 1'bx)
+    `check(w, 4'h3)
+    `check(a, 4)
+    `check(b, 5)
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_package_lifetime_fail.v
+++ b/ivtest/ivltests/sv_package_lifetime_fail.v
@@ -1,0 +1,6 @@
+// Check that automatic lifetime cannot be specified for variables declared in
+// a package.
+
+package P;
+  automatic int x;
+endpackage

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -280,6 +280,8 @@ sv_module_port1			vvp_tests/sv_module_port1.json
 sv_module_port2			vvp_tests/sv_module_port2.json
 sv_module_port3			vvp_tests/sv_module_port3.json
 sv_module_port4			vvp_tests/sv_module_port4.json
+sv_package_lifetime		vvp_tests/sv_package_lifetime.json
+sv_package_lifetime_fail	vvp_tests/sv_package_lifetime_fail.json
 sv_parameter_type		vvp_tests/sv_parameter_type.json
 sv_queue_assign_op		vvp_tests/sv_queue_assign_op.json
 sv_wildcard_import8		vvp_tests/sv_wildcard_import8.json

--- a/ivtest/vvp_tests/sv_package_lifetime.json
+++ b/ivtest/vvp_tests/sv_package_lifetime.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_lifetime.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_package_lifetime_fail.json
+++ b/ivtest/vvp_tests/sv_package_lifetime_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_package_lifetime_fail.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/parse.y
+++ b/parse.y
@@ -1283,22 +1283,24 @@ constraint_set /* IEEE1800-2005 A.1.9 */
   ;
 
 data_declaration /* IEEE1800-2005: A.2.1.3 */
-   : attribute_list_opt K_const_opt data_type list_of_variable_decl_assignments ';'
-      { data_type_t *data_type = $3;
-	if (!data_type) {
-	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
-	      FILE_NAME(data_type, @3);
-	}
-	pform_makewire(@3, 0, str_strength, $4, NetNet::IMPLICIT_REG, data_type,
-		       $1, $2);
-      }
-  | attribute_list_opt K_const_opt K_var data_type_or_implicit list_of_variable_decl_assignments ';'
+   : attribute_list_opt K_const_opt variable_lifetime_opt data_type list_of_variable_decl_assignments ';'
       { data_type_t *data_type = $4;
 	if (!data_type) {
 	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
+	      FILE_NAME(data_type, @4);
+	}
+	pform_makewire(@4, 0, str_strength, $5, NetNet::IMPLICIT_REG, data_type,
+		       $1, $2);
+	var_lifetime = LexicalScope::INHERITED;
+      }
+  | attribute_list_opt K_const_opt K_var variable_lifetime_opt data_type_or_implicit list_of_variable_decl_assignments ';'
+      { data_type_t *data_type = $5;
+	if (!data_type) {
+	      data_type = new vector_type_t(IVL_VT_LOGIC, false, 0);
 	      FILE_NAME(data_type, @3);
 	}
-	pform_make_var(@3, $5, data_type, $1, $2);
+	pform_make_var(@3, $6, data_type, $1, $2);
+	var_lifetime = LexicalScope::INHERITED;
       }
   | attribute_list_opt K_event event_variable_list ';'
       { if ($3) pform_make_events(@2, $3);
@@ -2705,10 +2707,16 @@ variable_dimension /* IEEE1800-2005: A.2.5 */
 
 variable_lifetime_opt
   : lifetime
-      { if (pform_requires_sv(@1, "Overriding default variable lifetime") &&
-	    $1 != pform_peek_scope()->default_lifetime) {
-	      yyerror(@1, "sorry: Overriding the default variable lifetime "
-			  "is not yet supported.");
+      { LexicalScope*scope = pform_peek_scope();
+	if (dynamic_cast<PPackage*>(scope)) {
+	      if ($1 == LexicalScope::AUTOMATIC) {
+		    yyerror(@1, "error: automatic lifetime is not allowed for "
+				"variables declared in packages.");
+	      }
+	} else if (pform_requires_sv(@1, "Overriding default variable lifetime") &&
+		   $1 != scope->default_lifetime) {
+	      yyerror(@1, "sorry: Overriding the default variable "
+			  "lifetime is not yet supported.");
 	}
 	var_lifetime = $1;
       }


### PR DESCRIPTION
The LRM allows to add a lifetime specified for variables declared in package scope. It is not particular useful since only static lifetime is allowed. But it is legal syntax, so support it.