### PR TITLE
Report UDP declaration errors instead of asserting

### DIFF
--- a/ivtest/ivltests/udp_ansi_initial_nonreg_fail.v
+++ b/ivtest/ivltests/udp_ansi_initial_nonreg_fail.v
@@ -1,0 +1,8 @@
+// Check that an ANSI-style UDP output initializer requires a reg output.
+
+primitive udp_ansi_initial_nonreg_fail (output o = 1'b0, input i);
+  table
+    0 : 0;
+    1 : 1;
+  endtable
+endprimitive

--- a/ivtest/ivltests/udp_ansi_initial_reg.v
+++ b/ivtest/ivltests/udp_ansi_initial_reg.v
@@ -1,0 +1,21 @@
+// Check that an ANSI-style UDP reg output can have an initializer.
+
+primitive udp_ansi_initial_reg (output reg o = 1'b0, input i);
+  table
+    0 : ? : 0;
+    1 : ? : 1;
+  endtable
+endprimitive
+
+module test;
+  reg i;
+  wire o;
+
+  udp_ansi_initial_reg i_udp(o, i);
+
+  initial begin
+    i = 1'b0;
+    #1;
+    $display("PASSED");
+  end
+endmodule

--- a/ivtest/ivltests/udp_initial_nonreg_fail.v
+++ b/ivtest/ivltests/udp_initial_nonreg_fail.v
@@ -1,0 +1,12 @@
+// Check that an old-style UDP initial statement requires a reg output.
+
+primitive udp_initial_nonreg_fail (o, i);
+  output o;
+  input i;
+  initial o = 1'b0;
+
+  table
+    0 : 0;
+    1 : 1;
+  endtable
+endprimitive

--- a/ivtest/ivltests/udp_port_decl_conflict_fail.v
+++ b/ivtest/ivltests/udp_port_decl_conflict_fail.v
@@ -1,0 +1,12 @@
+// Check that conflicting UDP port declarations generate an error.
+
+primitive udp_port_decl_conflict_fail (o, i);
+  output o;
+  input o;
+  input i;
+
+  table
+    0 : 0;
+    1 : 1;
+  endtable
+endprimitive

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -430,7 +430,11 @@ test_va_math			vvp_tests/test_va_math.json
 test_vams_math			vvp_tests/test_vams_math.json
 timing_check_syntax		vvp_tests/timing_check_syntax.json
 timing_check_delayed_signals	vvp_tests/timing_check_delayed_signals.json
+udp_ansi_initial_nonreg_fail	vvp_tests/udp_ansi_initial_nonreg_fail.json
+udp_ansi_initial_reg		vvp_tests/udp_ansi_initial_reg.json
 udp_empty_table_fail		vvp_tests/udp_empty_table_fail.json
+udp_initial_nonreg_fail		vvp_tests/udp_initial_nonreg_fail.json
+udp_port_decl_conflict_fail	vvp_tests/udp_port_decl_conflict_fail.json
 uwire_fail2			vvp_tests/uwire_fail2.json
 uwire_fail3			vvp_tests/uwire_fail3.json
 value_range1			vvp_tests/value_range1.json

--- a/ivtest/vvp_tests/udp_ansi_initial_nonreg_fail.json
+++ b/ivtest/vvp_tests/udp_ansi_initial_nonreg_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "CE",
+    "source" : "udp_ansi_initial_nonreg_fail.v"
+}

--- a/ivtest/vvp_tests/udp_ansi_initial_reg.json
+++ b/ivtest/vvp_tests/udp_ansi_initial_reg.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "normal",
+    "source" : "udp_ansi_initial_reg.v"
+}

--- a/ivtest/vvp_tests/udp_initial_nonreg_fail.json
+++ b/ivtest/vvp_tests/udp_initial_nonreg_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "CE",
+    "source" : "udp_initial_nonreg_fail.v"
+}

--- a/ivtest/vvp_tests/udp_port_decl_conflict_fail.json
+++ b/ivtest/vvp_tests/udp_port_decl_conflict_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "CE",
+    "source" : "udp_port_decl_conflict_fail.v"
+}

--- a/pform.cc
+++ b/pform.cc
@@ -1947,16 +1947,38 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 		  ivl_assert(loc, (*decl)[idx]);
 		  if ((*decl)[idx]->get_port_type() != NetNet::PIMPLICIT) {
 			bool rc = cur->set_port_type((*decl)[idx]->get_port_type());
-			ivl_assert(loc, rc);
+			if (!rc) {
+			      cerr << loc << ": error: "
+				   << "Port " << port_name << " of primitive "
+				   << name << " has conflicting port declarations."
+				   << endl;
+			      error_count += 1;
+			      local_errors += 1;
+			}
 		  }
 		  if ((*decl)[idx]->get_wire_type() != NetNet::IMPLICIT) {
 			bool rc = cur->set_wire_type((*decl)[idx]->get_wire_type());
-			ivl_assert(loc, rc);
+			if (!rc) {
+			      cerr << loc << ": error: "
+				   << "Port " << port_name << " of primitive "
+				   << name << " has conflicting data declarations."
+				   << endl;
+			      error_count += 1;
+			      local_errors += 1;
+			}
 		  }
 
 	    } else {
 		  defs[port_name] = (*decl)[idx];
 	    }
