### PR TITLE
vvp: Support local flag on real variables

### DIFF
--- a/ivtest/ivltests/real_delay_assign.v
+++ b/ivtest/ivltests/real_delay_assign.v
@@ -1,0 +1,20 @@
+// Check that blocking intra-assignment delays can assign real values.
+
+module test;
+  real r;
+  reg failed;
+
+  initial begin
+    failed = 1'b0;
+
+    r = #1 1.25;
+    if (r != 1.25) begin
+      $display("FAILED(%0d). Expected 1.25, got %0.2f", `__LINE__, r);
+      failed = 1'b1;
+    end
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -213,6 +213,7 @@ pv_wr_fn_vec2			vvp_tests/pv_wr_fn_vec2.json
 pv_wr_fn_vec4			vvp_tests/pv_wr_fn_vec4.json
 queue_fail			vvp_tests/queue_fail.json
 readmem-invalid			vvp_tests/readmem-invalid.json
+real_delay_assign		vvp_tests/real_delay_assign.json
 real_negative_zero		vvp_tests/real_negative_zero.json
 real_unary_minus_inf		vvp_tests/real_unary_minus_inf.json
 real_unary_minus_nan		vvp_tests/real_unary_minus_nan.json

--- a/ivtest/vvp_tests/real_delay_assign.json
+++ b/ivtest/vvp_tests/real_delay_assign.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "normal",
+    "source"        : "real_delay_assign.v"
+}

--- a/vvp/compile.h
+++ b/vvp/compile.h
@@ -504,7 +504,7 @@ extern void compile_variable(char*label, char*name,
 			     int msb, int lsb, int vpi_type_code,
 			     bool signed_flag, bool local_flag);
 
-extern void compile_var_real(char*label, char*name);
+extern void compile_var_real(char*label, char*name, bool local_flag);
 extern void compile_var_string(char*label, char*name);
 extern void compile_var_darray(char*label, char*name, unsigned size);
 extern void compile_var_cobject(char*label, char*name);

--- a/vvp/parse.y
+++ b/vvp/parse.y
@@ -763,8 +763,8 @@ statement
   | T_LABEL K_VAR_2U local_flag T_STRING ',' signed_t_number signed_t_number ';'
       { compile_variable($1, $4, $6, $7, vpiIntVar, false, $3); }
 
-  | T_LABEL K_VAR_R T_STRING ',' signed_t_number signed_t_number ';'
-      { compile_var_real($1, $3); }
+  | T_LABEL K_VAR_R local_flag T_STRING ',' signed_t_number signed_t_number ';'
+      { compile_var_real($1, $4, $3); }
 
   | T_LABEL K_VAR_STR T_STRING ';'
       { compile_var_string($1, $3); }

--- a/vvp/words.cc
+++ b/vvp/words.cc
@@ -35,7 +35,8 @@
 using namespace std;
 
 static void __compile_var_real(char*label, char*name,
-			       vvp_array_t array, unsigned long array_addr)
+			       vvp_array_t array, unsigned long array_addr,
+			       bool local_flag)
 {
       vvp_net_t*net = new vvp_net_t;
 
@@ -55,7 +56,8 @@ static void __compile_var_real(char*label, char*name,
 
       if (name) {
 	    assert(!array);
-	    vpip_attach_to_current_scope(obj);
+	    if (!local_flag)
+		  vpip_attach_to_current_scope(obj);
             if (!vpip_peek_current_scope()->is_automatic())
                   schedule_init_vector(vvp_net_ptr_t(net,0), 0.0);
       }
@@ -67,9 +69,9 @@ static void __compile_var_real(char*label, char*name,
       delete[] name;
 }
 
-void compile_var_real(char*label, char*name)
+void compile_var_real(char*label, char*name, bool local_flag)
 {
-      __compile_var_real(label, name, 0, 0);
+      __compile_var_real(label, name, 0, 0, local_flag);
 }
 
 void compile_var_string(char*label, char*name)


### PR DESCRIPTION
The vvp parser did not accept the local flag on `.var/real` declarations. This can happen when elaboration creates a compiler-generated real temporary, for example when a blocking intra-assignment delay is rewritten from:

    r = #1 1.25;

to assign the right hand side to a temporary before the delay and assign the temporary to the target after the delay.

Add support for the local flag. Keep a VPI symbol for the variable so `%load/real` can still resolve the label, but do not attach local real variables to the current scope.