### PR TITLE
Reject super access without a parent class

### DIFF
--- a/ivtest/ivltests/sv_super_member_fail.v
+++ b/ivtest/ivltests/sv_super_member_fail.v
@@ -1,0 +1,11 @@
+// Check that `super` access in a class without a parent class is rejected.
+
+module test;
+
+  class C;
+    function void f;
+      super.x = 1;
+    endfunction
+  endclass
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -288,6 +288,7 @@ sv_package_lifetime		vvp_tests/sv_package_lifetime.json
 sv_package_lifetime_fail	vvp_tests/sv_package_lifetime_fail.json
 sv_parameter_type		vvp_tests/sv_parameter_type.json
 sv_queue_assign_op		vvp_tests/sv_queue_assign_op.json
+sv_super_member_fail		vvp_tests/sv_super_member_fail.json
 sv_wildcard_import8		vvp_tests/sv_wildcard_import8.json
 sdf_header			vvp_tests/sdf_header.json
 task_return1			vvp_tests/task_return1.json

--- a/ivtest/vvp_tests/sv_super_member_fail.json
+++ b/ivtest/vvp_tests/sv_super_member_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_super_member_fail.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/symbol_search.cc
+++ b/symbol_search.cc
@@ -153,6 +153,15 @@ bool symbol_search(const LineInfo*li, Design*des, NetScope*scope,
 		  if (path_tail.name == "#") {
 			if (NetNet *net = scope->find_signal(perm_string::literal(THIS_TOKEN))) {
 			      const netclass_t *class_type = dynamic_cast<const netclass_t*>(net->net_type());
+			      ivl_assert(*li, class_type);
+			      if (!class_type->get_super()) {
+				    cerr << li->get_fileline() << ": error: "
+					 << "Class " << class_type->get_name()
+					 << " uses `super` without a base class."
+					 << endl;
+				    des->errors += 1;
+				    return false;
+			      }
 			      path.push_back(path_tail);
 			      res->scope = scope;
 			      res->net = net;


### PR DESCRIPTION
The `super` keyword refers to the parent class of the current class. If the
class has no parent the lookup still returned the current class handle and left
the `super` path component for l-value elaboration. This triggered the
`tail_path.empty()` assert.

Report an error during symbol lookup instead.