### PR TITLE
Add 2017 and 2023 language flag support

### DIFF
--- a/Documentation/usage/command_line_flags.rst
+++ b/Documentation/usage/command_line_flags.rst
@@ -68,6 +68,16 @@ These flags affect the general behavior of the compiler.
     This flag enables the IEEE1800-2012 standard, which includes
     SystemVerilog.
 
+  * 2017
+
+    This flag enables the IEEE1800-2017 standard, which includes
+    SystemVerilog.
+
+  * 2023
+
+    This flag enables the IEEE1800-2023 standard, which includes
+    SystemVerilog.
+
   * verilog-ams
 
     This flag enables Verilog-AMS features that are supported by Icarus

--- a/compiler.h
+++ b/compiler.h
@@ -165,6 +165,8 @@ enum generation_t {
       GN_VER2005_SV  = 5,
       GN_VER2009  = 6,
       GN_VER2012  = 7,
+      GN_VER2017  = 8,
+      GN_VER2023  = 9,
       GN_DEFAULT  = 4
 };
 

--- a/driver/iverilog.man.in
+++ b/driver/iverilog.man.in
@@ -6,7 +6,7 @@ iverilog - Icarus Verilog compiler
 .B iverilog
 [\-EiRSuVv] [\-Bpath] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
 [\-Pparameter=value] [\-pflag=value] [\-dname]
-[\-g1995\:|\-g2001\:|\-g2005\:|\-g2005-sv\:|\-g2009\:|\-g2012\:|\-g<feature>]
+[\-g1995\:|\-g2001\:|\-g2005\:|\-g2005-sv\:|\-g2009\:|\-g2012\:|\-g2017\:|\-g2023\:|\-g<feature>]
 [\-Iincludedir] [\-Lmoduledir] [\-mmodule] [\-M[mode=]file] [\-Nfile]
 [\-ooutputfilename] [\-stopmodule] [\-ttype] [\-Tmin/typ/max] [\-Wclass]
 [\-ypath] [\-lfile]
@@ -63,11 +63,11 @@ is the Verilog input, but with file inclusions and macro references
 expanded and removed. This is useful, for example, to preprocess
 Verilog source for use by other compilers.
 .TP 8
-.B -g1995\fI|\fP-g2001\fI|\fP-g2001-noconfig\fI|\fP-g2005\fI|\fP-g2005-sv\fI|\fP-g2009\fI|\fP-g2012
+.B -g1995\fI|\fP-g2001\fI|\fP-g2001-noconfig\fI|\fP-g2005\fI|\fP-g2005-sv\fI|\fP-g2009\fI|\fP-g2012\fI|\fP-g2017\fI|\fP-g2023
 Select the Verilog language \fIgeneration\fP to support in the compiler.
 This selects between \fIIEEE1364\-1995\fP, \fIIEEE1364\-2001\fP,
-\fIIEEE1364\-2005\fP, \fIIEEE1800\-2005\fP, \fIIEEE1800\-2009\fP, or
-\fIIEEE1800\-2012\fP.
+\fIIEEE1364\-2005\fP, \fIIEEE1800\-2005\fP, \fIIEEE1800\-2009\fP,
+\fIIEEE1800\-2012\fP, \fIIEEE1800\-2017\fP, or \fIIEEE1800\-2023\fP.
 Icarus Verilog currently defaults to the \fIIEEE1364\-2005\fP generation
 of the language. This flag is used to restrict the language to a set of
 keywords/features, this allows simulation of older Verilog code that may

--- a/driver/main.c
+++ b/driver/main.c
@@ -39,7 +39,7 @@ const char NOTICE[] =
 
 const char HELP[] =
 "Usage: iverilog [-EiRSuvV] [-B base] [-c cmdfile|-f cmdfile]\n"
-"                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012] [-g<feature>]\n"
+"                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012|-g2017|-g2023] [-g<feature>]\n"
 "                [-D macro[=defn]] [-I includedir] [-L moduledir]\n"
 "                [-M [mode=]depfile] [-m module]\n"
 "                [-N file] [-o filename] [-p flag=value]\n"
@@ -740,6 +740,12 @@ static int process_generation(const char*name)
       else if (strcmp(name,"2012") == 0)
 	    generation = "2012";
 