+      }
+
+      if (local_errors > 0) {
+	    delete parms;
+	    delete decl;
+	    delete table;
+	    delete init_expr;
+	    return;
       }
 
 
@@ -2070,22 +2092,56 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	   registered. Then save the initial value that I get. */
       verinum::V init = verinum::Vx;
       if (init_expr) {
-	      // XXXX
-	    ivl_assert(loc, pins[0]->get_wire_type() == NetNet::REG);
+	    if (pins[0]->get_wire_type() != NetNet::REG) {
+		  cerr << init_expr->get_fileline() << ": error: "
+		       << "Initial value for primitive " << name
+		       << " requires a registered output port." << endl;
+		  error_count += 1;
+		  local_errors += 1;
+	    }
 
-	    const PAssign*pa = dynamic_cast<PAssign*>(init_expr);
-	    ivl_assert(*init_expr, pa);
+	    auto*pa = dynamic_cast<PAssign*>(init_expr);
+	    if (!pa) {
+		  cerr << init_expr->get_fileline() << ": error: "
+		       << "Invalid initial statement for primitive "
+		       << name << "." << endl;
+		  error_count += 1;
+		  local_errors += 1;
+	    }
 
-	    const PEIdent*id = dynamic_cast<const PEIdent*>(pa->lval());
-	    ivl_assert(*init_expr, id);
+	    if (pa) {
+		  auto*id = dynamic_cast<const PEIdent*>(pa->lval());
+		  if (!id) {
+			cerr << init_expr->get_fileline() << ": error: "
+			     << "Invalid initial statement for primitive "
+			     << name << "." << endl;
+			error_count += 1;
+			local_errors += 1;
+		  }
 
-	      // XXXX
-	      //ivl_assert(*init_expr, id->name() == pins[0]->name());
+		    // XXXX
+		    //ivl_assert(*init_expr, id->name() == pins[0]->name());
 
-	    const PENumber*np = dynamic_cast<const PENumber*>(pa->rval());
-	    ivl_assert(*init_expr, np);
+		  auto*np = dynamic_cast<const PENumber*>(pa->rval());
+		  if (!np) {
+			cerr << init_expr->get_fileline() << ": error: "
+			     << "Invalid initial value for primitive "
+			     << name << "." << endl;
+			error_count += 1;
+			local_errors += 1;
+		  } else {
+			init = np->value()[0];
+		  }
+	    }
 
-	    init = np->value()[0];
+	    if (local_errors > 0) {
+		  delete parms;
+		  delete decl;
+		  delete table;
+		  delete init_expr;
+		  return;
+	    }
+
       }
 
 	// Put the primitive into the primitives table
@@ -2159,20 +2215,31 @@ void pform_make_udp(const struct vlltype&loc, perm_string name,
 	   registered. Then save the initial value that I get. */
       verinum::V init = verinum::Vx;
       if (init_expr) {
-	      // XXXX
-	    ivl_assert(*init_expr, pins[0]->get_wire_type() == NetNet::REG);
+	    bool local_errors = false;
 
-	    const PAssign*pa = dynamic_cast<PAssign*>(init_expr);
-	    ivl_assert(*init_expr, pa);
+	    if (pins[0]->get_wire_type() != NetNet::REG) {
+		  cerr << init_expr->get_fileline() << ": error: "
+		       << "Initial value for primitive " << name
+		       << " requires a registered output port." << endl;
+		  error_count += 1;
+		  local_errors = true;
+	    }
 
-	    const PEIdent*id = dynamic_cast<const PEIdent*>(pa->lval());
-	    ivl_assert(*init_expr, id);
+	    auto*np = dynamic_cast<const PENumber*>(init_expr);
+	    if (!np) {
+		  cerr << init_expr->get_fileline() << ": error: "
+		       << "Invalid initial value for primitive "
+		       << name << "." << endl;
+		  error_count += 1;
+		  local_errors = true;
+	    }
 
-	      // XXXX
-	      //ivl_assert(*init_expr, id->name() == pins[0]->name());
-
-	    const PENumber*np = dynamic_cast<const PENumber*>(pa->rval());
-	    ivl_assert(*init_expr, np);
+	    if (local_errors) {
+		  delete parms;
+		  delete table;
+		  delete init_expr;
+		  return;
+	    }
 
 	    init = np->value()[0];
       }


### PR DESCRIPTION
Malformed UDP declarations can reach `pform_make_udp()` with conflicting duplicate port declarations or with an initial value on an output that was not declared as a register. These cases currently trigger internal assertions instead of reporting normal compile errors.

The ANSI-style UDP output initializer path also treats the initializer expression as if it was the old-style `initial out = value` assignment statement. This makes a valid `output reg out = 1'b0` initializer assert as well.

Report errors for the invalid declarations and read the ANSI-style initializer value directly from the initializer expression.