### PR TITLE
NetAssignNB: Fix dump fallback for invalid rval

### DIFF
--- a/design_dump.cc
+++ b/design_dump.cc
@@ -1138,7 +1138,7 @@ void NetAssignNB::dump(ostream&o, unsigned ind) const
       if (rval())
 	    o << *rval() << ";" << endl;
       else
-	    o << "rval elaboration error>;" << endl;
+	    o << "<rval elaboration error>;" << endl;
 
 }
 


### PR DESCRIPTION
Currently NetAssignNB::dump() prints a malformed fallback marker when there is no rval expression. The leading '<' is missing, making it inconsistent with the blocking assignment dump output.

Print the complete error marker.