### PR TITLE
docs: add github url to html theme options

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -82,7 +82,9 @@ html_theme = 'shibuya'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "github_url": "https://github.com/steveicarus/iverilog",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Include the GitHub repository URL in the HTML theme options for better visibility and access to the project's source code.