### PR TITLE
parser: Reject implicit parameter types without parameter

### DIFF
--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -84,9 +84,6 @@ module_input_port_list_def	normal			ivltests
 module_input_port_type		normal			ivltests
 parameter_in_generate1		normal			ivltests
 parameter_no_default		normal			ivltests
-parameter_omit1			normal			ivltests
-parameter_omit2			normal			ivltests
-parameter_omit3			normal			ivltests
 pr3015421			CE			ivltests gold=pr3015421-fsv.gold
 resetall			normal,-Wtimescale	ivltests gold=resetall-fsv.gold
 scope2b				normal			ivltests

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -761,12 +761,6 @@ param_times		normal			ivltests # param has multiplication.
 parameter_1bit		normal			ivltests
 parameter_in_generate1	CE			ivltests
 parameter_no_default	CE			ivltests
-parameter_omit1		CE			ivltests
-parameter_omit2		CE			ivltests
-parameter_omit3		CE			ivltests
-parameter_omit_invalid1	CE			ivltests
-parameter_omit_invalid2	CE			ivltests
-parameter_omit_invalid3	CE			ivltests
 parameter_override_invalid1 CE			ivltests
 parameter_override_invalid2 CE			ivltests
 parameter_override_invalid3 CE			ivltests

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -371,6 +371,12 @@ sv_net_array_decl_assign	vvp_tests/sv_net_array_decl_assign.json
 sv_net_decl_assign		vvp_tests/sv_net_decl_assign.json
 sv_package_lifetime		vvp_tests/sv_package_lifetime.json
 sv_package_lifetime_fail	vvp_tests/sv_package_lifetime_fail.json
+parameter_omit1			vvp_tests/parameter_omit1.json
+parameter_omit2			vvp_tests/parameter_omit2.json
+parameter_omit3			vvp_tests/parameter_omit3.json
+parameter_omit_invalid1		vvp_tests/parameter_omit_invalid1.json
+parameter_omit_invalid2		vvp_tests/parameter_omit_invalid2.json
+parameter_omit_invalid3		vvp_tests/parameter_omit_invalid3.json
 sv_parameter_type		vvp_tests/sv_parameter_type.json
 sv_partsel_var_negative_packed	vvp_tests/sv_partsel_var_negative_packed.json
 sv_queue_ap_method		vvp_tests/sv_queue_ap_method.json

--- a/ivtest/vvp_tests/parameter_omit1.json
+++ b/ivtest/vvp_tests/parameter_omit1.json
@@ -1,0 +1,7 @@
+{
+    "type"          : "CE",
+    "source"        : "parameter_omit1.v",
+    "force-sv"      : {
+        "type"          : "normal"
+    }
+}

--- a/ivtest/vvp_tests/parameter_omit2.json
+++ b/ivtest/vvp_tests/parameter_omit2.json
@@ -1,0 +1,7 @@
+{
+    "type"          : "CE",
+    "source"        : "parameter_omit2.v",
+    "force-sv"      : {
+        "type"          : "normal"
+    }
+}

--- a/ivtest/vvp_tests/parameter_omit3.json
+++ b/ivtest/vvp_tests/parameter_omit3.json
@@ -1,0 +1,7 @@
+{
+    "type"          : "CE",
+    "source"        : "parameter_omit3.v",
+    "force-sv"      : {
+        "type"          : "normal"
+    }
+}

--- a/ivtest/vvp_tests/parameter_omit_invalid1.json
+++ b/ivtest/vvp_tests/parameter_omit_invalid1.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "parameter_omit_invalid1.v"
+}

--- a/ivtest/vvp_tests/parameter_omit_invalid2.json
+++ b/ivtest/vvp_tests/parameter_omit_invalid2.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "parameter_omit_invalid2.v"
+}

--- a/ivtest/vvp_tests/parameter_omit_invalid3.json
+++ b/ivtest/vvp_tests/parameter_omit_invalid3.json
@@ -1,0 +1,4 @@
+{
+    "type"          : "CE",
+    "source"        : "parameter_omit_invalid3.v"
+}

