### PR TITLE
iverilog: add command line option -BI and -Bt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,22 @@ AC_SUBST(EXEEXT)
 # Combined check for Microsoft-related bogosities; sets WIN32 if found
 AX_WIN32
 
+# detect msys shell
+AC_MSG_CHECKING([whether the shell is an MSYS2 runtime shell])
+
+AS_CASE([$host_os:$MSYSTEM],
+  [*mingw*:UCRT64|*mingw*:MINGW64|*mingw*:MINGW32|*mingw*:CLANG64], [
+    MSYS_SHELL=true
+    msys_shell_result=yes
+  ],
+  [
+    MSYS_SHELL=false
+    msys_shell_result=no
+  ]
+)
+AC_MSG_RESULT([$msys_shell_result])
+AC_SUBST([MSYS_SHELL])
+
 # Check to see if we are using the Sun compiler. If so then configure
 # some of the flags to match the Sun compiler syntax. This is also used
 # in the aclocal.m4 file to configure the flags used to build and link

--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -17,12 +17,18 @@
 #
 SHELL = /bin/sh
 
+EXEEXT = @EXEEXT@
+ENV_VVP=@ENV_VVP@
+MSYS_SHELL=@MSYS_SHELL@
+
 suffix = @install_suffix@
 
 prefix = @prefix@
 exec_prefix = @exec_prefix@
 srcdir = @srcdir@
 datarootdir = @datarootdir@
+builddir=@builddir@
+top_builddir=@top_builddir@
 
 VPATH = $(srcdir)
 
@@ -58,11 +64,25 @@ O = main.o substit.o cflexor.o cfparse.o
 all: dep iverilog@EXEEXT@ iverilog.man
 
 check: all
+	@if $(MSYS_SHELL); then \
+		echo "iverilog: execution from a build directory not suppported for this runtime"; \
+	else \
+		echo "iverilog: create .vpp from .v file and run it"; \
+		$(builddir)/iverilog@EXEEXT@ \
+			-B$(top_builddir)/tgt-vvp \
+			-BI$(top_builddir) \
+			-BM$(top_builddir)/vpi \
+			-BP$(top_builddir)/ivlpp \
+			-Bt$(top_builddir)/tgt-vvp \
+			$(verbose) -o top.vvp -s top $(srcdir)/hello_world.v; \
+		$(ENV_VVP) $(top_builddir)/vvp/vvp$(suffix)@EXEEXT@ top.vvp; \
+	fi
 
 clean:
 	rm -f *.o cflexor.c cfparse.c cfparse.h cfparse.output
 	rm -f iverilog@EXEEXT@ iverilog.man iverilog.pdf iverilog.ps
 	rm -rf dep
+	rm -f test.conf top.vvp
 
 distclean: clean
 	rm -f Makefile config.log

--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -82,7 +82,7 @@ clean:
 	rm -f *.o cflexor.c cfparse.c cfparse.h cfparse.output
 	rm -f iverilog@EXEEXT@ iverilog.man iverilog.pdf iverilog.ps
 	rm -rf dep
-	rm -f test.conf top.vvp
+	rm -f top.vvp
 
 distclean: clean
 	rm -f Makefile config.log

--- a/driver/hello_world.v
+++ b/driver/hello_world.v
@@ -1,0 +1,3 @@
+module top;
+    initial $display("Hello World!");
+endmodule

--- a/driver/iverilog.man.in
+++ b/driver/iverilog.man.in
@@ -4,7 +4,7 @@ iverilog - Icarus Verilog compiler
 
 .SH SYNOPSIS
 .B iverilog
-[\-EiRSuVv] [\-Bpath] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
+[\-EiRSuVv] [\-B[MPV]path] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
 [\-Pparameter=value] [\-pflag=value] [\-dname]
 [\-g1995\:|\-g2001\:|\-g2005\:|\-g2005-sv\:|\-g2009\:|\-g2012\:|\-g2017\:|\-g2023\:|\-g<feature>]
 [\-Iincludedir] [\-Lmoduledir] [\-mmodule] [\-M[mode=]file] [\-Nfile]
@@ -21,13 +21,28 @@ further processing. The main target is \fIvvp\fP for simulation.
 .SH OPTIONS
 \fIiverilog\fP accepts the following options:
 .TP 8
-.B -B\fIbase\fP
+.BI \-B path
 The \fIiverilog\fP program uses external programs and configuration
-files to preprocess and compile the Verilog source. Normally, the path
-used to locate these tools is built into the \fIiverilog\fP
-program. However, the \fB\-B\fP switch allows the user to select a
-different set of programs. The path given is used to locate
-\fIivlpp\fP, \fIivl\fP, code generators and the VPI modules.
+files to preprocess and compile Verilog source files. Normally, the
+paths used to locate these tools are built into the
+\fIiverilog\fP executable. The \fB\-B\fP option allows the user to
+override these paths.
+The specified path is used as the default base directory for locating
+\fIivlpp\fP, \fIivl\fP, code generators, configuration files, and
+VPI modules.
+Specialized forms of this option may be used to override individual
+tool paths:
+.RS
+.TP
+.BI \-BM path
+Directory for VPI modules.
+.TP
+.BI \-BP path
+Directory for the \fIivlpp\fP preprocessor.
+.TP
+.BI \-BV path
+Directory for the \fIvhdlpp\fP VHDL preprocessor.
+.RE
 .TP 8
 .B -c\fIfile\fP -f\fIfile\fP
 These flags specify an input file that contains a list of Verilog

--- a/driver/iverilog.man.in
+++ b/driver/iverilog.man.in
@@ -4,7 +4,7 @@ iverilog - Icarus Verilog compiler
 
 .SH SYNOPSIS
 .B iverilog
-[\-EiRSuVv] [\-B[IMPV]path] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
+[\-EiRSuVv] [\-B[IMPVt]path] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
 [\-Pparameter=value] [\-pflag=value] [\-dname]
 [\-g1995\:|\-g2001\:|\-g2005\:|\-g2005-sv\:|\-g2009\:|\-g2012\:|\-g2017\:|\-g2023\:|\-g<feature>]
 [\-Iincludedir] [\-Lmoduledir] [\-mmodule] [\-M[mode=]file] [\-Nfile]
@@ -45,6 +45,11 @@ Directory for the \fIivlpp\fP preprocessor.
 .TP
 .BI \-BV path
 Directory for the \fIvhdlpp\fP VHDL preprocessor.
+.TP
+.BI \-Bt path
+Directory used to locate target configuration files for the
+\fB\-t\fP\fItarget\fP option. The configuration file name is
+\fItarget\fP.conf.
 .RE
 .TP 8
 .B -c\fIfile\fP -f\fIfile\fP

--- a/driver/iverilog.man.in
+++ b/driver/iverilog.man.in
@@ -4,7 +4,7 @@ iverilog - Icarus Verilog compiler
 
 .SH SYNOPSIS
 .B iverilog
-[\-EiRSuVv] [\-B[MPV]path] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
+[\-EiRSuVv] [\-B[IMPV]path] [\-ccmdfile|\-fcmdfile] [\-Dmacro[=defn]]
 [\-Pparameter=value] [\-pflag=value] [\-dname]
 [\-g1995\:|\-g2001\:|\-g2005\:|\-g2005-sv\:|\-g2009\:|\-g2012\:|\-g2017\:|\-g2023\:|\-g<feature>]
 [\-Iincludedir] [\-Lmoduledir] [\-mmodule] [\-M[mode=]file] [\-Nfile]
@@ -33,6 +33,9 @@ VPI modules.
 Specialized forms of this option may be used to override individual
 tool paths:
 .RS
+.TP
+.BI \-BI path
+Directory for the \fIivl\fP parser.
 .TP
 .BI \-BM path
 Directory for VPI modules.

--- a/driver/main.c
+++ b/driver/main.c
@@ -38,7 +38,7 @@ const char NOTICE[] =
 ;
 
 const char HELP[] =
-"Usage: iverilog [-EiRSuvV] [-B[IMPV] base] [-c cmdfile|-f cmdfile]\n"
+"Usage: iverilog [-EiRSuvV] [-B[IMPVt] base] [-c cmdfile|-f cmdfile]\n"
 "                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012|-g2017|-g2023] [-g<feature>]\n"
 "                [-D macro[=defn]] [-I includedir] [-L moduledir]\n"
 "                [-M [mode=]depfile] [-m module]\n"
@@ -112,6 +112,7 @@ extern void cfreset(FILE*fd, const char*path);
 
 const char*base = 0;
 const char*vpi_dir = 0;
+const char*tconfig_dir = 0;
 const char*ivl_dir = 0;
 const char*ivlpp_dir = 0;
 const char*vhdlpp_dir= 0;
@@ -1237,6 +1238,9 @@ int main(int argc, char **argv)
 		      case 'V': /* Path for the vhdlpp VHDL processor */
 			vhdlpp_dir = optarg+1;
 			break;
