### PR TITLE
NetEvWait: Don't delete event in destructor

### DIFF
--- a/ivtest/ivltests/nb_ec_array.v
+++ b/ivtest/ivltests/nb_ec_array.v
@@ -78,6 +78,23 @@ module top;
       pass = 1'b0;
     end
 
+    // These should execute as if there was no event control
+    result[0] <= repeat(0) @(posedge clk) 4'h4;
+    #1
+    if ($simtime != 171 || result[0] !== 4'h4) begin
+      $display("Failed @ at %0t, expected 4'h4, got %h",
+               $simtime, result[0]);
+      pass = 1'b0;
+    end
+
+    result[0] <= repeat(-1) @(posedge clk) 4'h5;
+    #1
+    if ($simtime != 172 || result[0] !== 4'h5) begin
+      $display("Failed @ at %0t, expected 4'h5, got %h",
+               $simtime, result[0]);
+      pass = 1'b0;
+    end
+
     if (pass) $display("PASSED");
     $finish;
   end

--- a/ivtest/ivltests/nb_ec_array_pv.v
+++ b/ivtest/ivltests/nb_ec_array_pv.v
@@ -81,6 +81,16 @@ module top;
       pass = 1'b0;
     end
 
+    // These should execute as if there was no event control
+    result[0][3:0] <= repeat(0) @(posedge clk) 4'h3;
+    result[0][7:4] <= repeat(-1) @(posedge clk) 4'h4;
+    #1
+    if ($simtime != 171 || result[0] !== 8'h43) begin
+      $display("Failed @ at %0t, expected 8'h43, got %h",
+               $simtime, result[0]);
+      pass = 1'b0;
+    end
+
     if (pass) $display("PASSED");
     $finish;
   end

--- a/ivtest/ivltests/nb_ec_array_pv2.v
+++ b/ivtest/ivltests/nb_ec_array_pv2.v
@@ -84,6 +84,16 @@ module top;
       pass = 1'b0;
     end
 
+    // These should execute as if there was no event control
+    result[j][i+:4] <= repeat(0) @(posedge clk) 4'h3;
+    result[j][i+4+:4] <= repeat(-1) @(posedge clk) 4'h4;
+    #1
+    if ($simtime != 171 || result[j] !== 8'h43) begin
+      $display("Failed @ at %0t, expected 8'h43, got %h",
+               $simtime, result[j]);
+      pass = 1'b0;
+    end
+
     if (pass) $display("PASSED");
     $finish;
   end

--- a/ivtest/ivltests/nb_ec_pv.v
+++ b/ivtest/ivltests/nb_ec_pv.v
@@ -78,6 +78,16 @@ module top;
       pass = 1'b0;
     end
 
+    // These should execute as if there was no event control
+    result[3:0] <= repeat(0) @(posedge clk) 4'h3;
+    result[7:4] <= repeat(-1) @(posedge clk) 4'h4;
+    #1
+    if ($simtime != 171 || result !== 8'h43) begin
+      $display("Failed @ at %0t, expected 8'h43, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
     if (pass) $display("PASSED");
     $finish;
   end

--- a/ivtest/ivltests/nb_ec_pv2.v
+++ b/ivtest/ivltests/nb_ec_pv2.v
@@ -5,6 +5,7 @@ module top;
   reg clk = 0;
   reg [7:0] result;
   reg [3:0] bit;
+  integer count;
 
   always #10 clk = ~clk;
 
@@ -12,6 +13,7 @@ module top;
     // Since the bit is not defined this assignment will not happen.
     // We will check to verify this fact 1 time step after it should
     // happen (50).
+    #0;
     result[bit] <= repeat(3) @(posedge clk) 1'b0;
     if ($simtime != 0 || result !== 8'bx) begin
       $display("Failed repeat(3) blocked at %0t, expected 8'hxx, got %h",
@@ -30,6 +32,41 @@ module top;
     @(result)
     if ($simtime != 70 || result !== 8'bxxxxxxx0) begin
       $display("Failed repeat(3) at %0t, expected 8'bxxxxxxx0, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
+    // These should execute as if there was no event control
+    count = 0;
+    result[bit] <= repeat(count) @(posedge clk) 1'b1;
+    #1
+    if ($simtime != 71 || result !== 8'bxxxxxxx1) begin
+      $display("Failed @ at %0t, expected 8'bxxxxxxx1, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
+    count = -1;
+    result[bit+1] <= repeat(count) @(posedge clk) 1'b0;
+    #1
+    if ($simtime != 72 || result !== 8'bxxxxxx01) begin
+      $display("Failed @ at %0t, expected 8'bxxxxxx01, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
+    result[bit+2] <= repeat(0) @(posedge clk) 1'b1;
+    #1
+    if ($simtime != 73 || result !== 8'bxxxxx101) begin
+      $display("Failed @ at %0t, expected 8'bxxxxx101, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
+    result[bit+3] <= repeat(-1) @(posedge clk) 1'b0;
+    #1
+    if ($simtime != 74 || result !== 8'bxxxx0101) begin
+      $display("Failed @ at %0t, expected 8'bxxxx0101, got %h",
                $simtime, result);
       pass = 1'b0;
     end

--- a/ivtest/ivltests/nb_ec_real.v
+++ b/ivtest/ivltests/nb_ec_real.v
@@ -78,6 +78,23 @@ module top;
       pass = 1'b0;
     end
 
+    // These should execute as if there was no event control
+    result <= repeat(0) @(posedge clk) 4.0;
+    #1
+    if ($simtime != 171 || result != 4.0) begin
+      $display("Failed @ at %0t, expected 4.0, got %f",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
+    result <= repeat(-1) @(posedge clk) 5.0;
+    #1
+    if ($simtime != 172 || result != 5.0) begin
+      $display("Failed @ at %0t, expected 5.0, got %f",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
     if (pass) $display("PASSED");
     $finish;
   end

--- a/ivtest/ivltests/nb_ec_vector.v
+++ b/ivtest/ivltests/nb_ec_vector.v
@@ -78,6 +78,23 @@ module top;
       pass = 1'b0;
     end
 
+    // These should execute as if there was no event control
+    result <= repeat(0) @(posedge clk) 4'h4;
+    #1
+    if ($simtime != 171 || result !== 4'h4) begin
+      $display("Failed @ at %0t, expected 4'h4, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
+    result <= repeat(-1) @(posedge clk) 4'h5;
+    #1
+    if ($simtime != 172 || result !== 4'h5) begin
+      $display("Failed @ at %0t, expected 4'h5, got %h",
+               $simtime, result);
+      pass = 1'b0;
+    end
+
     if (pass) $display("PASSED");
     $finish;
   end

--- a/net_event.cc
+++ b/net_event.cc
@@ -407,7 +407,6 @@ NetEvWait::~NetEvWait()
 			tmp->next = tmp->next->next;
 			delete tmp;
 		  }
-		  delete tgt;
 	    }
 	    events_.clear();
       }


### PR DESCRIPTION
`NetEvWait` deletes the event that is assigned to it when itself is deleted. But the event is not owned by the `NetEvWait`, it is shared among all consumers of the event. Deleting it when the `NetEvWait` is deleted can result in undefined behavior.

This is mainly a problem for non-blocking event control assignments with a zero or negative immediate valued repeat. In this case the `NetEvWait` will be deleted as it is not needed.

```verilog
reg x;
event e;
x <= repeat(1) @e 1'b0;
x <= repeat(0) @e 1'b1; // Assert triggered since in-use event is freed
```

Remove the delete to fix this. Events that end up being unused will be freed by the nodangle functor.