### PR TITLE
Handle bogus member l-value paths

### DIFF
--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -298,6 +298,15 @@ NetAssign_*PEIdent::elaborate_lval_var_(Design *des, NetScope *scope,
 	// Past this point, we should have taken care of the cases
 	// where the name is a member/method of a struct/class.
 	// XXXX ivl_assert(*this, method_name.nil());
+      if (!tail_path.empty()) {
+	    cerr << get_fileline() << ": error: Variable "
+		 << reg->name()
+		 << " does not have a field named: "
+		 << tail_path << "." << endl;
+	    des->errors += 1;
+	    return nullptr;
+      }
+
       ivl_assert(*this, tail_path.empty());
 
       bool need_const_idx = is_cassign || is_force;

--- a/ivtest/ivltests/sv_bad_member_lval_proc_fail.v
+++ b/ivtest/ivltests/sv_bad_member_lval_proc_fail.v
@@ -1,0 +1,9 @@
+// Check that bogus member access on procedural l-values reports an error.
+
+module test;
+  logic r;
+
+  initial begin
+    r.bad = 1'b1;
+  end
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -254,6 +254,7 @@ sv_array_cassign10		vvp_tests/sv_array_cassign10.json
 sv_array_cassign_single	vvp_tests/sv_array_cassign_single.json
 sv_array_cassign_single_fail1	vvp_tests/sv_array_cassign_single_fail1.json
 sv_automatic_2state		vvp_tests/sv_automatic_2state.json
+sv_bad_member_lval_proc_fail	vvp_tests/sv_bad_member_lval_proc_fail.json
 sv_byte_array_string1		vvp_tests/sv_byte_array_string1.json
 sv_byte_array_string2		vvp_tests/sv_byte_array_string2.json
 sv_byte_array_string3		vvp_tests/sv_byte_array_string3.json

--- a/ivtest/vvp_tests/sv_bad_member_lval_proc_fail.json
+++ b/ivtest/vvp_tests/sv_bad_member_lval_proc_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_bad_member_lval_proc_fail.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
Currently the procedural l-value path asserts if symbol lookup leaves a member tail for a variable that is not a struct or class. For example, `r.bad = 1'b1;` where `r` is a scalar variable aborts during elaboration instead of reporting a normal error.

Report an error for the leftover member path before the assertion. This matches the r-value path behavior for the same kind of invalid member access.