### PR TITLE
Evaluate queue method arguments in assignment-like contexts

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -47,6 +47,7 @@
 # include  "netenum.h"
 # include  "netvector.h"
 # include  "netdarray.h"
+# include  "netqueue.h"
 # include  "netparray.h"
 # include  "netscalar.h"
 # include  "netclass.h"
@@ -4099,19 +4100,7 @@ NetProc* PCallTask::elaborate_queue_method_(Design*des, NetScope*scope,
 		 << "() method requires a single argument." << endl;
 	    des->errors += 1;
       }
-
-	// Get the context width if this is a logic type.
-      ivl_variable_type_t base_type = net->darray_type()->element_base_type();
-      int context_width = -1;
-      switch (base_type) {
-	  case IVL_VT_BOOL:
-	  case IVL_VT_LOGIC:
-	    context_width = net->darray_type()->element_width();
-	    break;
-	  default:
-	    break;
-      }
-
+      ivl_type_t element_type = net->queue_type()->element_type();
       vector<NetExpr*>argv (nparms+1);
       argv[0] = sig;
 
@@ -4123,8 +4112,8 @@ NetProc* PCallTask::elaborate_queue_method_(Design*des, NetScope*scope,
 		       << "() methods first argument is missing." << endl;
 		  des->errors += 1;
 	    } else {
-		  argv[1] = elab_and_eval(des, scope, args[0], context_width,
-		                          false, false, base_type);
+		  argv[1] = elaborate_rval_expr(des, scope, element_type,
+						args[0]);
 	    }
       } else {
 	    if (nparms == 0 || !args[0]) {
@@ -4133,8 +4122,9 @@ NetProc* PCallTask::elaborate_queue_method_(Design*des, NetScope*scope,
 		       << "() methods first argument is missing." << endl;
 		  des->errors += 1;
 	    } else {
-		  argv[1] = elab_and_eval(des, scope, args[0], context_width,
-		                          false, false, IVL_VT_LOGIC);
+		  argv[1] = elaborate_rval_expr(des, scope,
+						netvector_t::integer_type(),
+						args[0]);
 	    }
 
 	    if (nparms < 2 || !args[1]) {
@@ -4143,8 +4133,8 @@ NetProc* PCallTask::elaborate_queue_method_(Design*des, NetScope*scope,
 		       << "() methods second argument is missing." << endl;
 		  des->errors += 1;
 	    } else {
-		  argv[2] = elab_and_eval(des, scope, args[1], context_width,
-		                          false, false, base_type);
+		  argv[2] = elaborate_rval_expr(des, scope, element_type,
+						args[1]);
 	    }
       }
 

--- a/ivtest/ivltests/sv_queue_ap_method.v
+++ b/ivtest/ivltests/sv_queue_ap_method.v
@@ -1,0 +1,33 @@
+// Check that assignment patterns are supported for queue method arguments.
+
+module test;
+
+  bit failed;
+  bit [1:0][3:0] q[$];
+
+  `define check(val, exp) do begin \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0h, got %0h", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  initial begin
+    failed = 1'b0;
+
+    q.push_back('{4'h1, 4'h2});
+    q.push_front('{4'h3, 4'h4});
+    q.insert(1, '{4'h5, 4'h6});
+
+    `check(q.size(), 3);
+    `check(q[0], 8'h34);
+    `check(q[1], 8'h56);
+    `check(q[2], 8'h12);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -349,6 +349,7 @@ sv_net_decl_assign		vvp_tests/sv_net_decl_assign.json
 sv_package_lifetime		vvp_tests/sv_package_lifetime.json
 sv_package_lifetime_fail	vvp_tests/sv_package_lifetime_fail.json
 sv_parameter_type		vvp_tests/sv_parameter_type.json
+sv_queue_ap_method		vvp_tests/sv_queue_ap_method.json
 sv_queue_assign_op		vvp_tests/sv_queue_assign_op.json
 sv_soft_packed_union		vvp_tests/sv_soft_packed_union.json
 sv_soft_packed_union_fail1	vvp_tests/sv_soft_packed_union_fail1.json

--- a/ivtest/vvp_tests/sv_queue_ap_method.json
+++ b/ivtest/vvp_tests/sv_queue_ap_method.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_queue_ap_method.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Queues are not supported",
+        "type"          : "CE"
+    }
+}


### PR DESCRIPTION
The arguments of the queue `push_front()`, `push_back()` and `insert()` methods are passed to subroutine input ports. This makes them assignment-like contexts with the declared argument type as target type.

Use `elaborate_rval_expr()` instead of `elab_and_eval()` for these arguments. This evaluates the item argument with the queue element type and the `insert()` index argument with `integer`, so target-type-dependent expressions such as assignment patterns work and enum compatibility checks use the queue element type.