### PR TITLE
elab: Use common new array initializer elaboration

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -6654,19 +6654,8 @@ NetExpr* PENewArray::elaborate_expr(Design*des, NetScope*scope,
       NetExpr*size = size_->elaborate_expr(des, scope, use_wid, flags);
       NetExpr*init_val = 0;
 
-      if (dynamic_cast<PEAssignPattern*> (init_)) {
-	      // Special case: the initial value expression is an
-	      // array_pattern. Elaborate the expression like the
-	      // r-value to an assignment to array.
+      if (init_) {
 	    init_val = init_->elaborate_expr(des, scope, ntype, flags);
-
-      } else if (init_) {
-	      // Regular case: The initial value is an
-	      // expression. Elaborate the expression as an element
-	      // type. The run-time will assign this value to each element.
-	    const netarray_t*array_type = dynamic_cast<const netarray_t*> (ntype);
-
-	    init_val = init_->elaborate_expr(des, scope, array_type, flags);
       }
 
       NetENew*tmp = new NetENew(ntype, size, init_val);


### PR DESCRIPTION
here are two separate paths `PENewArray::elaborate_expr()`, one for assignment patterns and one for everything else.

But since since commit 5ca058bfb ("Add support for darray initialisation from another darray"). The two paths have been effectively the same.

Both call `elaborate_expr()` on the init values with the same parameters. The only difference is the regular path casts the type to `netarray_t`, but that doesn't really do anything since it gets passed to a function that takes a `ivl_type_t`, so is immediately cast back to the base type.

The comment on the regular path is also outdated since it still refers to the tpre 5ca058bfb code.

Remove the branching and route it through the same path.