### PR TITLE
Windows: route vpip_format_pretty through vpip_routines_s

### DIFF
--- a/vpi/libvpi.c
+++ b/vpi/libvpi.c
@@ -286,6 +286,11 @@ void vpip_format_strength(char*str, s_vpi_value*value, unsigned bit)
       assert(vpip_routines);
       vpip_routines->format_strength(str, value, bit);
 }
+char* vpip_format_pretty(vpiHandle ref)
+{
+      assert(vpip_routines);
+      return vpip_routines->format_pretty(ref);
+}
 void vpip_make_systf_system_defined(vpiHandle ref)
 {
       assert(vpip_routines);

--- a/vpi_user.h
+++ b/vpi_user.h
@@ -696,7 +696,7 @@ extern void vpip_count_drivers(vpiHandle ref, unsigned idx,
  */
 
 // Increment the version number any time vpip_routines_s is changed.
-static const PLI_UINT32 vpip_routines_version = 1;
+static const PLI_UINT32 vpip_routines_version = 2;
 
 typedef struct {
     vpiHandle   (*register_cb)(p_cb_data);
@@ -737,6 +737,7 @@ typedef struct {
     s_vpi_vecval(*calc_clog2)(vpiHandle);
     void        (*count_drivers)(vpiHandle, unsigned, unsigned [4]);
     void        (*format_strength)(char*, s_vpi_value*, unsigned);
+    char*       (*format_pretty)(vpiHandle);
     void        (*make_systf_system_defined)(vpiHandle);
     void        (*mcd_rawwrite)(PLI_UINT32, const char*, size_t);
     void        (*set_return_value)(int);

--- a/vvp/vpi_priv.cc
+++ b/vvp/vpi_priv.cc
@@ -2059,6 +2059,7 @@ extern "C" void vpip_count_drivers(vpiHandle ref, unsigned idx,
 }
 
 #if defined(__MINGW32__) || defined (__CYGWIN__)
+extern "C" char* vpip_format_pretty(vpiHandle ref);
 vpip_routines_s vpi_routines = {
     .register_cb                = vpi_register_cb,
     .remove_cb                  = vpi_remove_cb,
@@ -2098,6 +2099,7 @@ vpip_routines_s vpi_routines = {
     .calc_clog2                 = vpip_calc_clog2,
     .count_drivers              = vpip_count_drivers,
     .format_strength            = vpip_format_strength,
+    .format_pretty              = vpip_format_pretty,
     .make_systf_system_defined  = vpip_make_systf_system_defined,
     .mcd_rawwrite               = vpip_mcd_rawwrite,
     .set_return_value           = vpip_set_return_value,


### PR DESCRIPTION
Split from steveicarus/iverilog#1330 (**independent** of the #1416–#1422 feature stack). Can merge in any order relative to those PRs.

## Summary

Fixes **MinGW / Windows** link failures when building VPI modules: route **`vpip_format_pretty`** through **`vpip_routines_s`** (version bump) and export **`ivl_type_queue_max`** in **`ivl.def`**.

## User-visible behavior

No functional change on Linux. Windows CI / MSYS2 builds link `system.vpi` and related targets without undefined references to `vpip_format_pretty`.

## Implementation notes (high level)

- **`vpi_user.h`:** bump `vpip_routines_version` 1→2; add `format_pretty` to `vpip_routines_s`.
- **`vpi/libvpi.c`:** MinGW thunk `vpip_format_pretty()` → `vpip_routines->format_pretty`.
- **`vvp/vpi_priv.cc`:** jump table entry for `format_pretty`.
- **`ivl.def`:** export `ivl_type_queue_max` for MinGW.

## Tests / regressions

No new ivtest. Verified by Windows CI link of `system.vpi` (was failing with undefined reference to `vpip_format_pretty`).

## How to verify

```text
make -j$(nproc)
# On MSYS2 / MinGW: build should complete without vpip_format_pretty linker errors.
```

## Commits

**1** upstreamable commit on `upstream/master`:

- `Windows: route vpip_format_pretty through vpip_routines_s`

---

## Reviewer checklist

- [ ] `vpip_routines_version` bump is consistent across VPI consumers
- [ ] MinGW thunk and `vpi_priv.cc` jump table match
- [ ] `ivl.def` export list complete for Windows
- [ ] Linux build unaffected
