### PR TITLE
vvp: zero reused VPI result buffer in thread-vector value getter

### DIFF
--- a/ivtest/ivltests/sf_countones_inline.v
+++ b/ivtest/ivltests/sf_countones_inline.v
@@ -1,0 +1,57 @@
+// $countones / $onehot / $countbits used inline in an expression at a width
+// that is not a multiple of 32. Regresses the stale-high-bits bug in the
+// VPI thread-vector getter. Existing sf_countones.v only assigns to a var.
+module top;
+  reg pass;
+  reg [3:0]  an;
+  reg [11:0] w12;
+
+  initial begin
+    pass = 1'b1;
+    an   = 4'b1110;   // ~an = 0001 -> exactly one set bit
+    w12  = 12'b0000_0010_0000;
+
+    // The original failing idiom: one-cold / one-hot check inline.
+    if (($countones(~an) == 1) !== 1'b1) begin
+      $display("FAILED: $countones(~an)==1 should be true (an=%b)", an);
+      pass = 1'b0;
+    end
+
+    if (($countones(~an) != 1) !== 1'b0) begin
+      $display("FAILED: $countones(~an)!=1 should be false (an=%b)", an);
+      pass = 1'b0;
+    end
+
+    // Inline in arithmetic context.
+    if (($countones(~an) + 0) !== 1) begin
+      $display("FAILED: $countones(~an)+0 should be 1, got %0d", $countones(~an) + 0);
+      pass = 1'b0;
+    end
+
+    // Width that is not a multiple of 32, inline.
+    if (($countones(w12) == 1) !== 1'b1) begin
+      $display("FAILED: $countones(w12)==1 should be true (w12=%b)", w12);
+      pass = 1'b0;
+    end
+
+    // Same value via a variable must of course still agree.
+    if ($countones(~an) !== 1) begin
+      $display("FAILED: $countones(~an) (self) should be 1");
+      pass = 1'b0;
+    end
+
+    // Sibling functions share the same getter; check them inline too.
+    if (($onehot(~an) == 1) !== 1'b1) begin
+      $display("FAILED: $onehot(~an)==1 should be true");
+      pass = 1'b0;
+    end
+
+    if (($countbits(an, 1'b1) == 3) !== 1'b1) begin
+      $display("FAILED: $countbits(an,1)==3 should be true (an=%b)", an);
+      pass = 1'b0;
+    end
+
+    if (pass) $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/regress-sv.list
+++ b/ivtest/regress-sv.list
@@ -468,6 +468,7 @@ sbyte_test		normal,-g2005-sv	ivltests
 scalar_vector		normal,-g2005-sv	ivltests
 sf_countbits		normal,-g2012		ivltests
 sf_countones		normal,-g2009		ivltests
+sf_countones_inline	normal,-g2009		ivltests
 sf_isunknown		normal,-g2005-sv	ivltests
 sf_onehot		normal,-g2005-sv	ivltests
 sf_onehot0		normal,-g2005-sv	ivltests

--- a/vvp/vpi_vthr_vector.cc
+++ b/vvp/vpi_vthr_vector.cc
@@ -548,9 +548,17 @@ void __vpiVThrVec4Stack::vpi_get_value_vector_(p_vpi_value vp, const vvp_vector4
 {
       unsigned wid = val.size();
 
+      unsigned hwid = (wid+31)/32;
       vp->value.vector = static_cast<s_vpi_vecval*>
-                         (need_result_buf((wid+31)/32*sizeof(s_vpi_vecval), RBUF_VAL));
+                         (need_result_buf(hwid*sizeof(s_vpi_vecval), RBUF_VAL));
       assert(vp->value.vector);
+
+	/* Zero the reused result buffer first; the fill loop below only writes
+	   bits 0..wid-1, leaving stale data in the unused high bits otherwise. */
+      for (unsigned word = 0 ;  word < hwid ;  word += 1) {
+	    vp->value.vector[word].aval = 0;
+	    vp->value.vector[word].bval = 0;
+      }
 
       for (unsigned idx = 0 ;  idx < wid ;  idx += 1) {
 	    int word = idx/32;

--- a/vvp/vpi_vthr_vector.cc
+++ b/vvp/vpi_vthr_vector.cc
@@ -549,13 +549,13 @@ void __vpiVThrVec4Stack::vpi_get_value_vector_(p_vpi_value vp, const vvp_vector4
       unsigned wid = val.size();
 
       unsigned hwid = (wid+31)/32;
-      assert(hwid > 0);
       vp->value.vector = static_cast<s_vpi_vecval*>
                          (need_result_buf(hwid*sizeof(s_vpi_vecval), RBUF_VAL));
       assert(vp->value.vector);
 
 	/* Zero the top of the result buffer first since the fill loop below only writes
 	   bits 0..wid-1, which can leave stale data in the unused high bits. */
+      if (hwid == 0) hwid = 1;
       vp->value.vector[hwid-1].aval = 0;
       vp->value.vector[hwid-1].bval = 0;
 

--- a/vvp/vpi_vthr_vector.cc
+++ b/vvp/vpi_vthr_vector.cc
@@ -549,16 +549,15 @@ void __vpiVThrVec4Stack::vpi_get_value_vector_(p_vpi_value vp, const vvp_vector4
       unsigned wid = val.size();
 
       unsigned hwid = (wid+31)/32;
+      assert(hwid > 0);
       vp->value.vector = static_cast<s_vpi_vecval*>
                          (need_result_buf(hwid*sizeof(s_vpi_vecval), RBUF_VAL));
       assert(vp->value.vector);
 
-	/* Zero the reused result buffer first; the fill loop below only writes
-	   bits 0..wid-1, leaving stale data in the unused high bits otherwise. */
-      for (unsigned word = 0 ;  word < hwid ;  word += 1) {
-	    vp->value.vector[word].aval = 0;
-	    vp->value.vector[word].bval = 0;
-      }
+	/* Zero the top of the result buffer first since the fill loop below only writes
+	   bits 0..wid-1, which can leave stale data in the unused high bits. */
+      vp->value.vector[hwid-1].aval = 0;
+      vp->value.vector[hwid-1].bval = 0;
 
       for (unsigned idx = 0 ;  idx < wid ;  idx += 1) {
 	    int word = idx/32;


### PR DESCRIPTION
Fixes #1411.

`$countones`, `$onehot`, `$onehot0`, and `$countbits` can return the wrong value when used directly in an expression (e.g. `$countones(x) == 1`) for any operand width that is not a multiple of 32. The result depends on leftover buffer contents, so it is not deterministic, and assigning to a variable first usually hides it.

The VPI getter `__vpiVThrVec4Stack::vpi_get_value_vector_` fills a reused scratch buffer over bits `0..wid-1` only, leaving stale data in the unused high bits of the most significant word. The bitvec consumers count whole 32-bit words, so they count that garbage. The other value getters already zero their buffers; this one did not.

The fix zeros the buffer before filling it. Adds `sf_countones_inline.v` covering the inline case at non-32-multiple widths (the existing test only assigns to a variable).
