### PR TITLE
Handle single element static unpacked array assignments

### DIFF
--- a/elab_net.cc
+++ b/elab_net.cc
@@ -625,6 +625,9 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
       // array word assignment.
       bool widx_flag = false;
 
+      // Whether the signal is an array
+      const bool sig_is_array = sig->unpacked_dimensions() > 0;
+
       // Detect the net is a structure and there was a method path
       // detected. We have already broken the path_ into the path to
       // the net, and the path of member names. For example, if the
@@ -760,7 +763,7 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
 		  }
 	    }
 
-      } else if (gn_system_verilog() && sig->unpacked_dimensions() > 0 && path_tail.index.empty()) {
+      } else if (gn_system_verilog() && sig_is_array && path_tail.index.empty()) {
 
 	      // In this case, we are doing a continuous assignment to
 	      // an unpacked array. The NetNet representation is a
@@ -770,15 +773,14 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
 	      // This can come up from code like this:
 	      //   logic [...] data [0:3];
 	      //   assign data = ...;
-	      // In this case, "sig" is "data", and sig->pin_count()
-	      // is 4 to account for the unpacked size.
+	      // In this case, "sig" is "data".
 	    if (debug_elaborate) {
 		  cerr << get_fileline() << ": PEIdent::elaborate_lnet_common_: "
 		       << "Net assign to unpacked array \"" << sig->name()
 		       << "\" with " << sig->pin_count() << " elements." << endl;
 	    }
 
-      } else if (sig->unpacked_dimensions() > 0) {
+      } else if (sig_is_array) {
 
 	    list<long> unpacked_indices_const;
 
@@ -940,7 +942,7 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
 	    }
       }
 
