### PR TITLE
Report error for class tasks used as expressions

### DIFF
--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3410,6 +3410,14 @@ NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 		  return 0;
 	    }
 
+	    if (method->type() != NetScope::FUNC) {
+		  cerr << get_fileline() << ": error: Method " << method_name
+		       << " of class " << class_type->get_name()
+		       << " is not a function." << endl;
+		  des->errors++;
+		  return nullptr;
+	    }
+
 	    const NetFuncDef*def = method->func_def();
 	    ivl_assert(*this, def);
 

--- a/ivtest/ivltests/sv_class_task_expr_fail.v
+++ b/ivtest/ivltests/sv_class_task_expr_fail.v
@@ -1,0 +1,19 @@
+// Check that using a class task as an expression reports an error.
+
+module test;
+
+  class C;
+    task t;
+    endtask
+  endclass
+
+  C c;
+
+  initial begin
+    int x;
+    c = new;
+    x = c.t();
+    $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -272,6 +272,7 @@ sv_class_prop_nest_obj1		vvp_tests/sv_class_prop_nest_obj1.json
 sv_class_prop_nest_real1	vvp_tests/sv_class_prop_nest_real1.json
 sv_class_prop_nest_str1		vvp_tests/sv_class_prop_nest_str1.json
 sv_class_prop_nest_vec1		vvp_tests/sv_class_prop_nest_vec1.json
+sv_class_task_expr_fail	vvp_tests/sv_class_task_expr_fail.json
 sv_const1			vvp_tests/sv_const1.json
 sv_const2			vvp_tests/sv_const2.json
 sv_const3			vvp_tests/sv_const3.json

--- a/ivtest/vvp_tests/sv_class_task_expr_fail.json
+++ b/ivtest/vvp_tests/sv_class_task_expr_fail.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_class_task_expr_fail.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Classes are not supported",
+        "type"          : "CE"
+    }
+}


### PR DESCRIPTION
Class object method calls in expression context call func_def() without first checking that the resolved class method is a function. If the method is a task, func_def() triggers an assert instead of reporting a normal elaboration error.

Check the method scope type before accessing the function definition and report an error for tasks.