### PR TITLE
ivtest: Fix VVP regression test metadata

### DIFF
--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -249,8 +249,8 @@ sv_class_prop_assign_op2	vvp_tests/sv_class_prop_assign_op2.json
 sv_class_prop_logic		vvp_tests/sv_class_prop_logic.json
 sv_class_prop_nest_darray1	vvp_tests/sv_class_prop_nest_darray1.json
 sv_class_prop_nest_obj1		vvp_tests/sv_class_prop_nest_obj1.json
-sv_class_prop_nest_real1	vvp_tests/sv_class_prop_nest_str1.json
-sv_class_prop_nest_str1		vvp_tests/sv_class_prop_nest_real1.json
+sv_class_prop_nest_real1	vvp_tests/sv_class_prop_nest_real1.json
+sv_class_prop_nest_str1		vvp_tests/sv_class_prop_nest_str1.json
 sv_class_prop_nest_vec1		vvp_tests/sv_class_prop_nest_vec1.json
 sv_const1			vvp_tests/sv_const1.json
 sv_const2			vvp_tests/sv_const2.json

--- a/ivtest/vvp_tests/br_gh1256b.json
+++ b/ivtest/vvp_tests/br_gh1256b.json
@@ -1,5 +1,5 @@
 {
     "type"   : "normal",
-    "source" : "br_gh1256a.v",
+    "source" : "br_gh1256b.v",
     "iverilog-args" : [ "-g2009" ]
 }

--- a/ivtest/vvp_tests/sv_mixed_assign_error2.json
+++ b/ivtest/vvp_tests/sv_mixed_assign_error2.json
@@ -1,6 +1,6 @@
 {
     "type"          : "CE",
-    "source"        : "sv_mixed_assign_error1.v",
-    "gold"          : "sv_mixed_assign_error1",
+    "source"        : "sv_mixed_assign_error2.v",
+    "gold"          : "sv_mixed_assign_error2",
     "iverilog-args" : [ "-g2009" ]
 }

--- a/ivtest/vvp_tests/sv_mixed_assign_error3.json
+++ b/ivtest/vvp_tests/sv_mixed_assign_error3.json
@@ -1,6 +1,6 @@
 {
     "type"          : "CE",
-    "source"        : "sv_mixed_assign_error1.v",
-    "gold"          : "sv_mixed_assign_error1",
+    "source"        : "sv_mixed_assign_error3.v",
+    "gold"          : "sv_mixed_assign_error3",
     "iverilog-args" : [ "-g2009" ]
 }

--- a/ivtest/vvp_tests/sv_mixed_assign_error4.json
+++ b/ivtest/vvp_tests/sv_mixed_assign_error4.json
@@ -1,6 +1,6 @@
 {
     "type"          : "CE",
-    "source"        : "sv_mixed_assign_error1.v",
-    "gold"          : "sv_mixed_assign_error1",
+    "source"        : "sv_mixed_assign_error4.v",
+    "gold"          : "sv_mixed_assign_error4",
     "iverilog-args" : [ "-g2009" ]
 }


### PR DESCRIPTION
A few JSON regression test entries reference the wrong source or gold files. There are also two regress-vvp list entries that reference each other's JSON file.

Use the matching source and gold files for those entries.