### PR TITLE
tgt-vvp: Use `%cmp/e` instead of `%cmp/u` for `case` comparisons

### DIFF
--- a/tgt-vvp/vvp_process.c
+++ b/tgt-vvp/vvp_process.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2021 Stephen Williams (steve@icarus.com)
+ * Copyright (c) 2001-2026 Stephen Williams (steve@icarus.com)
  *
  *    This source code is free software; you can redistribute it
  *    and/or modify it in source code form under the terms of the GNU

--- a/tgt-vvp/vvp_process.c
+++ b/tgt-vvp/vvp_process.c
@@ -671,7 +671,7 @@ static int show_stmt_case(ivl_statement_t net, ivl_scope_t sscope)
 	    switch (ivl_statement_type(net)) {
 
 		case IVL_ST_CASE:
-		  fprintf(vvp_out, "    %%cmp/u;\n");
+		  fprintf(vvp_out, "    %%cmp/e;\n");
 		  fprintf(vvp_out, "    %%jmp/1 T_%u.%u, 6;\n",
 			  thread_count, local_base+idx);
 		  break;


### PR DESCRIPTION
`%cmp/e` and `%cmp/u` are very similar with `%cmp/e` not setting the lt flag and being a bit faster due to it. For case comparisons the flag is not needed so switch to `%cmp/e`. This speeds up simulation time designs which make use of case comparisons.