### PR TITLE
Preserve sign of negative zero

### DIFF
--- a/ivtest/ivltests/real_negative_zero.v
+++ b/ivtest/ivltests/real_negative_zero.v
@@ -1,0 +1,35 @@
+// Check that the vvp code generator preserves the sign of a negative zero
+// real constant. The sign used to be detected with (value < 0), which is
+// false for IEEE 754 -0.0, so a -0.0 constant was emitted as +0.0 and the
+// compiled value no longer matched the runtime real value.
+
+module test;
+
+  real nz;
+  real pz;
+
+  initial begin
+    nz = -0.0;
+    pz = 0.0;
+
+    // The sign bit is the only thing that tells -0.0 from +0.0.
+    if ($realtobits(nz) !== 64'h8000_0000_0000_0000) begin
+      $display("FAILED: -0.0 stored as %h", $realtobits(nz));
+      $finish;
+    end
+
+    if ($realtobits(pz) !== 64'h0000_0000_0000_0000) begin
+      $display("FAILED: 0.0 stored as %h", $realtobits(pz));
+      $finish;
+    end
+
+    // The reciprocal makes the sign observable: 1.0/-0.0 is -inf.
+    if (1.0 / nz >= 0.0) begin
+      $display("FAILED: 1.0/-0.0 = %g", 1.0 / nz);
+      $finish;
+    end
+
+    $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -207,6 +207,7 @@ pv_wr_fn_vec2			vvp_tests/pv_wr_fn_vec2.json
 pv_wr_fn_vec4			vvp_tests/pv_wr_fn_vec4.json
 queue_fail			vvp_tests/queue_fail.json
 readmem-invalid			vvp_tests/readmem-invalid.json
+real_negative_zero		vvp_tests/real_negative_zero.json
 scaled_real			vvp_tests/scaled_real.json
 scan-invalid			vvp_tests/scan-invalid.json
 sdf_interconnect1		vvp_tests/sdf_interconnect1.json

--- a/ivtest/vvp_tests/real_negative_zero.json
+++ b/ivtest/vvp_tests/real_negative_zero.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "normal",
+    "source" : "real_negative_zero.v"
+}

--- a/tgt-vvp/eval_real.c
+++ b/tgt-vvp/eval_real.c
@@ -202,9 +202,9 @@ static void draw_realnum_real(ivl_expr_t expr)
 	    return;
       }
 
-      if (value < 0) {
+      if (signbit(value)) {
 	    sign = 0x4000;
-	    value *= -1;
+	    value = -value;
       }
 
       fract = frexp(value, &expo);


### PR DESCRIPTION
Hi!

The function `draw_realnum_real()` detected the sign via `(value < 0)`, which is false for IEEE 754 -0.0. Therefore, a source/constant-folded -0.0 was emitted as +0.0. Use `signbit()` to set the sign bit, matching the runtime real value and
IEEE 754-2019 sec 3.4 / IEEE 1800-2017 sec 6.12.1.

Thanks!
Flavien