### PR TITLE
Reject `real` array indices

### DIFF
--- a/ivtest/ivltests/array_index_real_fail.v
+++ b/ivtest/ivltests/array_index_real_fail.v
@@ -1,0 +1,12 @@
+// Check that real expressions can not be used as array indices.
+
+module test;
+
+  reg [1:0] a[1:0];
+  real r;
+
+  initial begin
+    a[r] = 2'b10;
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -6,6 +6,7 @@ always4A			vvp_tests/always4A.json
 always4B			vvp_tests/always4B.json
 analog1				vvp_tests/analog1.json
 analog2				vvp_tests/analog2.json
+array_index_real_fail		vvp_tests/array_index_real_fail.json
 array_packed_sysfunct		vvp_tests/array_packed_sysfunct.json
 array_packed_value_list		vvp_tests/array_packed_value_list.json
 array_packed_write_read		vvp_tests/array_packed_write_read.json

--- a/ivtest/vvp_tests/array_index_real_fail.json
+++ b/ivtest/vvp_tests/array_index_real_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "CE",
+    "source" : "array_index_real_fail.v"
+}

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2025 Stephen Williams (steve@icarus.com)
+ * Copyright (c) 2001-2026 Stephen Williams (steve@icarus.com)
  *
  *    This source code is free software; you can redistribute it
  *    and/or modify it in source code form under the terms of the GNU
@@ -509,8 +509,15 @@ void indices_to_expressions(Design*des, NetScope*scope,
 
 	    NetExpr*word_index = elab_and_eval(des, scope, cur->msb, -1, need_const);
 
-	    if (word_index == 0)
+	    if (!word_index) {
 		  flags.invalid = true;
+	    } else if (word_index->expr_type() == IVL_VT_REAL) {
+		  cerr << cur->msb->get_fileline() << ": error: "
+		       << "Array index expression cannot be a real value."
+		       << endl;
+		  des->errors += 1;
+		  flags.invalid = true;
+	    }
 
 	      // Track if we detect any non-constant expressions
 	      // here. This may allow for a special case.


### PR DESCRIPTION
Array indices must be integral expressions. Using a real valued expression as an unpacked array index currently reaches the vvp real expression code and triggers an assert.

Packed bit and part select indices already report an elaboration error for real expressions since commit 2249d22 ("Bit/part selects cannot have real index expressions"). Do the same for unpacked array indices.