### PR TITLE
Allow repeat expression in event control to contain automatic terms

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3251,15 +3251,6 @@ NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
       NetEvWait*event = 0;
       if (count_ != 0 || event_ != 0) {
 	    if (count_ != 0) {
-                  if (scope->is_auto() && count_->has_aa_term(des, scope)) {
-                        cerr << get_fileline() << ": error: automatically "
-                                "allocated variables may not be referenced "
-                                "in intra-assignment event controls of "
-                                "non-blocking assignments." << endl;
-                        des->errors += 1;
-                        return 0;
-                  }
-
 		  ivl_assert(*this, event_ != 0);
 		  count = elab_and_eval(des, scope, count_, -1);
 		  if (count == 0) {

--- a/ivtest/ivltests/nb_ec_repeat_auto.v
+++ b/ivtest/ivltests/nb_ec_repeat_auto.v
@@ -1,0 +1,46 @@
+// Check that non-blocking event control repeat counts can use automatic terms.
+
+module test;
+
+  reg clk;
+  reg failed;
+  reg [3:0] result;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  task automatic schedule_update;
+    input integer count;
+    begin
+      result <= repeat(count) @(posedge clk) 4'ha;
+    end
+  endtask
+
+  always #5 clk = ~clk;
+
+  initial begin
+    clk = 1'b0;
+    failed = 1'b0;
+    result = 4'h0;
+
+    schedule_update(2);
+
+    @(posedge clk);
+    #1;
+    `check(result, 4'h0);
+
+    @(posedge clk);
+    #1;
+    `check(result, 4'ha);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+    $finish;
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -174,6 +174,7 @@ module_port_array1		vvp_tests/module_port_array1.json
 module_port_array_fail1		vvp_tests/module_port_array_fail1.json
 module_port_array_init1		vvp_tests/module_port_array_init1.json
 monitor4			vvp_tests/monitor4.json
+nb_ec_repeat_auto		vvp_tests/nb_ec_repeat_auto.json
 named_event_edge_fail		vvp_tests/named_event_edge_fail.json
 named_event_negedge_fail	vvp_tests/named_event_negedge_fail.json
 named_event_posedge_fail	vvp_tests/named_event_posedge_fail.json

--- a/ivtest/vvp_tests/nb_ec_repeat_auto.json
+++ b/ivtest/vvp_tests/nb_ec_repeat_auto.json
@@ -1,0 +1,8 @@
+{
+    "type"   : "normal",
+    "source" : "nb_ec_repeat_auto.v",
+    "vlog95" : {
+        "__comment" : "Automatic tasks are not supported",
+        "type"      : "CE"
+    }
+}


### PR DESCRIPTION
The repeat expression of an event controlled non-blocking assignment is evaluated once when the assignment is scheduled. This means there is no risk of it being referenced when its scope has already been freed. And hence there is no need to require the repeat expression to only contain static terms.