### PR TITLE
Handle invalid old-style UDP tables

### DIFF
--- a/ivtest/gold/br_gh1175c.gold
+++ b/ivtest/gold/br_gh1175c.gold
@@ -1,4 +1,3 @@
 ./ivltests/br_gh1175c.v:3: syntax error
 ./ivltests/br_gh1175c.v:3: errors in UDP table
 ./ivltests/br_gh1175c.v:1: error: Invalid table for UDP primitive id_0.
-

--- a/ivtest/gold/br_gh1175d.gold
+++ b/ivtest/gold/br_gh1175d.gold
@@ -1,4 +1,3 @@
 ./ivltests/br_gh1175d.v:3: syntax error
 ./ivltests/br_gh1175d.v:3: errors in UDP table
 ./ivltests/br_gh1175d.v:1: error: Invalid table for UDP primitive id_0.
-

--- a/ivtest/gold/br_gh1175e.gold
+++ b/ivtest/gold/br_gh1175e.gold
@@ -1,4 +1,3 @@
 ./ivltests/br_gh1175e.v:3: syntax error
 ./ivltests/br_gh1175e.v:3: errors in UDP table
 ./ivltests/br_gh1175e.v:1: error: Invalid table for UDP primitive id_0.
-

--- a/ivtest/gold/udp_empty_table_fail-iverilog-stderr.gold
+++ b/ivtest/gold/udp_empty_table_fail-iverilog-stderr.gold
@@ -1,0 +1,2 @@
+ivltests/udp_empty_table_fail.v:7: error: Empty UDP table.
+ivltests/udp_empty_table_fail.v:3: error: Invalid table for UDP primitive udp_empty_table_fail.

--- a/ivtest/ivltests/udp_empty_table_fail.v
+++ b/ivtest/ivltests/udp_empty_table_fail.v
@@ -1,0 +1,9 @@
+// Check that an empty old-style UDP table generates an error.
+
+primitive udp_empty_table_fail (o, i);
+  output o;
+  input i;
+
+  table
+  endtable
+endprimitive

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -389,6 +389,7 @@ test_va_math			vvp_tests/test_va_math.json
 test_vams_math			vvp_tests/test_vams_math.json
 timing_check_syntax		vvp_tests/timing_check_syntax.json
 timing_check_delayed_signals	vvp_tests/timing_check_delayed_signals.json
+udp_empty_table_fail		vvp_tests/udp_empty_table_fail.json
 uwire_fail2			vvp_tests/uwire_fail2.json
 uwire_fail3			vvp_tests/uwire_fail3.json
 value_range1			vvp_tests/value_range1.json

--- a/ivtest/vvp_tests/udp_empty_table_fail.json
+++ b/ivtest/vvp_tests/udp_empty_table_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"   : "CE",
+    "source" : "udp_empty_table_fail.v",
+    "gold"   : "udp_empty_table_fail"
+}

--- a/pform.cc
+++ b/pform.cc
@@ -2079,10 +2079,18 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	    for (unsigned idx = 0 ;  idx < pins.size() ;  idx += 1)
 		  udp->ports[idx] = pins[idx]->basename();
 
-	    process_udp_table(udp, table, loc);
-	    udp->initial  = init;
+	    if (table) {
+		  process_udp_table(udp, table, loc);
+		  udp->initial  = init;
 
-	    pform_primitives[name] = udp;
+		  pform_primitives[name] = udp;
+	    } else {
+		  ostringstream msg;
+		  msg << "error: Invalid table for UDP primitive " << name
+		      << ".";
+		  VLerror(loc, msg.str().c_str(), "");
+		  delete udp;
+	    }
       }
 
 
@@ -2172,7 +2180,7 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	    } else {
 		  ostringstream msg;
 		  msg << "error: Invalid table for UDP primitive " << name
-		      << "." << endl;
+		      << ".";
 		    // Some compilers warn if there is just a single C string.
 		  VLerror(loc, msg.str().c_str(), "");
 	    }


### PR DESCRIPTION
An empty old-style UDP table leaves the parsed table pointer unset after the parser reports the table error. The old-style UDP creation path still passed the null pointer to process_udp_table(), which crashes.

Report an invalid UDP table instead and do not register the primitive. Also keep the new-style invalid-table diagnostic formatting consistent.