+		      case 't': /* Path to target.conf for the -ttarget option */
+			tconfig_dir = optarg+1;
+			break;
 		      default: /* Otherwise, this is a default base. */
 			base=optarg;
 			break;
@@ -1383,6 +1387,8 @@ int main(int argc, char **argv)
 	    ivl_dir = base;
       if (vhdlpp_dir == 0)
 	    vhdlpp_dir = base;
+      if (tconfig_dir == 0)
+	    tconfig_dir = base;
 
       if (version_flag || verbose_flag) {
 	    printf("Icarus Verilog version " VERSION " (" VERSION_TAG ")\n\n");
@@ -1392,7 +1398,7 @@ int main(int argc, char **argv)
 
 	/* Make a common conf file path to reflect the target. */
       snprintf(iconfig_common_path, sizeof iconfig_common_path, "%s%c%s%s.conf",
-	      base, sep, targ, synth_flag? "-s" : "");
+	      tconfig_dir, sep, targ, synth_flag? "-s" : "");
 
 	/* Write values to the iconfig file. */
       fprintf(iconfig_file, "basedir:%s\n", base);

--- a/driver/main.c
+++ b/driver/main.c
@@ -38,7 +38,7 @@ const char NOTICE[] =
 ;
 
 const char HELP[] =
-"Usage: iverilog [-EiRSuvV] [-B base] [-c cmdfile|-f cmdfile]\n"
+"Usage: iverilog [-EiRSuvV] [-B[MPV] base] [-c cmdfile|-f cmdfile]\n"
 "                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012|-g2017|-g2023] [-g<feature>]\n"
 "                [-D macro[=defn]] [-I includedir] [-L moduledir]\n"
 "                [-M [mode=]depfile] [-m module]\n"

--- a/driver/main.c
+++ b/driver/main.c
@@ -38,7 +38,7 @@ const char NOTICE[] =
 ;
 
 const char HELP[] =
-"Usage: iverilog [-EiRSuvV] [-B[MPV] base] [-c cmdfile|-f cmdfile]\n"
+"Usage: iverilog [-EiRSuvV] [-B[IMPV] base] [-c cmdfile|-f cmdfile]\n"
 "                [-g1995|-g2001|-g2005|-g2005-sv|-g2009|-g2012|-g2017|-g2023] [-g<feature>]\n"
 "                [-D macro[=defn]] [-I includedir] [-L moduledir]\n"
 "                [-M [mode=]depfile] [-m module]\n"
@@ -112,6 +112,7 @@ extern void cfreset(FILE*fd, const char*path);
 
 const char*base = 0;
 const char*vpi_dir = 0;
+const char*ivl_dir = 0;
 const char*ivlpp_dir = 0;
 const char*vhdlpp_dir= 0;
 const char*vhdlpp_work = 0;
@@ -340,7 +341,7 @@ static int t_version_only(void)
       }
 
       fflush(0);
-      snprintf(tmp, sizeof tmp, "%s%civl -V -C\"%s\" -C\"%s\"", base, sep,
+      snprintf(tmp, sizeof tmp, "%s%civl -V -C\"%s\" -C\"%s\"", ivl_dir, sep,
 	       iconfig_path, iconfig_common_path);
       rc = system(tmp);
       if (rc != 0) {
@@ -447,7 +448,7 @@ static int t_compile(void)
 #endif
 
 	/* Build the ivl command. */
-      snprintf(tmp, sizeof tmp, "%s%civl", base, sep);
+      snprintf(tmp, sizeof tmp, "%s%civl", ivl_dir, sep);
       rc = strlen(tmp);
       cmd = realloc(cmd, ncmd+rc+1);
       strcpy(cmd+ncmd, tmp);
@@ -1224,6 +1225,9 @@ int main(int argc, char **argv)
 		       character of the path indicates which path the
 		       user is specifying. */
 		  switch (optarg[0]) {
+		      case 'I': /* Path for the ivl parser */
+			ivl_dir = optarg+1;
+			break;
 		      case 'M': /* Path for the VPI modules */
 			vpi_dir = optarg+1;
 			break;
@@ -1375,6 +1379,8 @@ int main(int argc, char **argv)
 	    vpi_dir = base;
       if (ivlpp_dir == 0)
 	    ivlpp_dir = base;
+      if (ivl_dir == 0)
+	    ivl_dir = base;
       if (vhdlpp_dir == 0)
 	    vhdlpp_dir = base;
 


### PR DESCRIPTION
This PR added the command-line options mentioned above and updated the documentation for them and for the previously missing `-B<selector>` options.

In addition, a test was added to verify the new options in the `iverilog` program.

Fix #1370