### PR TITLE
elab: Elaborate enum types in generate scopes

### DIFF
--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -1322,6 +1322,8 @@ void PGenerate::elaborate_subscope_(Design*des, NetScope*scope)
 
       collect_scope_signals(scope, wires);
 
+      elaborate_scope_enumerations(des, scope, enum_sets);
+
 	// Run through the defparams for this scope and save the result
 	// in a table for later final override.
 
@@ -1662,6 +1664,8 @@ void PFunction::elaborate_scope(Design*des, NetScope*scope) const
 
       collect_scope_signals(scope, wires);
 
+      elaborate_scope_enumerations(des, scope, enum_sets);
+
 	// Scan through all the named events in this scope.
       elaborate_scope_events_(des, scope, events);
 
@@ -1681,6 +1685,8 @@ void PTask::elaborate_scope(Design*des, NetScope*scope) const
       collect_scope_parameters(des, scope, parameters);
 
       collect_scope_signals(scope, wires);
+
+      elaborate_scope_enumerations(des, scope, enum_sets);
 
 	// Scan through all the named events in this scope.
       elaborate_scope_events_(des, scope, events);
@@ -1731,6 +1737,8 @@ void PBlock::elaborate_scope(Design*des, NetScope*scope) const
             collect_scope_parameters(des, my_scope, parameters);
 
 	    collect_scope_signals(my_scope, wires);
+
+	    elaborate_scope_enumerations(des, my_scope, enum_sets);
 
               // Scan through all the named events in this scope.
             elaborate_scope_events_(des, my_scope, events);

--- a/ivtest/ivltests/br_gh1385.v
+++ b/ivtest/ivltests/br_gh1385.v
@@ -1,0 +1,39 @@
+// Check that enum literals declared inside generate blocks are available in
+// the generated scope.
+
+module test;
+
+  reg failed;
+
+  `define check(val, exp) do begin \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  if (1) begin : g
+    typedef enum logic [3:0] {
+      A = 4'd1,
+      B = 4'd2
+    } EN_T;
+
+    EN_T e = A;
+
+    initial begin
+      failed = 1'b0;
+
+      #1;
+      `check(e, A);
+
+      e = B;
+      `check(e, B);
+
+      if (!failed) begin
+        $display("PASSED");
+      end
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/br_gh1385a.v
+++ b/ivtest/ivltests/br_gh1385a.v
@@ -1,0 +1,37 @@
+// Check that enum literals declared inside named blocks are available in
+// the block scope.
+
+module test;
+
+  reg failed;
+
+  `define check(val, exp) do begin \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  initial begin : b
+    typedef enum logic [3:0] {
+      A = 4'd1,
+      B = 4'd2
+    } EN_T;
+
+    static EN_T e = A;
+
+    failed = 1'b0;
+
+    #1;
+    `check(e, A);
+
+    e = B;
+    `check(e, B);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/br_gh1385b.v
+++ b/ivtest/ivltests/br_gh1385b.v
@@ -1,0 +1,41 @@
+// Check that enum literals declared inside tasks are available in the task
+// scope.
+
+module test;
+
+  reg failed;
+
+  `define check(val, exp) do begin \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  task check_task_enum;
+    typedef enum logic [3:0] {
+      A = 4'd1,
+      B = 4'd2
+    } EN_T;
+
+    static EN_T e = A;
+
+    `check(e, A);
+
+    e = B;
+    `check(e, B);
+  endtask
+
+  initial begin
+    failed = 1'b0;
+
+    #1;
+    check_task_enum();
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/br_gh1385c.v
+++ b/ivtest/ivltests/br_gh1385c.v
@@ -1,0 +1,39 @@
+// Check that enum literals declared inside functions are available in the
+// function scope.
+
+module test;
+
+  reg failed;
+
+  `define check(val, exp) do begin \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end \
+  end while (0)
+
+  function logic [3:0] check_func_enum;
+    typedef enum logic [3:0] {
+      A = 4'd1,
+      B = 4'd2
+    } EN_T;
+
+    static EN_T e = A;
+
+    e = B;
+    check_func_enum = e;
+  endfunction
+
+  initial begin
+    failed = 1'b0;
+
+    #1;
+    `check(check_func_enum(), 4'd2);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -82,6 +82,10 @@ br_gh1258a			vvp_tests/br_gh1258a.json
 br_gh1258b			vvp_tests/br_gh1258b.json
 br_gh1286			vvp_tests/br_gh1286.json
 br_gh1323			vvp_tests/br_gh1323.json
+br_gh1385			vvp_tests/br_gh1385.json
+br_gh1385a			vvp_tests/br_gh1385a.json
+br_gh1385b			vvp_tests/br_gh1385b.json
+br_gh1385c			vvp_tests/br_gh1385c.json
 ca_time_real			vvp_tests/ca_time_real.json
 case1				vvp_tests/case1.json
 case2				vvp_tests/case2.json

--- a/ivtest/vvp_tests/br_gh1385.json
+++ b/ivtest/vvp_tests/br_gh1385.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "br_gh1385.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Generate scopes are not translated",
+        "type"          : "CE"
+    }
+}

--- a/ivtest/vvp_tests/br_gh1385a.json
+++ b/ivtest/vvp_tests/br_gh1385a.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "br_gh1385a.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Enum typedefs are not translated",
+        "type"          : "CE"
+    }
+}

--- a/ivtest/vvp_tests/br_gh1385b.json
+++ b/ivtest/vvp_tests/br_gh1385b.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "br_gh1385b.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Enum typedefs are not translated",
+        "type"          : "CE"
+    }
+}

--- a/ivtest/vvp_tests/br_gh1385c.json
+++ b/ivtest/vvp_tests/br_gh1385c.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "br_gh1385c.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Enum typedefs are not translated",
+        "type"          : "CE"
+    }
+}


### PR DESCRIPTION
Enum types declared inside nested scopes are stored separately from typedefs. The enum sets need to be elaborated when the `NetScope` is created so enum literals are available for declarations and statements in the same scope.

Module, package and class scopes already do this. Generate, task, function and named block scopes can also declare enum typedefs, but did not elaborate their enum sets. Elaborate them while setting up these scopes.

Resolves #1385