### PR TITLE
vvp,tgt-fpga: cleanup doc related rules

### DIFF
--- a/tgt-fpga/Makefile.in
+++ b/tgt-fpga/Makefile.in
@@ -23,8 +23,8 @@ suffix = @install_suffix@
 prefix = @prefix@
 exec_prefix = @exec_prefix@
 srcdir = @srcdir@
-mandir = @mandir@
-datarootdir = @datarootdir@
+man1dir = @mandir@/man1
+docdir = @docdir@
 
 VPATH = $(srcdir)
 
@@ -94,13 +94,15 @@ iverilog-fpga.ps: $(srcdir)/iverilog-fpga.man
 iverilog-fpga.pdf: iverilog-fpga.ps
 	ps2pdf iverilog-fpga.ps iverilog-fpga.pdf
 
-ifeq (@WIN32@,yes)
-INSTALL_DOC = installpdf installman
-INSTALL_DOCDIR = $(mandir)/man1
+INSTALL_DOC =
+ifneq ($(MAN),none)
+INSTALL_DOC += installman
+ifneq ($(PS2PDF),none)
+ifeq (@MINGW32@,yes)
+INSTALL_DOC += installpdf
 all: iverilog-fpga.pdf
-else
-INSTALL_DOC = installman
-INSTALL_DOCDIR = $(mandir)/man1
+endif
+endif
 endif
 
 install: all installdirs installfiles
@@ -111,10 +113,10 @@ F = ./fpga.tgt \
 	$(INSTALL_DOC)
 
 installman: $(srcdir)/iverilog-fpga.man installdirs
-	$(INSTALL_DATA) $(srcdir)/iverilog-fpga.man "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
+	$(INSTALL_DATA) $(srcdir)/iverilog-fpga.man "$(DESTDIR)$(man1dir)/iverilog-fpga$(suffix).1"
 
 installpdf: iverilog-fpga.pdf installdirs
-	$(INSTALL_DATA) iverilog-fpga.pdf "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf"
+	$(INSTALL_DATA) iverilog-fpga.pdf "$(DESTDIR)$(docdir)/iverilog-fpga$(suffix).pdf"
 
 installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./fpga.tgt "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
@@ -126,7 +128,7 @@ installdirs: $(srcdir)/../mkinstalldirs
 
 uninstall:
 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.tgt"
-	rm -f "$(DESTDIR)$(prefix)/iverilog-fpga$(suffix).pdf" "$(DESTDIR)$(mandir)/man1/iverilog-fpga$(suffix).1"
+	rm -f "$(DESTDIR)$(docdir)/iverilog-fpga$(suffix).pdf" "$(DESTDIR)$(man1dir)/iverilog-fpga$(suffix).1"
 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga-s.conf"
 	rm -f "$(DESTDIR)$(libdir)/ivl$(suffix)/fpga.conf"
 

--- a/vvp/Makefile.in
+++ b/vvp/Makefile.in
@@ -28,11 +28,11 @@ VPATH = $(srcdir)
 
 bindir = @bindir@
 libdir = @libdir@
-mandir = @mandir@
+man1dir = @mandir@/man1
+docdir = @docdir@
 # This is actually the directory where we install our own header files.
 # It is a little different from the generic includedir.
 ivl_includedir = @includedir@/iverilog$(suffix)
-pdfdir = @docdir@
 
 # For a cross compile these defines will need to be set accordingly.
 HOSTCC = @CC@
@@ -195,25 +195,15 @@ vvp.ps: vvp.man
 vvp.pdf: vvp.ps
 	$(PS2PDF) $< $@
 
+INSTALL_DOC =
+ifneq ($(MAN),none)
+INSTALL_DOC += installman
+ifneq ($(PS2PDF),none)
 ifeq (@MINGW32@,yes)
-ifeq ($(MAN),none)
-INSTALL_DOC = installman
-INSTALL_PDFDIR = $(prefix)
-else
-ifeq ($(PS2PDF),none)
-INSTALL_DOC = installman
-INSTALL_PDFDIR = $(prefix)
-else
-INSTALL_DOC = installpdf installman
-INSTALL_PDFDIR = $(pdfdir)
+INSTALL_DOC += installpdf
 all: vvp.pdf
 endif
 endif
-INSTALL_DOCDIR = $(mandir)/man1
-else
-INSTALL_DOC = installman
-INSTALL_DOCDIR = $(mandir)/man1
-INSTALL_PDFDIR = $(prefix)
 endif
 
 stamp-config-h: $(srcdir)/config.h.in ../config.status
@@ -226,10 +216,10 @@ install: all installdirs installfiles
 F = ./vvp@EXEEXT@ $(srcdir)/libvvp.h $(INSTALL_DOC)
 
 installman: vvp.man installdirs
-	$(INSTALL_DATA) vvp.man "$(DESTDIR)$(mandir)/man1/vvp$(suffix).1"
+	$(INSTALL_DATA) vvp.man "$(DESTDIR)$(man1dir)/vvp$(suffix).1"
 
 installpdf: vvp.pdf installdirs
-	$(INSTALL_DATA) vvp.pdf "$(DESTDIR)$(pdfdir)/vvp$(suffix).pdf"
+	$(INSTALL_DATA) vvp.pdf "$(DESTDIR)$(docdir)/vvp$(suffix).pdf"
 
 installfiles: $(F) | installdirs
 	$(INSTALL_PROGRAM) ./vvp@EXEEXT@ "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
@@ -241,13 +231,14 @@ endif
 installdirs: $(srcdir)/../mkinstalldirs
 	$(srcdir)/../mkinstalldirs "$(DESTDIR)$(bindir)" \
 		"$(DESTDIR)$(libdir)" \
-		"$(DESTDIR)$(INSTALL_DOCDIR)" \
-		"$(DESTDIR)$(INSTALL_PDFDIR)"
+		"$(DESTDIR)$(docdir)" \
+		"$(DESTDIR)$(man1dir)"
 
 
 uninstall: $(UNINSTALL32)
 	rm -f "$(DESTDIR)$(bindir)/vvp$(suffix)@EXEEXT@"
-	rm -f "$(DESTDIR)$(mandir)/man1/vvp$(suffix).1" "$(DESTDIR)$(pdfdir)/vvp$(suffix).pdf"
+	rm -f "$(DESTDIR)$(man1dir)/vvp$(suffix).1" \
+	      "$(DESTDIR)$(docdir)/vvp$(suffix).pdf"
 ifeq (@LIBVVP@,yes)
 	rm -f "$(DESTDIR)$(SLDIR)/libvvp$(suffix).$(SLEXT)"
 	rm -f "$(DESTDIR)$(ivl_includedir)/libvvp.h"


### PR DESCRIPTION
Commit 181cb7b2e simplified the Makefile rules for generating documentation in the `driver-vpi` subdirectory; these changes also update the remaining rules in the `vvp` and `tgt-fpga` directories.