-      if (sig->pin_count() > 1 && widx_flag) {
+      if (sig_is_array && widx_flag) {
 	    if (widx < 0 || widx >= (long) sig->pin_count())
 		  return 0;
 	    NetNet*tmp = new NetNet(scope, scope->local_symbol(),
@@ -950,7 +952,7 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
 	    connect(sig->pin(widx), tmp->pin(0));
 	    sig = tmp;
 
-      } else if (sig->pin_count() > 1) {
+      } else if (sig_is_array) {
 
 	      // If this turns out to be an l-value unpacked array,
 	      // then let the caller handle it. It will probably be

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -135,7 +135,7 @@ void PGAssign::elaborate(Design*des, NetScope*scope) const
 
 	// If this turns out to be an assignment to an unpacked array,
 	// then handle that special case elsewhere.
-      if (lval->pin_count() > 1) {
+      if (lval->unpacked_dimensions() > 0) {
 	    elaborate_unpacked_array_(des, scope, lval);
 	    return;
       }

--- a/ivtest/ivltests/sv_ap_uarray_single1.v
+++ b/ivtest/ivltests/sv_ap_uarray_single1.v
@@ -1,0 +1,27 @@
+// Check that procedural assignment of unpacked array assignment patterns to
+// single element arrays is supported.
+
+module test;
+
+  reg failed;
+  integer a[0:0];
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    a = '{42};
+
+    `check(a[0], 42);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_ap_uarray_single2.v
+++ b/ivtest/ivltests/sv_ap_uarray_single2.v
@@ -1,0 +1,28 @@
+// Check that continuous assignment of unpacked array assignment patterns to
+// single element arrays is supported.
+
+module test;
+
+  reg failed;
+  integer a[0:0];
+
+  assign a = '{42};
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    #1;
+    `check(a[0], 42);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_array_assign_single_fail1.v
+++ b/ivtest/ivltests/sv_array_assign_single_fail1.v
@@ -1,0 +1,13 @@
+// Check that scalar expressions can not be procedurally assigned to single
+// element unpacked arrays.
+
+module test;
+
+  integer a[0:0];
+
+  initial begin
+    a = 1;
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_array_cassign_single.v
+++ b/ivtest/ivltests/sv_array_cassign_single.v
@@ -1,0 +1,30 @@
+// Check that continuous array assignment to single element unpacked arrays is
+// supported.
+
+module test;
+
+  reg failed;
+  wire [31:0] a[0:0];
+  reg [31:0] b[0:0];
+
+  assign a = b;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    b[0] = 32'd42;
+    #1;
+    `check(a[0], 32'd42);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_array_cassign_single_fail1.v
+++ b/ivtest/ivltests/sv_array_cassign_single_fail1.v
@@ -1,0 +1,10 @@
+// Check that scalar expressions can not be continuously assigned to single
+// element unpacked arrays.
+
+module test;
+
+  wire [31:0] a[0:0];
+
+  assign a = 1;
+
+endmodule

--- a/ivtest/ivltests/sv_lval_concat_uarray1.v
+++ b/ivtest/ivltests/sv_lval_concat_uarray1.v
@@ -1,0 +1,29 @@
+// Check that single element static unpacked array elements can be used in
+// procedural l-value concatenations.
+
+module test;
+
+  reg failed;
+  reg [7:0] a[0:0];
+  reg [7:0] y;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %h, got %h", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    y = 8'h78;
+    {a[0]} = y;
+
+    `check(a[0], 8'h78);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_lval_concat_uarray2.v
+++ b/ivtest/ivltests/sv_lval_concat_uarray2.v
@@ -1,0 +1,30 @@
+// Check that single element static unpacked array elements can be used in
+// continuous l-value concatenations.
+
+module test;
+
+  reg failed;
+  wire [7:0] a[0:0];
+  reg [7:0] y;
+
+  assign {a[0]} = y;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %h, got %h", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    y = 8'h78;
+    #1;
+    `check(a[0], 8'h78);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -233,12 +233,17 @@ sv_ap_uarray5			vvp_tests/sv_ap_uarray5.json
 sv_ap_uarray6			vvp_tests/sv_ap_uarray6.json
 sv_ap_uarray_fail1		vvp_tests/sv_ap_uarray_fail1.json
 sv_ap_uarray_fail2		vvp_tests/sv_ap_uarray_fail2.json
+sv_ap_uarray_single1		vvp_tests/sv_ap_uarray_single1.json
+sv_ap_uarray_single2		vvp_tests/sv_ap_uarray_single2.json
 sv_argumentless_func		vvp_tests/sv_argumentless_func.json
 sv_array_assign_fail1	vvp_tests/sv_array_assign_fail1.json
 sv_array_assign_fail2	vvp_tests/sv_array_assign_fail2.json
+sv_array_assign_single_fail1	vvp_tests/sv_array_assign_single_fail1.json
 sv_array_cassign6		vvp_tests/sv_array_cassign6.json
 sv_array_cassign7		vvp_tests/sv_array_cassign7.json
 sv_array_cassign8		vvp_tests/sv_array_cassign8.json
+sv_array_cassign_single	vvp_tests/sv_array_cassign_single.json
+sv_array_cassign_single_fail1	vvp_tests/sv_array_cassign_single_fail1.json
 sv_automatic_2state		vvp_tests/sv_automatic_2state.json
 sv_byte_array_string1		vvp_tests/sv_byte_array_string1.json
 sv_byte_array_string2		vvp_tests/sv_byte_array_string2.json
@@ -321,6 +326,8 @@ sv_lval_concat_string_fail1	vvp_tests/sv_lval_concat_string_fail1.json
 sv_lval_concat_string_fail2	vvp_tests/sv_lval_concat_string_fail2.json
 sv_lval_concat_string_fail3	vvp_tests/sv_lval_concat_string_fail3.json
 sv_lval_concat_string_fail4	vvp_tests/sv_lval_concat_string_fail4.json
+sv_lval_concat_uarray1		vvp_tests/sv_lval_concat_uarray1.json
+sv_lval_concat_uarray2		vvp_tests/sv_lval_concat_uarray2.json
 sv_lval_concat_uarray_fail1	vvp_tests/sv_lval_concat_uarray_fail1.json
 sv_lval_concat_uarray_fail2	vvp_tests/sv_lval_concat_uarray_fail2.json
 sv_lval_concat_uarray_fail3	vvp_tests/sv_lval_concat_uarray_fail3.json

--- a/ivtest/vvp_tests/sv_ap_uarray_single1.json
+++ b/ivtest/vvp_tests/sv_ap_uarray_single1.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray_single1.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment" : "Array nets are not supported",
+        "type"      : "CE"
+    }
+}

--- a/ivtest/vvp_tests/sv_ap_uarray_single2.json
+++ b/ivtest/vvp_tests/sv_ap_uarray_single2.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_ap_uarray_single2.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment" : "Array nets are not supported",
+        "type"      : "CE"
+    }
+}

--- a/ivtest/vvp_tests/sv_array_assign_single_fail1.json
+++ b/ivtest/vvp_tests/sv_array_assign_single_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_array_assign_single_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_array_cassign_single.json
+++ b/ivtest/vvp_tests/sv_array_cassign_single.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_array_cassign_single.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment" : "Array nets are not supported",
+        "type"      : "CE"
+    }
+}

--- a/ivtest/vvp_tests/sv_array_cassign_single_fail1.json
+++ b/ivtest/vvp_tests/sv_array_cassign_single_fail1.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_array_cassign_single_fail1.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_lval_concat_uarray1.json
+++ b/ivtest/vvp_tests/sv_lval_concat_uarray1.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_lval_concat_uarray1.v"
+}

--- a/ivtest/vvp_tests/sv_lval_concat_uarray2.json
+++ b/ivtest/vvp_tests/sv_lval_concat_uarray2.json
@@ -1,0 +1,8 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_lval_concat_uarray2.v",
+    "vlog95" : {
+        "__comment" : "Array nets are not supported",
+        "type"      : "CE"
+    }
+}


### PR DESCRIPTION
Currently single element static unpacked arrays are not always treated as unpacked arrays when elaborating assignment l-values. The net only has one pin, so checks using `pin_count() > 1` treat the array as a scalar value and skip the unpacked array path.

Use `unpacked_dimensions() > 0` instead of `pin_count() > 1` when checking whether a signal is an unpacked array. This lets single element arrays follow the same l-value elaboration paths as other unpacked arrays.