+      else if (strcmp(name,"2017") == 0)
+	    generation = "2017";
+
+      else if (strcmp(name,"2023") == 0)
+	    generation = "2023";
+
       else if (strcmp(name,"1") == 0) { /* Deprecated: use 1995 */
 	    generation = "1995";
 	    gen_xtypes = "no-xtypes";
@@ -860,6 +866,8 @@ static int process_generation(const char*name)
 		            "    2005-sv -- IEEE1800-2005\n"
 		            "    2009    -- IEEE1800-2009\n"
 		            "    2012    -- IEEE1800-2012\n"
+		            "    2017    -- IEEE1800-2017\n"
+		            "    2023    -- IEEE1800-2023\n"
 		            "Other generation flags:\n"
 		            "    assertions | supported-assertions | no-assertions\n"
 		            "    specify | no-specify\n"
@@ -1388,11 +1396,13 @@ int main(int argc, char **argv)
       fprintf(iconfig_file, "module:%s%cvhdl_sys.vpi\n", vpi_dir, sep);
       fprintf(iconfig_file, "module:%s%cvhdl_textio.vpi\n", vpi_dir, sep);
 
-	/* If verilog-2005/09/12 is enabled or icarus-misc or verilog-ams,
+	/* If verilog-2005/09/12/17/23 is enabled or icarus-misc or verilog-ams,
 	 * then include the v2005_math library. */
       if (strcmp(generation, "2005") == 0 ||
           strcmp(generation, "2009") == 0 ||
           strcmp(generation, "2012") == 0 ||
+          strcmp(generation, "2017") == 0 ||
+          strcmp(generation, "2023") == 0 ||
           strcmp(gen_icarus, "icarus-misc") == 0 ||
           strcmp(gen_verilog_ams, "verilog-ams") == 0) {
 	    fprintf(iconfig_file, "module:%s%cv2005_math.vpi\n", vpi_dir, sep);
@@ -1407,7 +1417,9 @@ int main(int argc, char **argv)
          v2009 module. */
       if (strcmp(generation, "2005-sv") == 0 ||
           strcmp(generation, "2009") == 0 ||
-          strcmp(generation, "2012") == 0) {
+          strcmp(generation, "2012") == 0 ||
+          strcmp(generation, "2017") == 0 ||
+          strcmp(generation, "2023") == 0) {
 	    fprintf(iconfig_file, "module:%s%cv2009.vpi\n", vpi_dir, sep);
       }
 

--- a/ivtest/ivltests/begin_keywords_1364_1995.v
+++ b/ivtest/ivltests/begin_keywords_1364_1995.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1364-1995 keyword set.
+
+`begin_keywords "1364-1995"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1364_2001.v
+++ b/ivtest/ivltests/begin_keywords_1364_2001.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1364-2001 keyword set.
+
+`begin_keywords "1364-2001"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1364_2001_noconfig.v
+++ b/ivtest/ivltests/begin_keywords_1364_2001_noconfig.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1364-2001-noconfig keyword set.
+
+`begin_keywords "1364-2001-noconfig"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1364_2005.v
+++ b/ivtest/ivltests/begin_keywords_1364_2005.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1364-2005 keyword set.
+
+`begin_keywords "1364-2005"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1800_2005.v
+++ b/ivtest/ivltests/begin_keywords_1800_2005.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1800-2005 keyword set.
+
+`begin_keywords "1800-2005"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1800_2009.v
+++ b/ivtest/ivltests/begin_keywords_1800_2009.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1800-2009 keyword set.
+
+`begin_keywords "1800-2009"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1800_2012.v
+++ b/ivtest/ivltests/begin_keywords_1800_2012.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1800-2012 keyword set.
+
+`begin_keywords "1800-2012"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1800_2017.v
+++ b/ivtest/ivltests/begin_keywords_1800_2017.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1800-2017 keyword set.
+
+`begin_keywords "1800-2017"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_1800_2023.v
+++ b/ivtest/ivltests/begin_keywords_1800_2023.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the 1800-2023 keyword set.
+
+`begin_keywords "1800-2023"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/ivltests/begin_keywords_vams_2_3.v
+++ b/ivtest/ivltests/begin_keywords_vams_2_3.v
@@ -1,0 +1,9 @@
+// Check that `begin_keywords accepts the VAMS-2.3 keyword set.
+
+`begin_keywords "VAMS-2.3"
+module test;
+  initial begin
+    $display("PASSED");
+  end
+endmodule
+`end_keywords

--- a/ivtest/perl-lib/RegressionList.pm
+++ b/ivtest/perl-lib/RegressionList.pm
@@ -172,13 +172,15 @@ sub read_regression_list {
         $nameidx{$tname} = @testlist - 1;
 
         # The generation to use is passed if it does not match
-        # the default. To make sure the tests are protable we
+        # the default. To make sure the tests are portable we
         # use the force SV flag to force all tests to be run
         # as the latest SystemVerilog generation. This assumes
         # the correct `begin_keywords has been added to the
         # various files.
         if ($force_sv) {
-            my $fsv_flags = "-g2012";
+            my $fsv_flags = "-g2023";
+            $args{$tname} =~ s/-g2023//;
+            $args{$tname} =~ s/-g2017//;
             $args{$tname} =~ s/-g2012//;
             $args{$tname} =~ s/-g2009//;
             $args{$tname} =~ s/-g2005-sv//;

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -14,6 +14,16 @@ array_slice_concat		vvp_tests/array_slice_concat.json
 automatic_error11		vvp_tests/automatic_error11.json
 automatic_error12		vvp_tests/automatic_error12.json
 automatic_error13		vvp_tests/automatic_error13.json
+begin_keywords_1364_1995	vvp_tests/begin_keywords_1364_1995.json
+begin_keywords_1364_2001	vvp_tests/begin_keywords_1364_2001.json
+begin_keywords_1364_2001_noconfig	vvp_tests/begin_keywords_1364_2001_noconfig.json
+begin_keywords_1364_2005	vvp_tests/begin_keywords_1364_2005.json
+begin_keywords_1800_2005	vvp_tests/begin_keywords_1800_2005.json
+begin_keywords_1800_2009	vvp_tests/begin_keywords_1800_2009.json
+begin_keywords_1800_2012	vvp_tests/begin_keywords_1800_2012.json
+begin_keywords_1800_2017	vvp_tests/begin_keywords_1800_2017.json
+begin_keywords_1800_2023	vvp_tests/begin_keywords_1800_2023.json
+begin_keywords_vams_2_3	vvp_tests/begin_keywords_vams_2_3.json
 bits4				vvp_tests/bits4.json
 bitsel11			vvp_tests/bitsel11.json
 br_gh13a			vvp_tests/br_gh13a.json

--- a/ivtest/vlog95_reg.pl
+++ b/ivtest/vlog95_reg.pl
@@ -4,7 +4,7 @@
 #
 # This script is based on code with the following Copyright.
 #
-# Copyright (c) 1999-2025 Guy Hutchison (ghutchis@pacbell.net)
+# Copyright (c) 1999-2026 Guy Hutchison (ghutchis@pacbell.net)
 #
 #    This source code is free software; you can redistribute it
 #    and/or modify it in source code form under the terms of the GNU
@@ -183,6 +183,8 @@ sub execute_regression {
         $args{$tname} =~ s/-g2005(-sv)?//g;
         $args{$tname} =~ s/-g2009//g;
         $args{$tname} =~ s/-g2012//g;
+        $args{$tname} =~ s/-g2017//g;
+        $args{$tname} =~ s/-g2023//g;
         $args{$tname} =~ s/-gverilog-ams//g;
         $cmd = "iverilog$sfx -o vsim $gen_flag $args{$tname}";
         $cmd .= " -s $testmod{$tname}" if ($testmod{$tname} ne "");

--- a/ivtest/vvp_reg.py
+++ b/ivtest/vvp_reg.py
@@ -64,7 +64,7 @@ def process_overrides(group: str, it_dict: dict, it_opts: dict):
 
 def force_gen(it_opts: dict):
     '''Remove the current generation and force it to the latest.'''
-    generations = ['-g2012', '-g2009', '-g2005-sv',
+    generations = ['-g2023', '-g2017', '-g2012', '-g2009', '-g2005-sv',
                    '-g2005', '-g2001-noconfig', '-g2001', '-g1995',
                    '-g2', '-g1']
     for gen in generations:
@@ -75,7 +75,7 @@ def force_gen(it_opts: dict):
         idx_to_replace = it_opts['iverilog_args'].index('-g2x')
         it_opts[idx_to_replace] = '-gicarus-misc'
 
-    it_opts['iverilog_args'].insert(0, '-g2012')
+    it_opts['iverilog_args'].insert(0, '-g2023')
 
 
 def process_test(item: list, cfg: list) -> str:

--- a/ivtest/vvp_tests/begin_keywords_1364_1995.json
+++ b/ivtest/vvp_tests/begin_keywords_1364_1995.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1364_1995.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1364_2001.json
+++ b/ivtest/vvp_tests/begin_keywords_1364_2001.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1364_2001.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1364_2001_noconfig.json
+++ b/ivtest/vvp_tests/begin_keywords_1364_2001_noconfig.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1364_2001_noconfig.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1364_2005.json
+++ b/ivtest/vvp_tests/begin_keywords_1364_2005.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1364_2005.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1800_2005.json
+++ b/ivtest/vvp_tests/begin_keywords_1800_2005.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1800_2005.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1800_2009.json
+++ b/ivtest/vvp_tests/begin_keywords_1800_2009.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1800_2009.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1800_2012.json
+++ b/ivtest/vvp_tests/begin_keywords_1800_2012.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1800_2012.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1800_2017.json
+++ b/ivtest/vvp_tests/begin_keywords_1800_2017.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1800_2017.v",
+    "iverilog-args" : [ "-g2017" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_1800_2023.json
+++ b/ivtest/vvp_tests/begin_keywords_1800_2023.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_1800_2023.v",
+    "iverilog-args" : [ "-g2023" ]
+}

--- a/ivtest/vvp_tests/begin_keywords_vams_2_3.json
+++ b/ivtest/vvp_tests/begin_keywords_vams_2_3.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "begin_keywords_vams_2_3.v",
+    "iverilog-args" : [ "-g2005-sv", "-gverilog-ams" ]
+}

--- a/lexor.lex
+++ b/lexor.lex
@@ -789,7 +789,9 @@ TU [munpf]
 		                |GN_KEYWORDS_1364_2005
 		                |GN_KEYWORDS_1800_2005
 		                |GN_KEYWORDS_1800_2009;
-      } else if (strcmp(word,"1800-2012") == 0) {
+      } else if (strcmp(word,"1800-2012") == 0
+              || strcmp(word,"1800-2017") == 0
+              || strcmp(word,"1800-2023") == 0) {
 	    lexor_keyword_mask = GN_KEYWORDS_1364_1995
 		                |GN_KEYWORDS_1364_2001
 		                |GN_KEYWORDS_1364_2001_CONFIG

--- a/main.cc
+++ b/main.cc
@@ -323,6 +323,12 @@ static void process_generation_flag(const char*gen)
       } else if (strcmp(gen,"2012") == 0) {
 	    generation_flag = GN_VER2012;
 
+      } else if (strcmp(gen,"2017") == 0) {
+	    generation_flag = GN_VER2017;
+
+      } else if (strcmp(gen,"2023") == 0) {
+	    generation_flag = GN_VER2023;
+
       } else if (strcmp(gen,"icarus-misc") == 0) {
 	    gn_icarus_misc_flag = true;
 
@@ -1058,6 +1064,8 @@ int main(int argc, char*argv[])
 
       lexor_keyword_mask = 0;
       switch (generation_flag) {
+        case GN_VER2023:
+        case GN_VER2017:
         case GN_VER2012:
 	  lexor_keyword_mask |= GN_KEYWORDS_1800_2012;
 	  // fallthrough
@@ -1112,6 +1120,12 @@ int main(int argc, char*argv[])
 		  break;
 		case GN_VER2012:
 		  cout << "IEEE1800-2012";
+		  break;
+		case GN_VER2017:
+		  cout << "IEEE1800-2017";
+		  break;
+		case GN_VER2023:
+		  cout << "IEEE1800-2023";
 		  break;
 	    }
 


### PR DESCRIPTION
Add flags to enable IEEE1800-2017 and IEEE1800-2023 languages generations and also support them in the `begin_keywords macro. Since neither defines new keywords they'll use the same keyword mask as 2012.

Update the driver, compiler, documentation and regression test harness so -g2017 and -g2023 are recognized as language generation flags.

There are no specific features from these versions added yet, this is just the necessary infrastructure to allow gating new features from those generations when they are added later.

Add regression tests that check for each language generation that the `begin_keywords value is supported. The tests do not check that only the right subset of keywords is supported though since that would get exhaustive.