--- a/parse.y
+++ b/parse.y
@@ -1020,6 +1020,8 @@ Module::port_t *module_declare_interface_port(const YYLTYPE&loc, char *type,
 %type <type_id_range> data_type_or_implicit_plus_id
 %type <type_id_range> data_type_or_implicit_plus_id_dim
 %type <type_id_range> data_type_or_implicit_or_void_plus_id
+%type <type_id_range> data_type_or_parameter_id_base
+%type <type_id_range> data_type_or_parameter_id_dim
 %type <type_id_range> partial_port_name_dim
 %type <type_id_range> partial_port_type_plus_id_dim
 %type <type_id_range> partial_port_typedef_plus_id_dim
@@ -2782,6 +2784,33 @@ data_type_or_implicit_plus_id_dim
       { set_type_id_range($$, nullptr, $1.text, @1, $2);
       }
   | data_type_or_implicit_plus_id_base dimensions_opt
+      { $$ = $1;
+	$$.ranges = $2;
+      }
+  ;
+
+  // Parameter port lists can omit the `parameter` keyword, but the optional
+  // type in that form is a data_type, not data_type_or_implicit. Keep this
+  // separate from data_type_or_implicit_plus_id_dim so a bare typedef name can
+  // still be parsed as a parameter name while implicit types like `signed P`
+  // and `[3:0] P` are rejected.
+data_type_or_parameter_id_base
+  : IDENTIFIER
+      { set_type_id_range($$, nullptr, $1, @1, nullptr);
+      }
+  | atomic_type identifier_name
+      { set_type_id_range($$, $1, $2, @2, nullptr);
+      }
+  | ps_type_identifier_dim identifier_name
+      { set_type_id_range($$, $1, $2, @2, nullptr);
+      }
+  ;
+
+data_type_or_parameter_id_dim
+  : TYPE_IDENTIFIER dimensions_opt
+      { set_type_id_range($$, nullptr, $1.text, @1, $2);
+      }
+  | data_type_or_parameter_id_base dimensions_opt
       { $$ = $1;
 	$$.ranges = $2;
       }
@@ -5271,7 +5300,7 @@ module_parameter
 
 module_parameter_port_list
   : module_parameter
-  | value_parameter_assign_with_type
+  | value_parameter_assign_without_parameter
       { pform_requires_sv(@1, "Omitting initial `parameter` in parameter port "
 			      "list");
       }
@@ -5951,20 +5980,30 @@ value_parameter_assign_with_type
       }
   ;
 
+value_parameter_assign_without_parameter
+  : data_type_or_parameter_id_dim initializer_opt parameter_value_ranges_opt
+      { param_is_type = false;
+	param_type_restrict = {};
+	param_data_type = $1.type;
+	YYLTYPE id_loc = @1;
+	id_loc.first_line = $1.first_line;
+	id_loc.first_column = $1.first_column;
+	id_loc.last_line = $1.last_line;
+	id_loc.last_column = $1.last_column;
+	id_loc.lexical_pos = $1.lexical_pos;
+	pform_set_parameter(id_loc, $1.id, param_is_local,
+			    param_is_type, param_type_restrict,
+			    param_data_type, $1.ranges, $2, $3);
+      }
+  ;
+
   // Parameter port lists allow an explicit type after a comma without
   // repeating `parameter`, e.g. `#(parameter p = 1, int q = 2)`. Keep this
   // narrower than value_parameter_assign_with_type so a bare typedef name
-  // after a comma remains a parameter name that inherits the previous type.
+  // after a comma remains a parameter name that inherits the previous type. The
+  // LRM allows data_type here, but not implicit_type.
 value_parameter_assign_with_explicit_type
   : atomic_type identifier_name dimensions_opt initializer_opt parameter_value_ranges_opt
-      { param_is_type = false;
-	param_type_restrict = {};
-	param_data_type = $1;
-	pform_set_parameter(@2, $2, param_is_local,
-			    param_is_type, param_type_restrict,
-			    param_data_type, $3, $4, $5);
-      }
-  | implicit_type identifier_name dimensions_opt initializer_opt parameter_value_ranges_opt
       { param_is_type = false;
 	param_type_restrict = {};
 	param_data_type = $1;


### PR DESCRIPTION
The LRM allows omitting the `parameter` keyword in a module parameter port list, but the optional type in that form is a data_type, not an implicit data type. A parameter port list like this is therefore invalid:

```SystemVerilog
    module M #([3:0] P = 1);
```

The parameter declaration grammar was reusing the general value_parameter_assign_with_type rule for the omitted-keyword form. That rule also accepts implicit types so that ordinary `parameter signed P = 1` declarations work, which made the omitted-keyword form accept implicit types as well.

Add a separate rule for value parameter assignments without the `parameter` keyword. The rule still accepts bare identifiers and explicit data types so a parameter name can shadow a visible typedef name, but it rejects implicit types.

Also move the tests that cover this to the new json format so that CI is able to detect when the tests fail.