### PR TITLE
ivtest: Run nested enum tests through vlog95

### DIFF
--- a/ivtest/vvp_tests/br_gh1385a.json
+++ b/ivtest/vvp_tests/br_gh1385a.json
@@ -1,9 +1,5 @@
 {
     "type"          : "normal",
     "source"        : "br_gh1385a.v",
-    "iverilog-args" : [ "-g2005-sv" ],
-    "vlog95" : {
-        "__comment"     : "Enum typedefs are not translated",
-        "type"          : "CE"
-    }
+    "iverilog-args" : [ "-g2005-sv" ]
 }

--- a/ivtest/vvp_tests/br_gh1385b.json
+++ b/ivtest/vvp_tests/br_gh1385b.json
@@ -1,9 +1,5 @@
 {
     "type"          : "normal",
     "source"        : "br_gh1385b.v",
-    "iverilog-args" : [ "-g2005-sv" ],
-    "vlog95" : {
-        "__comment"     : "Enum typedefs are not translated",
-        "type"          : "CE"
-    }
+    "iverilog-args" : [ "-g2005-sv" ]
 }

--- a/ivtest/vvp_tests/br_gh1385c.json
+++ b/ivtest/vvp_tests/br_gh1385c.json
@@ -1,9 +1,5 @@
 {
     "type"          : "normal",
     "source"        : "br_gh1385c.v",
-    "iverilog-args" : [ "-g2005-sv" ],
-    "vlog95" : {
-        "__comment"     : "Enum typedefs are not translated",
-        "type"          : "CE"
-    }
+    "iverilog-args" : [ "-g2005-sv" ]
 }


### PR DESCRIPTION
The br_gh1385a, br_gh1385b, and br_gh1385c JSON descriptors mark the vlog95 variants as compile errors. The enum typedefs are translated correctly, so the compile error expectation causes the tests to fail when compilation succeeds.

Remove the stale overrides and run the translated tests through vlog95.

Fixes: 10349287a030 ("Add regression tests for enum typedefs in nested scopes")