### PR TITLE
parser: Fix parameter assignment grammar conflict

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -85,6 +85,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
 INSTALL_DATA = @INSTALL_DATA@
 LEX = @LEX@
 YACC = @YACC@
+YACC_CONFLICT_FLAGS = -Werror=conflicts-sr -Werror=conflicts-rr
 MAN = @MAN@
 PS2PDF = @PS2PDF@
 GROFF = @GROFF@
@@ -241,10 +242,10 @@ parse.o: parse.cc
 
 # Use pattern rules to avoid parallel build issues (see pr3462585)
 parse%cc parse%h: $(srcdir)/parse%y
-	$(YACC) --verbose -t -p VL --defines=parse.h -o parse.cc $<
+	$(YACC) --verbose $(YACC_CONFLICT_FLAGS) -t -p VL --defines=parse.h -o parse.cc $<
 
 syn-rules.cc: $(srcdir)/syn-rules.y
-	$(YACC) --verbose -t -p syn_ -o $@ $<
+	$(YACC) --verbose $(YACC_CONFLICT_FLAGS) -t -p syn_ -o $@ $<
 
 lexor.cc: $(srcdir)/lexor.lex
 	$(LEX) -s -t $< > $@

--- a/parse.y
+++ b/parse.y
@@ -5991,10 +5991,17 @@ value_parameter_assign_with_explicit_type
   ;
 
 parameter_assign
-  : identifier_name dimensions_opt initializer_opt parameter_value_ranges_opt
-      { pform_set_parameter(@1, $1, param_is_local,
+  : IDENTIFIER dimensions_opt initializer_opt parameter_value_ranges_opt
+      { pform_set_parameter(@1, lex_strings.make($1), param_is_local,
 			    param_is_type, param_type_restrict,
 			    param_data_type, $2, $3, $4);
+	delete[]$1;
+      }
+  | TYPE_IDENTIFIER dimensions_opt initializer_opt parameter_value_ranges_opt
+      { pform_set_parameter(@1, lex_strings.make($1.text), param_is_local,
+			    param_is_type, param_type_restrict,
+			    param_data_type, $2, $3, $4);
+	delete[]$1.text;
       }
   ;
 


### PR DESCRIPTION
The parameter declaration grammar allows a visible type identifier to be used as a parameter name. The assignment continuation rule still used `identifier_name`, which made Bison reduce a `TYPE_IDENTIFIER` before it had seen whether following dimensions belonged to the parameter name or to an explicit type identifier.

Match ordinary and type identifiers directly in `parameter_assign` so the parser can shift dimensions before deciding between a parameter name and an explicit parameter type.

To avoid added parser conflicts again make sure to treat them as warnings instead of errors.