### PR TITLE
Detect automatic terms in assignment patterns

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -108,6 +108,16 @@ PEAssignPattern::~PEAssignPattern()
 {
 }
 
+bool PEAssignPattern::has_aa_term(Design*des, NetScope*scope) const
+{
+      bool flag = false;
+      for (const auto *parm : parms_) {
+	    if (parm)
+		  flag = parm->has_aa_term(des, scope) || flag;
+      }
+      return flag;
+}
+
 PEBinary::PEBinary(char op, PExpr*l, PExpr*r)
 : op_(op), left_(l), right_(r)
 {

--- a/PExpr.h
+++ b/PExpr.h
@@ -208,6 +208,8 @@ class PEAssignPattern : public PExpr {
 
       void dump(std::ostream&) const override;
 
+      virtual bool has_aa_term(Design*des, NetScope*scope) const override;
+
       virtual unsigned test_width(Design*des, NetScope*scope, width_mode_t&mode) override;
       virtual NetExpr*elaborate_expr(Design*des, NetScope*scope,
 				     ivl_type_t type, unsigned flags) const override;

--- a/ivtest/ivltests/sv_assign_pattern_auto_force_fail.v
+++ b/ivtest/ivltests/sv_assign_pattern_auto_force_fail.v
@@ -1,0 +1,19 @@
+// Check that assignment patterns cannot reference automatic variables in
+// procedural force statements.
+
+module test;
+
+  reg [3:0] result;
+
+  task automatic t;
+    input [3:0] value;
+    begin
+      force result = '{value[3], value[2], value[1], value[0]};
+    end
+  endtask
+
+  initial begin
+    t(4'ha);
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -259,6 +259,7 @@ sv_array_cassign9		vvp_tests/sv_array_cassign9.json
 sv_array_cassign10		vvp_tests/sv_array_cassign10.json
 sv_array_cassign_single	vvp_tests/sv_array_cassign_single.json
 sv_array_cassign_single_fail1	vvp_tests/sv_array_cassign_single_fail1.json
+sv_assign_pattern_auto_force_fail	vvp_tests/sv_assign_pattern_auto_force_fail.json
 sv_automatic_2state		vvp_tests/sv_automatic_2state.json
 sv_bad_member_lval_proc_fail	vvp_tests/sv_bad_member_lval_proc_fail.json
 sv_byte_array_string1		vvp_tests/sv_byte_array_string1.json

--- a/ivtest/vvp_tests/sv_assign_pattern_auto_force_fail.json
+++ b/ivtest/vvp_tests/sv_assign_pattern_auto_force_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "sv_assign_pattern_auto_force_fail.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}


### PR DESCRIPTION
Assignment patterns contain child expressions, but currently inherit `PExpr::has_aa_term()` which always returns false. This means automatic variables inside a pattern are not caught by checks for procedural force and procedural continuous assignment statements.

Implement `has_aa_term()` for `PEAssignPattern` and recurse into all pattern elements.