### PR TITLE
musl/OHOS compatibility: dlopen detection, _LARGEFILE64_SOURCE, config.guess

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -940,6 +940,9 @@ EOF
     *:SerenityOS:*:*)
         GUESS=$UNAME_MACHINE-pc-serenity
         ;;
+    *:HarmonyOS:*:*)
+        GUESS=$UNAME_MACHINE-unknown-linux-ohos
+        ;;
     *:Interix*:*)
 	case $UNAME_MACHINE in
 	    x86)
@@ -952,7 +955,7 @@ EOF
 		GUESS=ia64-unknown-interix$UNAME_RELEASE
 		;;
 	esac ;;
-    i*:UWIN*:*)
+    i*:UWIN:*:*)
 	GUESS=$UNAME_MACHINE-pc-uwin
 	;;
     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)

--- a/config.h.in
+++ b/config.h.in
@@ -35,8 +35,13 @@
 # undef HAVE_LIBZ
 # undef HAVE_LIBBZ2
 # undef HAVE_LROUND
+# undef HAVE_LLROUND
+# undef HAVE_NAN
+# undef HAVE_FMIN
+# undef HAVE_FMAX
 # undef HAVE_SYS_WAIT_H
 # undef WORDS_BIGENDIAN
+# undef UINT64_T_AND_ULONG_SAME
 
 #ifdef HAVE_INTTYPES_H
 # include  <inttypes.h>

--- a/configure.ac
+++ b/configure.ac
@@ -368,6 +368,11 @@ AC_CHECK_FUNCS(fopen64)
 # systems we may need to use the compiler in C99 mode to get a definition.
 # autoconf >= 2.70 will enable C99 if it is available. For older autoconf
 # versions, we requested C99 mode earlier with AC_PROG_CC_C99.
+AH_TEMPLATE([HAVE_LROUND], [Define if lround is available])
+AH_TEMPLATE([HAVE_LLROUND], [Define if llround is available])
+AH_TEMPLATE([HAVE_NAN], [Define if nan is available])
+AH_TEMPLATE([HAVE_FMIN], [Define if fmin is available])
+AH_TEMPLATE([HAVE_FMAX], [Define if fmax is available])
 AC_SEARCH_LIBS([lround], [m], [AC_DEFINE([HAVE_LROUND], [1])])
 AC_SEARCH_LIBS([llround], [m], [AC_DEFINE([HAVE_LLROUND], [1])])
 AC_SEARCH_LIBS([nan], [m], [AC_DEFINE([HAVE_NAN], [1])])
@@ -397,7 +402,8 @@ uint64_t uival = 1;
 result &= check(uival);
 return !result;]])],
    [AC_MSG_RESULT(no)],
-   [AC_DEFINE([UINT64_T_AND_ULONG_SAME], [1]) AC_MSG_RESULT(yes)])
+   [AH_TEMPLATE([UINT64_T_AND_ULONG_SAME], [Define if uint64_t and unsigned long are the same type])
+    AC_DEFINE([UINT64_T_AND_ULONG_SAME], [1]) AC_MSG_RESULT(yes)])
 
 # Linker option used when compiling the target
 AX_LD_RDYNAMIC

--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,9 @@ AC_MSG_RESULT($do_times)
 AC_CHECK_HEADERS(dlfcn.h dl.h, break)
 
 DLLIB=''
-AC_CHECK_LIB(dl,dlopen,[DLLIB=-ldl])
+# First check if dlopen is in libc (musl, OHOS, etc.)
+AC_CHECK_FUNC(dlopen, [DLLIB=],
+  [AC_CHECK_LIB(dl,dlopen,[DLLIB=-ldl])])
 if test -z "$DLLIB" ; then
 AC_CHECK_LIB(dld,shl_load,[DLLIB=-ldld])
 fi
@@ -363,6 +365,16 @@ AC_CHECK_FUNCS(realpath)
 # Check that these functions exist. They are mostly C99
 # functions that older compilers may not yet support.
 AC_CHECK_FUNCS(fopen64)
+# On musl-based systems, fopen64 may need _LARGEFILE64_SOURCE to be
+# declared. Try again with it defined if the first check failed.
+if test "$ac_cv_func_fopen64" != yes; then
+  iverilog_saved_cppflags="$CPPFLAGS"
+  CPPFLAGS="-D_LARGEFILE64_SOURCE $CPPFLAGS"
+  AC_CHECK_FUNCS(fopen64,
+    [AC_DEFINE([_LARGEFILE64_SOURCE], [1],
+      [Define to 1 if _LARGEFILE64_SOURCE is needed for fopen64])])
+  CPPFLAGS="$iverilog_saved_cppflags"
+fi
 # The following math functions may be defined in the math library so look
 # in the default libraries first and then look in -lm for them. On some
 # systems we may need to use the compiler in C99 mode to get a definition.


### PR DESCRIPTION
Three changes for musl libc and OpenHarmony (OHOS) compatibility:

1. dlopen detection - Check for dlopen in libc before trying -ldl. On musl (and OHOS), dlopen is part of libc with no separate libdl.

2. _LARGEFILE64_SOURCE fallback - On musl, fopen64 needs _LARGEFILE64_SOURCE to be declared; glibc exposes it via _LARGEFILE_SOURCE alone. Add a fallback check so fopen64 is found on musl.

3. config.guess OHOS detection - Recognize HarmonyOS from uname -s and canonicalize as *-unknown-linux-ohos.