### PR TITLE
elab: Remove redundant enum parameter width handling

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -4231,20 +4231,6 @@ NetExpr* PEIdent::calculate_up_do_base_(Design*des, NetScope*scope,
 
 unsigned PEIdent::test_width_parameter_(const NetExpr *par, width_mode_t&mode)
 {
-	// The width of an enumeration literal is the width of the
-	// enumeration base.
-      if (const NetEConstEnum*par_enum = dynamic_cast<const NetEConstEnum*> (par)) {
-	    const netenum_t*use_enum = par_enum->enumeration();
-	    ivl_assert(*this, use_enum != 0);
-
-	    expr_type_   = use_enum->base_type();
-	    expr_width_  = use_enum->packed_width();
-	    min_width_   = expr_width_;
-	    signed_flag_ = par_enum->has_sign();
-
-	    return expr_width_;
-      }
-
       expr_type_   = par->expr_type();
       expr_width_  = par->expr_width();
       min_width_   = expr_width_;


### PR DESCRIPTION
`PEIdent::test_width_parameter_()` has a special case for `NetEConstEnum` that queries the enum base type directly. This was needed when enum constants kept their enum type separately from the `NetExpr` type.

Commit f63a16232974 ("Provide data type for more NetExpr subclasses") made `NetEConstEnum` attach the enum type to the `NetExpr`. The generic parameter width path now gets the same type, width and signedness as the special case.

Remove the redundant special case and use the common path for enum constants as well.