### PR TITLE
ivtest: Fix source for sv_mixed_assign2 test

### DIFF
--- a/ivtest/vvp_tests/sv_mixed_assign2.json
+++ b/ivtest/vvp_tests/sv_mixed_assign2.json
@@ -1,5 +1,5 @@
 {
     "type"          : "NI",
-    "source"        : "sv_mixed_assign1.v",
+    "source"        : "sv_mixed_assign2.v",
     "iverilog-args" : [ "-g2009" ]
 }


### PR DESCRIPTION
The sv_mixed_assign2 JSON entry accidentally references sv_mixed_assign1.v. Point it at sv_mixed_assign2.v instead.