### PR TITLE
Preserve function and final context in nested scopes

### DIFF
--- a/ivtest/ivltests/final_nested_block_task_fail.v
+++ b/ivtest/ivltests/final_nested_block_task_fail.v
@@ -1,0 +1,12 @@
+// Check that final context is preserved when elaborating nested blocks.
+
+module test;
+
+  task t;
+  endtask
+
+  final begin : nested
+    t;
+  end
+
+endmodule

--- a/ivtest/ivltests/func_nested_block_nb_fail.v
+++ b/ivtest/ivltests/func_nested_block_nb_fail.v
@@ -1,0 +1,21 @@
+// Check that function context is preserved when elaborating nested blocks.
+
+module test;
+
+  reg x;
+  integer y;
+
+  function integer f;
+    input a;
+    begin : nested
+      x <= a;
+      f = 0;
+    end
+  endfunction
+
+  initial begin
+    y = f(1'b1);
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -137,9 +137,11 @@ early_sig_elab3			vvp_tests/early_sig_elab3.json
 eofmt_percent			vvp_tests/eofmt_percent.json
 fdisplay3			vvp_tests/fdisplay3.json
 final3				vvp_tests/final3.json
+final_nested_block_task_fail	vvp_tests/final_nested_block_task_fail.json
 fmonitor1			vvp_tests/fmonitor1.json
 fmonitor2			vvp_tests/fmonitor2.json
 fread-error			vvp_tests/fread-error.json
+func_nested_block_nb_fail	vvp_tests/func_nested_block_nb_fail.json
 line_directive			vvp_tests/line_directive.json
 localparam_type			vvp_tests/localparam_type.json
 macro_str_esc			vvp_tests/macro_str_esc.json

--- a/ivtest/vvp_tests/final_nested_block_task_fail.json
+++ b/ivtest/vvp_tests/final_nested_block_task_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "final_nested_block_task_fail.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/func_nested_block_nb_fail.json
+++ b/ivtest/vvp_tests/func_nested_block_nb_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "func_nested_block_nb_fail.v"
+}

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -535,7 +535,24 @@ NetFuncDef* NetScope::func_def()
 
 bool NetScope::in_func() const
 {
-      return (type_ == FUNC) ? true : false;
+      if (type_ == FUNC)
+	    return true;
+
+      if (type_ == BEGIN_END || type_ == FORK_JOIN || type_ == GENBLOCK)
+	    return up_ ? up_->in_func() : false;
+
+      return false;
+}
+
+bool NetScope::in_final() const
+{
+      if (in_final_)
+	    return true;
+
+      if (type_ == BEGIN_END || type_ == FORK_JOIN || type_ == GENBLOCK)
+	    return up_ ? up_->in_final() : false;
+
+      return false;
 }
 
 const NetFuncDef* NetScope::func_def() const

--- a/netlist.h
+++ b/netlist.h
@@ -1193,7 +1193,7 @@ class NetScope : public Definitions, public Attrib {
 
         /* Is this scope elaborating a final procedure? */
       void in_final(bool in_final__) { in_final_ = in_final__; };
-      bool in_final() const { return in_final_; };
+      bool in_final() const;
 
       const NetTaskDef* task_def() const;
       const NetFuncDef* func_def() const;


### PR DESCRIPTION
Currently checks for statements that are not allowed in functions or final
procedures only inspect the immediate scope. If the statement is inside a
named block or a block with declarations, the current scope is the block and
the context is lost.

Make `NetScope::in_func()` and `NetScope::in_final()` preserve the context
through begin-end, fork-join and generate block scopes. Other scope types are
treated as context boundaries so function and final state does not leak across
subroutine or definition scopes.