### PR TITLE
Ignore configure generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,17 +35,19 @@ Makefile
 /_pli_types.h
 config.h
 /tgt-pcb/pcb_config.h
-/tgt-pcb/fp.cc
-/tgt-pcb/fp.h
-/tgt-pcb/fp.output
-/tgt-pcb/fp_lex.cc
 /tgt-vvp/vvp_config.h
 /tgt-vhdl/vhdl_config.h
+/vhdlpp/vhdlpp_config.h
 /vpi/vpi_config.h
 stamp-*-h
-/version.h
 /version_tag.h
 /version_base.h
+
+/driver-vpi/iverilog-vpi.man
+/driver-vpi/res.rc
+/driver/iverilog.man
+/vvp/libvvp.pc
+/vvp/vvp.man
 
 # Directories
 autom4te.cache
@@ -57,8 +59,6 @@ dep
 *.vpi
 /cadpli/cadpli.vpl
 
-/tgt-blif/Makefile
-
 # lex, yacc and gperf output
 /driver/cflexor.c
 /driver/cfparse.c
@@ -67,14 +67,6 @@ dep
 
 /ivlpp/lexor.c
 
-/vhdlpp/lexor.cc
-/vhdlpp/lexor_keyword.cc
-/vhdlpp/parse.cc
-/vhdlpp/parse.h
-/vhdlpp/parse.output
-/vhdlpp/vhdlpp_config.h
-/vhdlpp/vhdlpp
-
 /lexor.cc
 /lexor_keyword.cc
 /parse.cc
@@ -82,6 +74,17 @@ dep
 /parse.output
 /syn-rules.cc
 /syn-rules.output
+
+/tgt-pcb/fp.cc
+/tgt-pcb/fp.h
+/tgt-pcb/fp.output
+/tgt-pcb/fp_lex.cc
+
+/vhdlpp/lexor.cc
+/vhdlpp/lexor_keyword.cc
+/vhdlpp/parse.cc
+/vhdlpp/parse.h
+/vhdlpp/parse.output
 
 /vpi/sdf_lexor.c
 /vpi/sdf_parse.c
@@ -95,7 +98,6 @@ dep
 
 /vvp/dump.*
 /vvp/lexor.cc
-/vvp/libvvp.pc
 /vvp/parse.cc
 /vvp/parse.h
 /vvp/parse.output
@@ -103,18 +105,13 @@ dep
 # Program created files
 /vvp/tables.cc
 
-/iverilog-vpi.man
-/driver-vpi/res.rc
-/driver-vpi/iverilog-vpi.man
-/driver/iverilog.man
-/vvp/vvp.man
-
 # The executables.
 *.exe
 /driver/iverilog
-/iverilog-vpi
+/driver-vpi/iverilog-vpi
 /ivl
 /ivlpp/ivlpp
+/vhdlpp/vhdlpp
 /vvp/vvp
 
 /ivl.exp
@@ -122,3 +119,4 @@ dep
 
 # Check output
 /check.vvp
+/driver/top.vvp

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ config.h
 stamp-*-h
 /version.h
 /version_tag.h
+/version_base.h
 
 # Directories
 autom4te.cache
@@ -94,6 +95,7 @@ dep
 
 /vvp/dump.*
 /vvp/lexor.cc
+/vvp/libvvp.pc
 /vvp/parse.cc
 /vvp/parse.h
 /vvp/parse.output
@@ -103,6 +105,7 @@ dep
 
 /iverilog-vpi.man
 /driver-vpi/res.rc
+/driver-vpi/iverilog-vpi.man
 /driver/iverilog.man
 /vvp/vvp.man
 


### PR DESCRIPTION
###  Description:

Some files and directories are generated automatically either by ./configure:

### Configure-generated files:

version_base.h – defines version macros for the build.
vvp/libvvp.pc – pkg-config file for the VVP runtime library.
driver-vpi/iverilog-vpi.man – man page for iverilog-vpi.

They clutter git status output and make it harder to see actual source code differences during development. They can also cause potential accidental commits, as I have personally experienced.

This PR updates .gitignore to exclude all these artifacts: