### PR TITLE
Support unpacked arrays as parameters, constant-function returns, and subroutine ports

### DIFF
--- a/PExpr.h
+++ b/PExpr.h
@@ -499,7 +499,9 @@ class PEIdent : public PExpr {
 					      bool up, bool need_const) const;
       NetExpr*elaborate_expr_param_slice_(const NetEConst*par_ex,
 					  const NetScope*found_in,
-					  const netvector_t*par_vec,
+					  long msb0, long lsb0,
+					  unsigned long elem_w,
+					  bool packed_layout,
 					  NetExpr*sel,
 					  perm_string name) const;
       NetExpr*elaborate_expr_net(Design*des,

--- a/PExpr.h
+++ b/PExpr.h
@@ -36,6 +36,7 @@ class NetNet;
 class NetExpr;
 class NetScope;
 class PPackage;
+class netsarray_t;
 struct symbol_search_results;
 class netclass_t;
 
@@ -504,6 +505,13 @@ class PEIdent : public PExpr {
 					  bool packed_layout,
 					  NetExpr*sel,
 					  perm_string name) const;
+      NetExpr*elaborate_expr_param_uarray_(Design*des,
+					   NetScope*scope,
+					   const NetEConst*par_ex,
+					   const NetScope*found_in,
+					   const netsarray_t*par_arr,
+					   bool need_const,
+					   perm_string name) const;
       NetExpr*elaborate_expr_net(Design*des,
 				 NetScope*scope,
 				 NetNet*net,

--- a/PExpr.h
+++ b/PExpr.h
@@ -497,6 +497,11 @@ class PEIdent : public PExpr {
 					      const NetScope*found_in,
 					      ivl_type_t par_type,
 					      bool up, bool need_const) const;
+      NetExpr*elaborate_expr_param_slice_(const NetEConst*par_ex,
+					  const NetScope*found_in,
+					  const netvector_t*par_vec,
+					  NetExpr*sel,
+					  perm_string name) const;
       NetExpr*elaborate_expr_net(Design*des,
 				 NetScope*scope,
 				 NetNet*net,

--- a/ca.log
+++ b/ca.log
@@ -1,0 +1,2 @@
+ca.sv: No such file or directory
+Preprocessor failed with 1 error(s).

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -5048,9 +5048,17 @@ unsigned PEIdent::test_width(Design*des, NetScope*scope, width_mode_t&mode)
       }
 
       // The width of a parameter is the width of the parameter value
-      // (as evaluated earlier).
-      if (sr.par_val != 0)
-	    return test_width_parameter_(sr.par_val, mode);
+      // (as evaluated earlier). The exception is an indexed unpacked-array
+      // parameter: its stored value is the whole (flattened) array, but an
+      // element select has the width of a single element, which is computed
+      // from the resolved element type below.
+      if (sr.par_val != 0) {
+	    bool unpacked_elem_sel = use_sel != index_component_t::SEL_NONE
+		  && dynamic_cast<const netsarray_t*>(sr.type)
+		  && !dynamic_cast<const netparray_t*>(sr.type);
+	    if (!unpacked_elem_sel)
+		  return test_width_parameter_(sr.par_val, mode);
+      }
 
       // If the identifier has a type take the information from the type
       if (type) {
@@ -6011,29 +6019,32 @@ static NetExpr* scale_expr_by_const(NetExpr*expr, unsigned long val)
  * constant index we fold it directly, otherwise we build an indexed part
  * select over a NetEConstParam. Only the outermost dimension is indexed here
  * (the common ROM/LUT case, `name[idx]`); the selected element keeps the
- * remaining packed dimensions as its width.
+ * remaining dimensions as its width.
+ *
+ * The flat bit layout differs between packed and unpacked array parameters:
+ *   - packed (packed_layout true): the value comes from a concatenation, so
+ *     the element at index sel_v sits at bit (sel_v - lsb)*elem_w for an
+ *     ascending-LSB range, mirroring an ordinary packed part select.
+ *   - unpacked (packed_layout false): the value was flattened lowest-array-
+ *     index first, so the element at index sel_v sits at bit
+ *     (sel_v - min_index)*elem_w regardless of the declared range direction.
  */
 NetExpr* PEIdent::elaborate_expr_param_slice_(const NetEConst*par_ex,
 					      const NetScope*found_in,
-					      const netvector_t*par_vec,
+					      long msb0, long lsb0,
+					      unsigned long elem_w,
+					      bool packed_layout,
 					      NetExpr*sel,
 					      perm_string name) const
 {
-      const netranges_t&pdims = par_vec->packed_dims();
-      long msb0 = pdims[0].get_msb();
-      long lsb0 = pdims[0].get_lsb();
-      unsigned long outer_w = (msb0 >= lsb0) ? (unsigned long)(msb0 - lsb0 + 1)
-					     : (unsigned long)(lsb0 - msb0 + 1);
-      unsigned long full_w = par_vec->packed_width();
-
-	// The element width is the flat width divided by the number of
-	// elements in the outermost dimension.
-      unsigned long elem_w = full_w / outer_w;
+      long min_idx = (msb0 <= lsb0) ? msb0 : lsb0;
+      long max_idx = (msb0 <= lsb0) ? lsb0 : msb0;
 
       if (debug_elaborate)
 	    cerr << get_fileline() << ": debug: Calculate element select "
 		 << name << "[" << *sel << "] element width " << elem_w
-		 << " from packed range [" << msb0 << ":" << lsb0 << "]." << endl;
+		 << " from " << (packed_layout ? "packed" : "unpacked")
+		 << " range [" << msb0 << ":" << lsb0 << "]." << endl;
 
 	// Constant index: fold to the selected element bits directly.
       if (const NetEConst*sel_c = dynamic_cast<NetEConst*>(sel)) {
@@ -6043,8 +6054,11 @@ NetExpr* PEIdent::elaborate_expr_param_slice_(const NetEConst*par_ex,
 		  return res;
 	    }
 	    long sel_v = sel_c->value().as_long();
-	      // Canonical element index counting from the LSB end.
-	    long cidx = (msb0 >= lsb0) ? (sel_v - lsb0) : (lsb0 - sel_v);
+	      // Canonical element index counting from the LSB end of the flat
+	      // value.
+	    long cidx = packed_layout
+		  ? ((msb0 >= lsb0) ? (sel_v - lsb0) : (lsb0 - sel_v))
+		  : (sel_v - min_idx);
 	    long lsv = cidx * (long)elem_w;
 	    verinum result = param_part_select_bits(par_ex->value(), elem_w, lsv);
 	    NetEConst*res = new NetEConst(result);
@@ -6054,10 +6068,10 @@ NetExpr* PEIdent::elaborate_expr_param_slice_(const NetEConst*par_ex,
 
 	// Variable index: build an indexed part select over the flat value.
 	// Normalize the outer index to a canonical element index, then scale
-	// it up to a bit offset by the element width (mirrors the outermost
-	// dimension handling in collapse_array_exprs()).
-      NetExpr*base = normalize_variable_base(sel, msb0, lsb0, elem_w,
-					     msb0 > lsb0);
+	// it up to a bit offset by the element width.
+      NetExpr*base = packed_layout
+	    ? normalize_variable_base(sel, msb0, lsb0, elem_w, msb0 > lsb0)
+	    : normalize_variable_base(sel, max_idx, min_idx, elem_w, true);
       base = scale_expr_by_const(base, elem_w);
 
       NetEConstParam*ptmp = new NetEConstParam(found_in, name, par_ex->value());
@@ -6088,18 +6102,35 @@ NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 
       perm_string name = peek_tail_name(path_);
 
-	// A multi-dimension packed array parameter, e.g.
-	//   localparam logic [0:63][3:0] MEM = '{ ... };
-	// An index select MEM[idx] selects a whole element (a slice of the
-	// flat packed value that is the width of a single element), not a
-	// single bit. Handle that here before falling back to the single
-	// bit-select machinery used for ordinary packed vectors.
+	// An index select of an array parameter selects a whole element, not
+	// a single bit. This applies both to a multi-dimension packed array,
+	// e.g. localparam logic [0:63][3:0] MEM = '{...}, and to an unpacked
+	// array, e.g. localparam logic [3:0] MEM [0:63] = '{...} (whose value
+	// has been flattened to the packed-equivalent constant). The selected
+	// element keeps the remaining dimensions as its width.
       if (const netvector_t*par_vec = dynamic_cast<const netvector_t*>(par_type)) {
 	    if (par_vec->packed_dims().size() > 1) {
-		  NetExpr*res = elaborate_expr_param_slice_(par_ex, found_in,
-							    par_vec, sel, name);
-		  if (res) return res;
-		  return 0;
+		  const netranges_t&pdims = par_vec->packed_dims();
+		  long msb0 = pdims[0].get_msb();
+		  long lsb0 = pdims[0].get_lsb();
+		  unsigned long outer_w =
+			(msb0 >= lsb0) ? (unsigned long)(msb0 - lsb0 + 1)
+				       : (unsigned long)(lsb0 - msb0 + 1);
+		  unsigned long elem_w = par_vec->packed_width() / outer_w;
+		  return elaborate_expr_param_slice_(par_ex, found_in,
+						     msb0, lsb0, elem_w,
+						     true, sel, name);
+	    }
+      }
+      if (const netsarray_t*par_arr = dynamic_cast<const netsarray_t*>(par_type)) {
+	    if (!dynamic_cast<const netparray_t*>(par_arr)) {
+		  const netranges_t&udims = par_arr->static_dimensions();
+		  long msb0 = udims[0].get_msb();
+		  long lsb0 = udims[0].get_lsb();
+		  unsigned long elem_w = par_arr->element_type()->packed_width();
+		  return elaborate_expr_param_slice_(par_ex, found_in,
+						     msb0, lsb0, elem_w,
+						     false, sel, name);
 	    }
       }
 

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -5975,6 +5975,99 @@ static verinum param_part_select_bits(const verinum&par_val, long wid,
       return result;
 }
 
+/*
+ * Multiply a base expression by an unsigned constant, widening losslessly so
+ * the product cannot overflow. This mirrors the (file-static) make_mult_expr()
+ * in netmisc.cc, which is not exported.
+ */
+static NetExpr* scale_expr_by_const(NetExpr*expr, unsigned long val)
+{
+      unsigned val_wid = 0;
+      for (unsigned long tmp = val ; tmp > 1 ; tmp >>= 1)
+	    val_wid += 1;
+      unsigned use_wid = expr->expr_width() + val_wid + 1;
+
+      verinum val_v (val, use_wid);
+      val_v.has_sign(expr->has_sign());
+      NetEConst*val_c = new NetEConst(val_v);
+      val_c->set_line(*expr);
+
+      expr = pad_to_width(expr, use_wid, *expr);
+
+      NetEBMult*res = new NetEBMult('*', expr, val_c, use_wid, expr->has_sign());
+      res->set_line(*expr);
+      return res;
+}
+
+/*
+ * Handle an index select of a multi-dimension packed array parameter, e.g.
+ *
+ *    localparam logic [0:63][3:0] MEM = '{ ... };
+ *    assign o = MEM[idx];
+ *
+ * Unlike an ordinary packed vector, MEM[idx] selects a whole element (here a
+ * 4-bit slice), not a single bit. The parameter value is a flat packed
+ * constant, so this becomes a fixed-width part select of the flat value: for a
+ * constant index we fold it directly, otherwise we build an indexed part
+ * select over a NetEConstParam. Only the outermost dimension is indexed here
+ * (the common ROM/LUT case, `name[idx]`); the selected element keeps the
+ * remaining packed dimensions as its width.
+ */
+NetExpr* PEIdent::elaborate_expr_param_slice_(const NetEConst*par_ex,
+					      const NetScope*found_in,
+					      const netvector_t*par_vec,
+					      NetExpr*sel,
+					      perm_string name) const
+{
+      const netranges_t&pdims = par_vec->packed_dims();
+      long msb0 = pdims[0].get_msb();
+      long lsb0 = pdims[0].get_lsb();
+      unsigned long outer_w = (msb0 >= lsb0) ? (unsigned long)(msb0 - lsb0 + 1)
+					     : (unsigned long)(lsb0 - msb0 + 1);
+      unsigned long full_w = par_vec->packed_width();
+
+	// The element width is the flat width divided by the number of
+	// elements in the outermost dimension.
+      unsigned long elem_w = full_w / outer_w;
+
+      if (debug_elaborate)
+	    cerr << get_fileline() << ": debug: Calculate element select "
+		 << name << "[" << *sel << "] element width " << elem_w
+		 << " from packed range [" << msb0 << ":" << lsb0 << "]." << endl;
+
+	// Constant index: fold to the selected element bits directly.
+      if (const NetEConst*sel_c = dynamic_cast<NetEConst*>(sel)) {
+	    if (! sel_c->value().is_defined()) {
+		  NetEConst*res = new NetEConst(verinum(verinum::Vx, elem_w, true));
+		  res->set_line(*this);
+		  return res;
+	    }
+	    long sel_v = sel_c->value().as_long();
+	      // Canonical element index counting from the LSB end.
+	    long cidx = (msb0 >= lsb0) ? (sel_v - lsb0) : (lsb0 - sel_v);
+	    long lsv = cidx * (long)elem_w;
+	    verinum result = param_part_select_bits(par_ex->value(), elem_w, lsv);
+	    NetEConst*res = new NetEConst(result);
+	    res->set_line(*this);
+	    return res;
+      }
+
+	// Variable index: build an indexed part select over the flat value.
+	// Normalize the outer index to a canonical element index, then scale
+	// it up to a bit offset by the element width (mirrors the outermost
+	// dimension handling in collapse_array_exprs()).
+      NetExpr*base = normalize_variable_base(sel, msb0, lsb0, elem_w,
+					     msb0 > lsb0);
+      base = scale_expr_by_const(base, elem_w);
+
+      NetEConstParam*ptmp = new NetEConstParam(found_in, name, par_ex->value());
+      ptmp->set_line(found_in->get_parameter_line_info(name));
+
+      NetExpr*tmp = new NetESelect(ptmp, base, elem_w, IVL_SEL_IDX_UP);
+      tmp->set_line(*this);
+      return tmp;
+}
+
 NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 					    const NetExpr*par,
 					    const NetScope*found_in,
@@ -5983,10 +6076,6 @@ NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 {
       const NetEConst*par_ex = dynamic_cast<const NetEConst*> (par);
       ivl_assert(*this, par_ex);
-
-      long par_msv, par_lsv;
-      if(! calculate_param_range(*this, par_type, par_msv, par_lsv,
-				 par_ex->value().len())) return 0;
 
       const name_component_t&name_tail = path_.back();
       ivl_assert(*this, !name_tail.index.empty());
@@ -5998,6 +6087,25 @@ NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
       if (sel == 0) return 0;
 
       perm_string name = peek_tail_name(path_);
+
+	// A multi-dimension packed array parameter, e.g.
+	//   localparam logic [0:63][3:0] MEM = '{ ... };
+	// An index select MEM[idx] selects a whole element (a slice of the
+	// flat packed value that is the width of a single element), not a
+	// single bit. Handle that here before falling back to the single
+	// bit-select machinery used for ordinary packed vectors.
+      if (const netvector_t*par_vec = dynamic_cast<const netvector_t*>(par_type)) {
+	    if (par_vec->packed_dims().size() > 1) {
+		  NetExpr*res = elaborate_expr_param_slice_(par_ex, found_in,
+							    par_vec, sel, name);
+		  if (res) return res;
+		  return 0;
+	    }
+      }
+
+      long par_msv, par_lsv;
+      if(! calculate_param_range(*this, par_type, par_msv, par_lsv,
+				 par_ex->value().len())) return 0;
 
       if (sel->expr_type() == IVL_VT_REAL) {
 	    cerr << get_fileline() << ": error: Index expression for "

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3551,8 +3551,17 @@ unsigned PECallFunction::elaborate_arguments_(Design*des, NetScope*scope,
 	    PExpr *tmp = args[idx];
 
 	    if (tmp) {
-		  parms[pidx] = elaborate_rval_expr(des, scope,
-						    def->port(pidx)->net_type(),
+		    // For a formal with unpacked dimensions the context type is
+		    // the array type; net_type() would give the element type
+		    // and the actual would then be rejected as needing an
+		    // index.
+		  const NetNet*formal = def->port(pidx);
+		  ivl_type_t ctype = formal->net_type();
+		  if (formal->unpacked_dimensions() > 0) {
+			if (const netarray_t*at = formal->array_type())
+			      ctype = at;
+		  }
+		  parms[pidx] = elaborate_rval_expr(des, scope, ctype,
 						    tmp, need_const);
 		  if (parms[pidx] == 0) {
 			parm_errors += 1;

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -6082,6 +6082,153 @@ NetExpr* PEIdent::elaborate_expr_param_slice_(const NetEConst*par_ex,
       return tmp;
 }
 
+/*
+ * Add two non-negative bit-offset expressions, widening so the sum cannot
+ * overflow. (make_add_expr() in netmisc.cc is file-static and not exported.)
+ */
+static NetExpr* add_offset_exprs(NetExpr*a, NetExpr*b)
+{
+      unsigned w = a->expr_width();
+      if (b->expr_width() > w) w = b->expr_width();
+      w += 1;
+      a = pad_to_width(a, w, *a);
+      b = pad_to_width(b, w, *b);
+      NetEBAdd*res = new NetEBAdd('+', a, b, w, false);
+      res->set_line(*a);
+      return res;
+}
+
+/*
+ * Handle an index select of a multi-dimension unpacked array parameter, e.g.
+ *
+ *    localparam logic [3:0] TBL [0:3][0:15] = '{ '{...}, ... };
+ *    assign o = TBL[row][col];
+ *
+ * The value has been flattened row-major into a single packed constant (see
+ * flatten_const_array_pattern() in net_design.cc). The path applies nsel index
+ * expressions (1..ndim of them); index k selects along unpacked dimension k.
+ * With canon_k = (i_k - min_k) and P_k the product of the sizes of the inner
+ * dimensions (k+1..ndim-1), the flat bit offset of the selected element is
+ * (sum_k canon_k*P_k)*base_w; writing stride_k = base_w*P_k that is
+ * sum_k canon_k*stride_k. A partial select (nsel < ndim) keeps the remaining
+ * dimensions, so its width is base_w * prod(size d for d>=nsel). All-constant
+ * indices fold directly; a variable index builds a part select over the flat
+ * NetEConstParam.
+ */
+NetExpr* PEIdent::elaborate_expr_param_uarray_(Design*des, NetScope*scope,
+					       const NetEConst*par_ex,
+					       const NetScope*found_in,
+					       const netsarray_t*par_arr,
+					       bool need_const,
+					       perm_string name) const
+{
+      const netranges_t&udims = par_arr->static_dimensions();
+      size_t ndim = udims.size();
+      unsigned long base_w = par_arr->element_type()->packed_width();
+
+      const name_component_t&name_tail = path_.back();
+      size_t nsel = name_tail.index.size();
+      if (nsel > ndim) {
+	    cerr << get_fileline() << ": error: " << nsel
+		 << " index expressions for array parameter " << name
+		 << ", which has only " << ndim << " dimensions." << endl;
+	    des->errors += 1;
+	    return 0;
+      }
+
+	// stride[k] (in bits) = base_w * product of the inner-dimension sizes.
+      std::vector<unsigned long> stride(ndim);
+      unsigned long acc = base_w;
+      for (size_t k = ndim ; k-- > 0 ; ) {
+	    stride[k] = acc;
+	    acc *= udims[k].width();
+      }
+	// Width of the slice left after consuming nsel dimensions.
+      unsigned long result_w = base_w;
+      for (size_t k = nsel ; k < ndim ; k += 1)
+	    result_w *= udims[k].width();
+
+      if (debug_elaborate)
+	    cerr << get_fileline() << ": debug: Calculate " << nsel
+		 << "-index element select of " << ndim << "-D unpacked array "
+		 << name << ", element width " << result_w << "." << endl;
+
+      NetExpr*off_expr = 0;         // runtime bit-offset accumulator
+      long const_off = 0;           // constant bit-offset accumulator
+      bool all_const = true;
+      bool out_of_bounds = false;
+
+      size_t k = 0;
+      for (std::list<index_component_t>::const_iterator icur = name_tail.index.begin()
+		 ; icur != name_tail.index.end() ; ++icur, ++k) {
+	    ivl_assert(*this, icur->msb && !icur->lsb);
+	    NetExpr*idx = elab_and_eval(des, scope, icur->msb, -1, need_const);
+	    if (idx == 0) return 0;
+
+	    long lo = udims[k].get_lsb();
+	    long hi = udims[k].get_msb();
+	    long mink = (lo <= hi) ? lo : hi;
+	    long maxk = (lo <= hi) ? hi : lo;
+
+	    if (NetEConst*idx_c = dynamic_cast<NetEConst*>(idx)) {
+		  if (!idx_c->value().is_defined()) {
+			out_of_bounds = true;
+		  } else {
+			long v = idx_c->value().as_long();
+			if (v < mink || v > maxk)
+			      out_of_bounds = true;
+			else
+			      const_off += (v - mink) * (long)stride[k];
+		  }
+		  delete idx;
+	    } else {
+		  all_const = false;
+		    // canonical (idx - mink), then scaled up by the stride.
+		  NetExpr*canon = normalize_variable_base(idx, maxk, mink,
+							  stride[k], true);
+		  canon = scale_expr_by_const(canon, stride[k]);
+		  off_expr = off_expr ? add_offset_exprs(off_expr, canon) : canon;
+	    }
+      }
+
+	// All-constant index: fold to the selected element bits directly.
+      if (all_const) {
+	    if (out_of_bounds) {
+		  if (warn_ob_select)
+			cerr << get_fileline() << ": warning: Constant index "
+			     << "out of bounds for array parameter " << name
+			     << "; replacing with a constant 'bx." << endl;
+		  NetEConst*res = new NetEConst(verinum(verinum::Vx,
+							(unsigned)result_w, true));
+		  res->set_line(*this);
+		  return res;
+	    }
+	    verinum result = param_part_select_bits(par_ex->value(),
+						    (long)result_w, const_off);
+	    NetEConst*res = new NetEConst(result);
+	    res->set_line(*this);
+	    return res;
+      }
+
+	// Variable index: fold the constant part of the offset in, then build
+	// an indexed part select of the fixed element width over the flat value.
+      if (const_off != 0) {
+	    unsigned cw = 1;
+	    for (long t = const_off ; t > 0 ; t >>= 1) cw += 1;
+	    NetEConst*c = new NetEConst(verinum((uint64_t)const_off, cw));
+	    c->set_line(*this);
+	    off_expr = off_expr ? add_offset_exprs(off_expr, c) : c;
+      }
+
+      NetEConstParam*ptmp = new NetEConstParam(found_in, name, par_ex->value());
+      ptmp->set_line(found_in->get_parameter_line_info(name));
+
+      NetExpr*tmp = new NetESelect(ptmp, off_expr, (unsigned)result_w,
+				   IVL_SEL_IDX_UP);
+      tmp->set_line(*this);
+      return tmp;
+}
+
 NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 					    const NetExpr*par,
 					    const NetScope*found_in,
@@ -6093,14 +6240,31 @@ NetExpr* PEIdent::elaborate_expr_param_bit_(Design*des, NetScope*scope,
 
       const name_component_t&name_tail = path_.back();
       ivl_assert(*this, !name_tail.index.empty());
+
+      perm_string name = peek_tail_name(path_);
+
+	// A multi-dimension unpacked array parameter, e.g.
+	//   localparam logic [3:0] TBL [0:3][0:15] = '{ '{...}, ... };
+	// Its value has been flattened row-major to a single packed constant.
+	// The path may apply one or more index expressions (a partial TBL[i] or
+	// the fully-indexed TBL[i][j]); each consumes one unpacked dimension and
+	// the selected slice keeps the remaining dimensions (plus the packed
+	// element) as its width. Handle this before the single-index machinery
+	// below, which only knows about the outermost dimension.
+      if (const netsarray_t*par_arr = dynamic_cast<const netsarray_t*>(par_type)) {
+	    if (!dynamic_cast<const netparray_t*>(par_arr)
+		&& par_arr->static_dimensions().size() > 1)
+		  return elaborate_expr_param_uarray_(des, scope, par_ex,
+						      found_in, par_arr,
+						      need_const, name);
+      }
+
       const index_component_t&index_tail = name_tail.index.back();
       ivl_assert(*this, index_tail.msb);
       ivl_assert(*this, !index_tail.lsb);
 
       NetExpr*sel = elab_and_eval(des, scope, index_tail.msb, -1, need_const);
       if (sel == 0) return 0;
-
-      perm_string name = peek_tail_name(path_);
 
 	// An index select of an array parameter selects a whole element, not
 	// a single bit. This applies both to a multi-dimension packed array,

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3484,6 +3484,20 @@ NetExpr* PECallFunction::elaborate_base_(Design*des, NetScope*scope, NetScope*ds
 	   return value is the name within that scope. */
 
       if (NetNet*res = dscope->find_signal(dscope->basename())) {
+	      // A function that returns an unpacked array can be evaluated in a
+	      // constant context (its result is folded into a constant), but the
+	      // run-time code generator has no representation for returning a
+	      // whole unpacked array. Reject a run-time call with a clean
+	      // diagnostic rather than emitting something that cannot be drawn.
+	    bool res_is_uarray = res->unpacked_dimensions() > 0
+		  || dynamic_cast<const netuarray_t*>(res->net_type());
+	    if (res_is_uarray && !need_const) {
+		  cerr << get_fileline() << ": sorry: a function that returns an "
+		          "unpacked array can only be called in a constant context "
+		          "(such as a parameter or localparam initializer)." << endl;
+		  des->errors += 1;
+		  return 0;
+	    }
 	    NetESignal*eres = new NetESignal(res);
 	    NetEUFunc*func = new NetEUFunc(scope, dscope, eres, parms, need_const);
 	    func->set_line(*this);
@@ -5292,9 +5306,23 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 	    return 0;
       }
 
+      const name_component_t&use_comp = path_.back();
+
+	// When the whole net is referenced (no unpacked index), the type to
+	// compare against the context is the net's type as seen by the caller.
+	// For an unpacked array that is the array type, not the element
+	// (net_type()) type. This lets a whole unpacked array be used where an
+	// unpacked-array type is expected, e.g. `return r;` in a function that
+	// returns an unpacked-array typedef.
+      ivl_type_t net_ctype = net->net_type();
+      if (net->unpacked_dimensions() > 0 && use_comp.index.empty()) {
+	    if (const netarray_t*at = net->array_type())
+		  net_ctype = at;
+      }
+
       ivl_type_t check_type = ntype;
       if (const netdarray_t*array_type = dynamic_cast<const netdarray_t*> (ntype)) {
-            if (array_type->type_compatible(net->net_type()) &&
+            if (array_type->type_compatible(net_ctype) &&
 		sr.path_tail.empty()) {
                   NetESignal*tmp = new NetESignal(net);
                   tmp->set_line(*this);
@@ -5306,13 +5334,13 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 	    check_type = array_type->element_type();
       }
 
-      if (! check_type->type_compatible(net->net_type())) {
+      if (! check_type->type_compatible(net_ctype)) {
 	    cerr << get_fileline() << ": error: the type of the variable '"
 		 << path_ << "' doesn't match the context type." << endl;
 
 	    cerr << get_fileline() << ":      : " << "variable type=";
-	    if (net->net_type())
-		  net->net_type()->debug_dump(cerr);
+	    if (net_ctype)
+		  net_ctype->debug_dump(cerr);
 	    else
 		  cerr << "<nil>";
 	    cerr << endl;
@@ -5324,9 +5352,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 	    des->errors += 1;
 	    return 0;
       }
-      ivl_assert(*this, ntype->type_compatible(net->net_type()));
-
-      const name_component_t&use_comp = path_.back();
+      ivl_assert(*this, ntype->type_compatible(net_ctype));
 
       if (debug_elaborate) {
 	    cerr << get_fileline() << ": PEIdent::elaborate_expr: "
@@ -5334,6 +5360,15 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 		 << " with " << use_comp.index.size() << " indices"
 		 << " and " << net->unpacked_dimensions() << " expected."
 		 << endl;
+      }
+
+	// A reference to the whole net (no index) elaborates to the signal
+	// itself. This covers scalars, packed vectors and whole unpacked
+	// arrays (e.g. returning an unpacked array by value).
+      if (use_comp.index.empty()) {
+	    NetESignal*tmp = new NetESignal(net);
+	    tmp->set_line(*this);
+	    return tmp;
       }
 
 // FIXME: The real array to queue is failing here.
@@ -5345,12 +5380,6 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
 		 << endl;
 	    des->errors += 1;
 
-	    NetESignal*tmp = new NetESignal(net);
-	    tmp->set_line(*this);
-	    return tmp;
-      }
-
-      if (net->unpacked_dimensions() == 0) {
 	    NetESignal*tmp = new NetESignal(net);
 	    tmp->set_line(*this);
 	    return tmp;

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -847,11 +847,6 @@ void PTaskFunc::elaborate_sig_ports_(Design*des, NetScope*scope,
 		       << "Function arguments must be input ports." << endl;
 		  des->errors += 1;
 	    }
-	    if (tmp->unpacked_dimensions() != 0) {
-		  cerr << get_fileline() << ": sorry: Subroutine ports with "
-			  "unpacked dimensions are not yet supported." << endl;
-		 des->errors += 1;
-	    }
       }
 }
 

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -4771,7 +4771,14 @@ NetProc* PCallTask::elaborate_build_call_(Design*des, NetScope*scope,
 	    NetExpr*rv = 0;
 
 	    if (args[parms_idx]) {
-		  rv = elaborate_rval_expr(des, scope, port->net_type(),
+		    // As for functions: an unpacked-array formal takes the
+		    // array type as its context, not the element type.
+		  ivl_type_t ctype = port->net_type();
+		  if (port->unpacked_dimensions() > 0) {
+			if (const netarray_t*at = port->array_type())
+			      ctype = at;
+		  }
+		  rv = elaborate_rval_expr(des, scope, ctype,
 					   args[parms_idx]);
 		  if (const NetEEvent*evt = dynamic_cast<NetEEvent*> (rv)) {
 			cerr << evt->get_fileline() << ": error: An event '"

--- a/emit.cc
+++ b/emit.cc
@@ -28,6 +28,7 @@
 # include  "target.h"
 # include  "netclass.h"
 # include  "netlist.h"
+# include  "netparray.h"
 # include  "compiler.h"
 # include  <typeinfo>
 # include  <cassert>
@@ -458,12 +459,40 @@ void netclass_t::emit_scope(struct target_t*tgt) const
       class_scope_->emit_scope(tgt);
 }
 
+/*
+ * A function that returns an unpacked array is evaluated entirely at
+ * elaboration time (in constant contexts); the run-time code generator has no
+ * representation for a whole-unpacked-array return value, and run-time calls to
+ * such a function are rejected during elaboration. So such a function scope is
+ * never referenced at run time and must not be emitted (drawing its body would
+ * fail). Detect that here.
+ */
+static bool skip_unpacked_array_func(const NetScope*scope)
+{
+      if (scope->type() != NetScope::FUNC)
+	    return false;
+      const NetFuncDef*def = scope->func_def();
+      if (!def)
+	    return false;
+      const NetNet*rsig = def->return_sig();
+      if (!rsig)
+	    return false;
+	// The unpacked array may be recorded either as separate unpacked
+	// dimensions on the signal or as a netuarray_t net type, depending on
+	// how the return signal was created.
+      return rsig->unpacked_dimensions() > 0
+	    || dynamic_cast<const netuarray_t*>(rsig->net_type());
+}
+
 void NetScope::emit_scope(struct target_t*tgt) const
 {
       if (debug_emit) {
 	    cerr << "NetScope::emit_scope: "
 		 << "Emit scope " << scope_path(this) << endl;
       }
+
+      if (skip_unpacked_array_func(this))
+	    return;
 
       tgt->scope(this);
 
@@ -511,6 +540,11 @@ bool NetScope::emit_defs(struct target_t*tgt) const
 	    cerr << "NetScope::emit_defs: "
 		 << "Emit definitions for " << scope_path(this) << endl;
       }
+
+	// Skip functions that return an unpacked array (see
+	// skip_unpacked_array_func): they are only used at elaboration time.
+      if (skip_unpacked_array_func(this))
+	    return true;
 
       switch (type_) {
 	  case PACKAGE:

--- a/eval_tree.cc
+++ b/eval_tree.cc
@@ -171,8 +171,15 @@ NetExpr* NetEBAdd::eval_tree()
 
             unsigned wid = expr_width();
             ivl_assert(*this, wid > 0);
-            ivl_assert(*this, lval.len() == wid);
-            ivl_assert(*this, rval.len() == wid);
+	      // Constant folding during compile-time function evaluation can
+	      // deliver operands whose width does not match the node width
+	      // (e.g. an int loop variable used in a narrower index
+	      // expression). Resize to the node width; for the elaboration-time
+	      // callers the operands already match, so this is a no-op.
+	    if (lval.len() != wid)
+		  lval = verinum(lval, wid);
+	    if (rval.len() != wid)
+		  rval = verinum(rval, wid);
 
 	    verinum val;
 	    if (op_ == se->op_) {
@@ -214,8 +221,15 @@ NetExpr* NetEBAdd::eval_arguments_(const NetExpr*l, const NetExpr*r) const
 
             unsigned wid = expr_width();
             ivl_assert(*this, wid > 0);
-            ivl_assert(*this, lval.len() == wid);
-            ivl_assert(*this, rval.len() == wid);
+	      // Constant folding during compile-time function evaluation can
+	      // deliver operands whose width does not match the node width
+	      // (e.g. an int loop variable used in a narrower index
+	      // expression). Resize to the node width; for the elaboration-time
+	      // callers the operands already match, so this is a no-op.
+	    if (lval.len() != wid)
+		  lval = verinum(lval, wid);
+	    if (rval.len() != wid)
+		  rval = verinum(rval, wid);
 
 	    verinum val;
 	    switch (op_) {

--- a/ivtest/gold/br_gh1180a-iverilog-stderr.gold
+++ b/ivtest/gold/br_gh1180a-iverilog-stderr.gold
@@ -1,1 +1,0 @@
-ivltests/br_gh1180a.v:3: sorry: packed array parameters are not supported yet.

--- a/ivtest/gold/br_gh1180b-iverilog-stderr.gold
+++ b/ivtest/gold/br_gh1180b-iverilog-stderr.gold
@@ -1,1 +1,0 @@
-ivltests/br_gh1180b.v:3: sorry: unpacked array parameters are not supported yet.

--- a/ivtest/ivltests/br_gh1180c.v
+++ b/ivtest/ivltests/br_gh1180c.v
@@ -1,0 +1,44 @@
+// Multi-dimension unpacked array parameters (GitHub #1180). The value is a
+// nested assignment pattern flattened row-major; an index select that consumes
+// every unpacked dimension yields the packed element. Exercises constant and
+// variable indices, ascending and descending declared ranges.
+module test();
+
+  // Ascending 2-D.
+  localparam logic [3:0] TBL [0:1][0:3] = '{ '{4'd1, 4'd2, 4'd3, 4'd4},
+                                             '{4'd5, 4'd6, 4'd7, 4'd8} };
+  // Descending outer dimension, ascending inner.
+  localparam logic [3:0] DTBL [1:0][0:3] = '{ '{4'd1, 4'd2, 4'd3, 4'd4},
+                                              '{4'd5, 4'd6, 4'd7, 4'd8} };
+  // 3-D.
+  localparam logic [3:0] CUBE [0:1][0:1][0:1] = '{ '{'{4'd1,4'd2}, '{4'd3,4'd4}},
+                                                   '{'{4'd5,4'd6}, '{4'd7,4'd8}} };
+
+  reg [1:0] r, c;
+  integer errs = 0;
+
+  task check(input [31:0] got, input [31:0] exp, input [127:0] label);
+    if (got !== exp) begin
+      errs = errs + 1;
+      $display("FAILED: %0s got %0d expected %0d", label, got, exp);
+    end
+  endtask
+
+  initial begin
+    // Constant indices (folded at elaboration).
+    check(TBL[0][0], 1, "TBL[0][0]");
+    check(TBL[1][3], 8, "TBL[1][3]");
+    // For a descending [1:0] range, '{a,b} assigns a->index1, b->index0.
+    check(DTBL[0][0], 5, "DTBL[0][0]");
+    check(DTBL[1][3], 4, "DTBL[1][3]");
+    check(CUBE[1][0][1], 6, "CUBE[1][0][1]");
+
+    // Variable indices (runtime part select of the flat value).
+    r = 1; c = 2; #1; check(TBL[r][c], 7, "TBL[r=1][c=2]");
+    r = 0; c = 1; #1; check(DTBL[r][c], 6, "DTBL[r=0][c=1]");
+
+    if (errs == 0) $display("PASSED");
+    else           $display("FAILED");
+  end
+
+endmodule

--- a/ivtest/ivltests/func_return_uarray.v
+++ b/ivtest/ivltests/func_return_uarray.v
@@ -1,0 +1,43 @@
+// A constant function that returns an unpacked array, used to initialize a
+// localparam ROM (a common way to build lookup tables). The array is evaluated
+// at elaboration time and then indexed. This is legal SystemVerilog that other
+// simulators accept. See the RS(576,514) GF decoder reproducer.
+
+module test;
+
+  typedef logic [9:0] rom_t [0:7];
+
+  function automatic rom_t build();
+    rom_t r;
+    int i;
+    for (i = 0 ; i < 8 ; i = i + 1)
+      r[i] = i * 3 + 1;
+    return r;
+  endfunction
+
+  localparam rom_t ROM = build();
+
+  // A constant element select must work in a constant expression too.
+  localparam int K = ROM[4];
+
+  integer i;
+  integer errors = 0;
+  logic [9:0] v;
+
+  initial begin
+    for (i = 0 ; i < 8 ; i = i + 1) begin
+      v = ROM[i];
+      if (v !== (i*3 + 1)) begin
+        errors = errors + 1;
+        $display("FAILED: ROM[%0d] = %0d, expected %0d", i, v, i*3 + 1);
+      end
+    end
+    if (K !== 13) begin
+      errors = errors + 1;
+      $display("FAILED: constant ROM[4] = %0d, expected 13", K);
+    end
+    if (errors == 0)
+      $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/func_return_uarray_2d.v
+++ b/ivtest/ivltests/func_return_uarray_2d.v
@@ -1,0 +1,39 @@
+// A constant function that returns a two-dimensional unpacked array, used to
+// initialize a localparam ROM. Exercises the flattened multi-index arithmetic
+// during compile-time function evaluation. See the RS(576,514) GF decoder
+// reproducer (the alpha^(o*m) tables).
+
+module test;
+
+  typedef logic [9:0] rom_t [0:7][0:31];
+
+  function automatic rom_t build();
+    rom_t t;
+    int o, m;
+    for (o = 0 ; o < 8 ; o = o + 1)
+      for (m = 0 ; m < 32 ; m = m + 1)
+        t[o][m] = o * 32 + m;
+    return t;
+  endfunction
+
+  localparam rom_t ROM = build();
+
+  integer o, m;
+  integer errors = 0;
+  logic [9:0] v;
+
+  initial begin
+    for (o = 0 ; o < 8 ; o = o + 1)
+      for (m = 0 ; m < 32 ; m = m + 1) begin
+        v = ROM[o][m];
+        if (v !== (o*32 + m)) begin
+          errors = errors + 1;
+          $display("FAILED: ROM[%0d][%0d] = %0d, expected %0d",
+                   o, m, v, o*32 + m);
+        end
+      end
+    if (errors == 0)
+      $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/func_return_uarray_rt_fail.v
+++ b/ivtest/ivltests/func_return_uarray_rt_fail.v
@@ -1,0 +1,23 @@
+// A function that returns an unpacked array can be evaluated in a constant
+// context, but the run-time code generator has no representation for returning
+// a whole unpacked array. Calling such a function at run time must be reported
+// with a clean error (not a crash).
+
+module test;
+
+  typedef logic [9:0] rom_t [0:3];
+
+  function automatic rom_t build();
+    rom_t r;
+    r[0] = 10'd1; r[1] = 10'd2; r[2] = 10'd3; r[3] = 10'd4;
+    return r;
+  endfunction
+
+  rom_t ROM;
+
+  initial begin
+    ROM = build();   // run-time call: not supported
+    $display("%0d", ROM[0]);
+  end
+
+endmodule

--- a/ivtest/ivltests/param_array_packed.v
+++ b/ivtest/ivltests/param_array_packed.v
@@ -1,0 +1,48 @@
+// Check that a multi-dimension packed array parameter can be initialized with
+// an assignment pattern and that an index select returns the whole element,
+// for both ascending and descending outer dimensions, and for both constant
+// and variable indices. See GitHub issue #1180.
+
+module test;
+
+  // Ascending and descending outer dimension, same element values.
+  localparam logic [0:7][3:0] PA = '{4'd8, 4'd9, 4'd10, 4'd11,
+                                     4'd12, 4'd13, 4'd14, 4'd15};
+  localparam logic [7:0][3:0] PD = '{4'd8, 4'd9, 4'd10, 4'd11,
+                                     4'd12, 4'd13, 4'd14, 4'd15};
+
+  // Reference nets initialized identically. Indexing these uses Icarus's
+  // existing (independent) net path, so they define the expected behavior.
+  logic [0:7][3:0] NA = '{4'd8, 4'd9, 4'd10, 4'd11,
+                          4'd12, 4'd13, 4'd14, 4'd15};
+  logic [7:0][3:0] ND = '{4'd8, 4'd9, 4'd10, 4'd11,
+                          4'd12, 4'd13, 4'd14, 4'd15};
+
+  // A constant element select must be usable in a constant expression.
+  localparam int K = PA[2];
+
+  integer i;
+  integer errors = 0;
+
+  initial begin
+    for (i = 0 ; i < 8 ; i = i + 1) begin
+      if (PA[i] !== NA[i]) begin
+        errors = errors + 1;
+        $display("FAILED: PA[%0d] = %0d, expected %0d", i, PA[i], NA[i]);
+      end
+      if (PD[i] !== ND[i]) begin
+        errors = errors + 1;
+        $display("FAILED: PD[%0d] = %0d, expected %0d", i, PD[i], ND[i]);
+      end
+    end
+
+    if (K !== 10) begin
+      errors = errors + 1;
+      $display("FAILED: constant PA[2] = %0d, expected 10", K);
+    end
+
+    if (errors == 0)
+      $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/param_array_param_ref.v
+++ b/ivtest/ivltests/param_array_param_ref.v
@@ -1,0 +1,75 @@
+/*
+ * Unpacked array parameters used in the ways reported against PR #501:
+ *   - an element of one array parameter feeding the initialiser of another,
+ *     nested two levels deep
+ *   - an element inside a constant function call ($clog2)
+ *   - `integer` (signed, 4-state) elements rather than logic vectors
+ *   - a run-time variable index, in both a continuous assignment and a
+ *     procedural block
+ * Each of these crashed that branch with a different assertion.
+ */
+module top;
+
+   localparam integer NTAPS  [0:3] = '{ 960, 540, 360, 180 };
+   localparam integer R      [0:3] = '{ 20, 10, 4, 2 };
+
+   // element of a previous array parameter, with arithmetic
+   localparam integer NCOEFF [0:3] = '{ NTAPS[0]/2, NTAPS[1]/2,
+					NTAPS[2]/2, NTAPS[3]/2 };
+
+   // scalar parameter folded from array elements
+   localparam integer TOTAL = NCOEFF[0] + NCOEFF[1] + NCOEFF[2] + NCOEFF[3];
+
+   // array element inside a constant system function
+   localparam integer N_PSF_W   = $clog2(R[0]);
+   localparam integer N_PCOEF_W = $clog2(NCOEFF[3] / R[3]);
+
+   // two levels of parameter referencing parameter
+   localparam integer T2 [0:1] = '{ 32, 688 };
+   localparam integer C2 [0:1] = '{ T2[0]/2, T2[1]/2 };
+   localparam integer B2 [0:1] = '{ 0, C2[0] };
+
+   reg  [1:0]         f;
+   wire signed [15:0] y_ca;
+   reg  signed [15:0] y_pr;
+
+   assign y_ca = NTAPS[f];        // variable index, continuous assignment
+   always @* y_pr = NTAPS[f];     // variable index, procedural
+
+   integer errors = 0;
+
+   task ck(input [8*16:1] nm, input integer got, input integer exp);
+      begin
+	 if (got !== exp) begin
+	    $display("FAILED -- %0s got %0d expected %0d", nm, got, exp);
+	    errors = errors + 1;
+	 end
+      end
+   endtask
+
+   initial begin
+      ck("NCOEFF[0]", NCOEFF[0], 480);
+      ck("NCOEFF[3]", NCOEFF[3], 90);
+      ck("TOTAL",     TOTAL,     1020);
+      ck("N_PSF_W",   N_PSF_W,   5);   // $clog2(20)
+      ck("N_PCOEF_W", N_PCOEF_W, 6);   // $clog2(45)
+      ck("B2[1]",     B2[1],     16);  // C2[0] = 32/2
+
+      for (int i = 0; i < 4; i = i + 1) begin
+	 f = i[1:0];
+	 #1;
+	 if (y_ca !== NTAPS[i]) begin
+	    $display("FAILED -- continuous assign index %0d gave %0d", i, y_ca);
+	    errors = errors + 1;
+	 end
+	 if (y_pr !== NTAPS[i]) begin
+	    $display("FAILED -- procedural index %0d gave %0d", i, y_pr);
+	    errors = errors + 1;
+	 end
+      end
+
+      if (errors == 0) $display("PASSED");
+      $finish;
+   end
+
+endmodule

--- a/ivtest/ivltests/param_array_unpacked.v
+++ b/ivtest/ivltests/param_array_unpacked.v
@@ -1,0 +1,49 @@
+// Check that an unpacked array parameter can be initialized with an assignment
+// pattern and that an index select returns the addressed element, for both
+// ascending and descending declared ranges, and for both constant and variable
+// indices. See GitHub issue #1180.
+
+module test;
+
+  // Ascending and descending unpacked dimension, same element values.
+  localparam logic [3:0] PA [0:7] = '{4'd8, 4'd9, 4'd10, 4'd11,
+                                      4'd12, 4'd13, 4'd14, 4'd15};
+  localparam logic [3:0] PD [7:0] = '{4'd8, 4'd9, 4'd10, 4'd11,
+                                      4'd12, 4'd13, 4'd14, 4'd15};
+
+  // Reference nets initialized identically. Indexing these uses Icarus's
+  // existing (independent) net path, so they define the expected behavior.
+  logic [3:0] NA [0:7];
+  logic [3:0] ND [7:0];
+
+  // A constant element select must be usable in a constant expression.
+  localparam int K = PA[3];
+
+  integer i;
+  integer errors = 0;
+
+  initial begin
+    NA = '{4'd8, 4'd9, 4'd10, 4'd11, 4'd12, 4'd13, 4'd14, 4'd15};
+    ND = '{4'd8, 4'd9, 4'd10, 4'd11, 4'd12, 4'd13, 4'd14, 4'd15};
+
+    for (i = 0 ; i < 8 ; i = i + 1) begin
+      if (PA[i] !== NA[i]) begin
+        errors = errors + 1;
+        $display("FAILED: PA[%0d] = %0d, expected %0d", i, PA[i], NA[i]);
+      end
+      if (PD[i] !== ND[i]) begin
+        errors = errors + 1;
+        $display("FAILED: PD[%0d] = %0d, expected %0d", i, PD[i], ND[i]);
+      end
+    end
+
+    if (K !== 11) begin
+      errors = errors + 1;
+      $display("FAILED: constant PA[3] = %0d, expected 11", K);
+    end
+
+    if (errors == 0)
+      $display("PASSED");
+  end
+
+endmodule

--- a/ivtest/ivltests/uarray_ca_fail.v
+++ b/ivtest/ivltests/uarray_ca_fail.v
@@ -1,0 +1,25 @@
+/*
+ * Passing an unpacked array to a function from a continuous assignment is not
+ * supported: a .ufunc node is driven by nexuses and an unpacked array is not a
+ * net. Check that this is reported rather than asserting.
+ */
+module top;
+   logic [7:0] a [0:3];
+   logic [7:0] y;
+
+   function automatic logic [7:0] sum4(input logic [7:0] v [0:3]);
+      logic [7:0] r;
+      begin
+	 r = '0;
+	 for (int i = 0; i < 4; i++) r += v[i];
+	 return r;
+      end
+   endfunction
+
+   assign y = sum4(a);
+
+   initial begin
+      $display("FAILED -- should not have compiled");
+      $finish;
+   end
+endmodule

--- a/ivtest/ivltests/uarray_subroutine_port.v
+++ b/ivtest/ivltests/uarray_subroutine_port.v
@@ -1,0 +1,114 @@
+/*
+ * Passing a whole unpacked array to a function or task, and copying one
+ * unpacked array to another at run time. Covers ascending and descending
+ * declared ranges, two dimensions, real elements, and x propagation.
+ */
+module top;
+
+   logic [7:0] asc [0:3];
+   logic [7:0] cpy [0:3];
+   logic [7:0] dsc [3:0];
+   logic [3:0] m2d [0:1][0:2];
+   logic [3:0] n2d [0:1][0:2];
+   real        rr  [0:3];
+   real        rc  [0:3];
+
+   int errors = 0;
+
+   function automatic logic [7:0] sum4(input logic [7:0] a [0:3]);
+      logic [7:0] r;
+      begin
+	 r = '0;
+	 for (int i = 0; i < 4; i++) r += a[i];
+	 return r;
+      end
+   endfunction
+
+   function automatic logic [7:0] sum4d(input logic [7:0] a [3:0]);
+      logic [7:0] r;
+      begin
+	 r = '0;
+	 for (int i = 0; i < 4; i++) r += a[i];
+	 return r;
+      end
+   endfunction
+
+   function automatic real rsum(input real a [0:3]);
+      real r;
+      begin
+	 r = 0.0;
+	 for (int i = 0; i < 4; i++) r = r + a[i];
+	 return r;
+      end
+   endfunction
+
+   task automatic copy2d(input logic [3:0] s [0:1][0:2]);
+      n2d = s;
+   endtask
+
+   // A function used from a procedural context, taking an array argument.
+   logic [7:0] comb_out;
+   always_comb comb_out = sum4(asc);
+
+   initial begin
+      for (int i = 0; i < 4; i++) asc[i] = 8'(i + 1);
+      for (int i = 0; i < 4; i++) dsc[i] = 8'(i + 1);
+      for (int i = 0; i < 2; i++)
+	for (int j = 0; j < 3; j++) m2d[i][j] = 4'(i*3 + j);
+      for (int i = 0; i < 4; i++) rr[i] = i * 1.5;
+
+      // whole unpacked array assignment at run time
+      cpy = asc;
+      if (cpy[0] !== 8'd1 || cpy[3] !== 8'd4) begin
+	 $display("FAILED -- array copy cpy[0]=%0d cpy[3]=%0d", cpy[0], cpy[3]);
+	 errors = errors + 1;
+      end
+
+      // array passed to a function, ascending and descending ranges
+      if (sum4(asc) !== 8'd10) begin
+	 $display("FAILED -- sum4=%0d", sum4(asc));
+	 errors = errors + 1;
+      end
+      if (sum4d(dsc) !== 8'd10) begin
+	 $display("FAILED -- sum4d=%0d", sum4d(dsc));
+	 errors = errors + 1;
+      end
+
+      // array passed to a task, two dimensions
+      copy2d(m2d);
+      if (n2d[1][2] !== 4'd5) begin
+	 $display("FAILED -- copy2d n2d[1][2]=%0d", n2d[1][2]);
+	 errors = errors + 1;
+      end
+
+      // real elements, both copy and argument
+      rc = rr;
+      if (rc[3] != 4.5) begin
+	 $display("FAILED -- real copy rc[3]=%f", rc[3]);
+	 errors = errors + 1;
+      end
+      if (rsum(rr) != 9.0) begin
+	 $display("FAILED -- rsum=%f", rsum(rr));
+	 errors = errors + 1;
+      end
+
+      // x propagates through a copy
+      asc[2] = 8'bxxxxxxxx;
+      cpy = asc;
+      if (cpy[2] !== 8'bxxxxxxxx) begin
+	 $display("FAILED -- x propagation cpy[2]=%b", cpy[2]);
+	 errors = errors + 1;
+      end
+
+      // the always_comb above should have tracked asc
+      #1;
+      if (comb_out !== sum4(asc)) begin
+	 $display("FAILED -- always_comb out=%0d expected %0d", comb_out, sum4(asc));
+	 errors = errors + 1;
+      end
+
+      if (errors == 0) $display("PASSED");
+      $finish;
+   end
+
+endmodule

--- a/ivtest/ivltests/uarray_subroutine_port.v
+++ b/ivtest/ivltests/uarray_subroutine_port.v
@@ -46,6 +46,15 @@ module top;
       n2d = s;
    endtask
 
+   // output and inout array ports, which need the copy in the other direction
+   task automatic fill_out(output logic [7:0] o [0:3]);
+      for (int i = 0; i < 4; i++) o[i] = 8'(i + 10);
+   endtask
+
+   task automatic bump_inout(inout logic [7:0] io [0:3]);
+      for (int i = 0; i < 4; i++) io[i] = io[i] + 8'd1;
+   endtask
+
    // A function used from a procedural context, taking an array argument.
    logic [7:0] comb_out;
    always_comb comb_out = sum4(asc);
@@ -89,6 +98,20 @@ module top;
       end
       if (rsum(rr) != 9.0) begin
 	 $display("FAILED -- rsum=%f", rsum(rr));
+	 errors = errors + 1;
+      end
+
+      // output port: callee writes the caller's array
+      fill_out(cpy);
+      if (cpy[0] !== 8'd10 || cpy[3] !== 8'd13) begin
+	 $display("FAILED -- output port cpy[0]=%0d cpy[3]=%0d", cpy[0], cpy[3]);
+	 errors = errors + 1;
+      end
+
+      // inout port: copied in, modified, copied back
+      bump_inout(cpy);
+      if (cpy[3] !== 8'd14) begin
+	 $display("FAILED -- inout port cpy[3]=%0d", cpy[3]);
 	 errors = errors + 1;
       end
 

--- a/ivtest/regress-fsv.list
+++ b/ivtest/regress-fsv.list
@@ -68,6 +68,7 @@
 #
 
 # Some constructs/usage are not errors in SystemVerilog
+br1015a				normal			ivltests
 br1027a				normal			ivltests gold=br1027a-fsv.gold
 br1027c				normal			ivltests gold=br1027c-fsv.gold
 br1027e				normal			ivltests gold=br1027e-fsv.gold
@@ -110,8 +111,6 @@ array_lval_select3a		NI			ivltests
 br605a				NI			ivltests
 br605b				NI			ivltests
 br971				NI			ivltests
-br1015a				NI			ivltests
-br1015b				NI			ivltests
 br_ml20150315b			NI			ivltests
 sv_darray_nest1			NI			ivltests
 sv_darray_nest2			NI			ivltests

--- a/ivtest/regress-ivl1.list
+++ b/ivtest/regress-ivl1.list
@@ -274,7 +274,6 @@ array_lval_select3a	CE			ivltests
 br605a			EF			ivltests
 br605b			EF			ivltests
 br971			EF			ivltests
-br1015b			CE,-g2009		ivltests
 br_ml20150315b		CE,-g2009		ivltests
 sv_deferred_assert1	CE,-g2009		ivltests gold=sv_deferred_assert1.gold
 sv_deferred_assert2	CE,-g2009		ivltests gold=sv_deferred_assert2.gold

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -73,6 +73,7 @@ br_gh1155			vvp_tests/br_gh1155.json
 br_gh1163			vvp_tests/br_gh1163.json
 br_gh1180a			vvp_tests/br_gh1180a.json
 br_gh1180b			vvp_tests/br_gh1180b.json
+br_gh1180c			vvp_tests/br_gh1180c.json
 param_array_packed		vvp_tests/param_array_packed.json
 param_array_unpacked		vvp_tests/param_array_unpacked.json
 br_gh1181			vvp_tests/br_gh1181.json

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -530,3 +530,4 @@ wreal				vvp_tests/wreal.json
 writemem-invalid		vvp_tests/writemem-invalid.json
 uarray_subroutine_port	vvp_tests/uarray_subroutine_port.json
 uarray_ca_fail		vvp_tests/uarray_ca_fail.json
+param_array_param_ref	vvp_tests/param_array_param_ref.json

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -73,6 +73,8 @@ br_gh1155			vvp_tests/br_gh1155.json
 br_gh1163			vvp_tests/br_gh1163.json
 br_gh1180a			vvp_tests/br_gh1180a.json
 br_gh1180b			vvp_tests/br_gh1180b.json
+param_array_packed		vvp_tests/param_array_packed.json
+param_array_unpacked		vvp_tests/param_array_unpacked.json
 br_gh1181			vvp_tests/br_gh1181.json
 br_gh1184			vvp_tests/br_gh1184.json
 br_gh1242			vvp_tests/br_gh1242.json

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -528,3 +528,5 @@ vvp_quiet_mode			vvp_tests/vvp_quiet_mode.json
 warn_opt_sys_tf			vvp_tests/warn_opt_sys_tf.json
 wreal				vvp_tests/wreal.json
 writemem-invalid		vvp_tests/writemem-invalid.json
+uarray_subroutine_port	vvp_tests/uarray_subroutine_port.json
+uarray_ca_fail		vvp_tests/uarray_ca_fail.json

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -76,6 +76,9 @@ br_gh1180b			vvp_tests/br_gh1180b.json
 br_gh1180c			vvp_tests/br_gh1180c.json
 param_array_packed		vvp_tests/param_array_packed.json
 param_array_unpacked		vvp_tests/param_array_unpacked.json
+func_return_uarray		vvp_tests/func_return_uarray.json
+func_return_uarray_2d		vvp_tests/func_return_uarray_2d.json
+func_return_uarray_rt_fail	vvp_tests/func_return_uarray_rt_fail.json
 br_gh1181			vvp_tests/br_gh1181.json
 br_gh1184			vvp_tests/br_gh1184.json
 br_gh1242			vvp_tests/br_gh1242.json

--- a/ivtest/vvp_tests/br_gh1180a.json
+++ b/ivtest/vvp_tests/br_gh1180a.json
@@ -1,6 +1,5 @@
 {
-    "type"   : "CE",
+    "type"   : "normal",
     "source" : "br_gh1180a.v",
-    "iverilog-args" : [ "-g2009" ],
-    "gold" : "br_gh1180a"
+    "iverilog-args" : [ "-g2009" ]
 }

--- a/ivtest/vvp_tests/br_gh1180b.json
+++ b/ivtest/vvp_tests/br_gh1180b.json
@@ -1,6 +1,5 @@
 {
-    "type"   : "CE",
+    "type"   : "normal",
     "source" : "br_gh1180b.v",
-    "iverilog-args" : [ "-g2009" ],
-    "gold" : "br_gh1180b"
+    "iverilog-args" : [ "-g2009" ]
 }

--- a/ivtest/vvp_tests/br_gh1180c.json
+++ b/ivtest/vvp_tests/br_gh1180c.json
@@ -1,0 +1,5 @@
+{
+    "type"   : "normal",
+    "source" : "br_gh1180c.v",
+    "iverilog-args" : [ "-g2009" ]
+}

--- a/ivtest/vvp_tests/func_return_uarray.json
+++ b/ivtest/vvp_tests/func_return_uarray.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "func_return_uarray.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/ivtest/vvp_tests/func_return_uarray_2d.json
+++ b/ivtest/vvp_tests/func_return_uarray_2d.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "func_return_uarray_2d.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/ivtest/vvp_tests/func_return_uarray_rt_fail.json
+++ b/ivtest/vvp_tests/func_return_uarray_rt_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "func_return_uarray_rt_fail.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/ivtest/vvp_tests/param_array_packed.json
+++ b/ivtest/vvp_tests/param_array_packed.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "param_array_packed.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/param_array_param_ref.json
+++ b/ivtest/vvp_tests/param_array_param_ref.json
@@ -1,0 +1,5 @@
+{
+    "type"   : "normal",
+    "source" : "param_array_param_ref.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/ivtest/vvp_tests/param_array_unpacked.json
+++ b/ivtest/vvp_tests/param_array_unpacked.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "param_array_unpacked.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/uarray_ca_fail.json
+++ b/ivtest/vvp_tests/uarray_ca_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"   : "CE",
+    "source" : "uarray_ca_fail.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/ivtest/vvp_tests/uarray_subroutine_port.json
+++ b/ivtest/vvp_tests/uarray_subroutine_port.json
@@ -1,0 +1,5 @@
+{
+    "type"   : "normal",
+    "source" : "uarray_subroutine_port.v",
+    "iverilog-args" : [ "-g2012" ]
+}

--- a/net_design.cc
+++ b/net_design.cc
@@ -499,6 +499,52 @@ void Design::evaluate_parameters()
       }
 }
 
+/*
+ * A constant unpacked-array parameter, e.g.
+ *   localparam logic [3:0] MEM [0:63] = '{ ... };
+ * elaborates to a NetEArrayPattern rather than a foldable NetEConst. Flatten
+ * that pattern of constant elements into a single packed constant. The pattern
+ * items are already stored lowest-array-index first (NetEArrayPattern item[k]
+ * is the value at array index min_index+k, independent of the declared index
+ * direction), so lay item[k] at bit offset k*elem_w. Element index selects
+ * undo this in elaborate_expr_param_slice_().
+ * Returns nullptr if any element is not a foldable constant (e.g. a nested
+ * unpacked array), in which case the caller falls back to the normal error.
+ */
+static NetExpr* flatten_const_array_pattern(const NetEArrayPattern*pat,
+					    const netarray_t*arr,
+					    const LineInfo&loc)
+{
+      unsigned long elem_w = arr->element_type()->packed_width();
+      size_t count = pat->item_size();
+      if (elem_w == 0 || count == 0)
+	    return nullptr;
+
+      verinum flat (verinum::Vx, elem_w * count, true);
+      for (size_t idx = 0 ; idx < count ; idx += 1) {
+	    const NetEConst*item = dynamic_cast<const NetEConst*>(pat->item(idx));
+	    if (!item)
+		  return nullptr;
+
+	    const verinum&iv = item->value();
+	    unsigned long base = (unsigned long)idx * elem_w;
+	    for (unsigned long bit = 0 ; bit < elem_w ; bit += 1) {
+		  verinum::V val;
+		  if (bit < iv.len())
+			val = iv.get(bit);
+		  else if (iv.has_sign() && iv.len() > 0)
+			val = iv.get(iv.len() - 1);
+		  else
+			val = verinum::V0;
+		  flat.set(base + bit, val);
+	    }
+      }
+
+      NetEConst*res = new NetEConst(flat);
+      res->set_line(loc);
+      return res;
+}
+
 void NetScope::evaluate_parameter_logic_(Design*des, param_ref_t cur)
 {
 	/* Evaluate the parameter expression. */
@@ -562,6 +608,18 @@ void NetScope::evaluate_parameter_logic_(Design*des, param_ref_t cur)
       }
       if (! expr)
             return;
+
+      // A constant unpacked-array parameter elaborates to a NetEArrayPattern.
+      // Flatten it into the packed-equivalent constant so it can be stored and
+      // indexed like any other packed value.
+      if (const NetEArrayPattern*pat = dynamic_cast<const NetEArrayPattern*>(expr)) {
+	    if (const netarray_t*arr = dynamic_cast<const netarray_t*>(param_type)) {
+		  if (NetExpr*flat = flatten_const_array_pattern(pat, arr, *expr)) {
+			delete expr;
+			expr = flat;
+		  }
+	    }
+      }
 
       // Make sure to carry the signed-ness from a vector type.
       if (param_vect)

--- a/net_design.cc
+++ b/net_design.cc
@@ -500,33 +500,61 @@ void Design::evaluate_parameters()
 }
 
 /*
+ * Recursively collect the constant leaf elements of a (possibly nested) array
+ * assignment pattern in row-major order: outermost dimension first, and within
+ * each dimension lowest-array-index first (NetEArrayPattern item[k] is the
+ * value at array index min_index+k, independent of the declared index
+ * direction). Returns false if any leaf is not a foldable constant.
+ */
+static bool collect_pattern_leaves(const NetExpr*expr,
+				   std::vector<const NetEConst*>&leaves)
+{
+      if (const NetEConst*c = dynamic_cast<const NetEConst*>(expr)) {
+	    leaves.push_back(c);
+	    return true;
+      }
+      if (const NetEArrayPattern*p = dynamic_cast<const NetEArrayPattern*>(expr)) {
+	    for (size_t idx = 0 ; idx < p->item_size() ; idx += 1) {
+		  const NetExpr*it = p->item(idx);
+		  if (!it || !collect_pattern_leaves(it, leaves))
+			return false;
+	    }
+	    return true;
+      }
+      return false;
+}
+
+/*
  * A constant unpacked-array parameter, e.g.
  *   localparam logic [3:0] MEM [0:63] = '{ ... };
- * elaborates to a NetEArrayPattern rather than a foldable NetEConst. Flatten
- * that pattern of constant elements into a single packed constant. The pattern
- * items are already stored lowest-array-index first (NetEArrayPattern item[k]
- * is the value at array index min_index+k, independent of the declared index
- * direction), so lay item[k] at bit offset k*elem_w. Element index selects
- * undo this in elaborate_expr_param_slice_().
- * Returns nullptr if any element is not a foldable constant (e.g. a nested
- * unpacked array), in which case the caller falls back to the normal error.
+ * or a multi-dimension unpacked array, e.g.
+ *   localparam logic [3:0] TBL [0:3][0:15] = '{ '{...}, ... };
+ * elaborates to a (possibly nested) NetEArrayPattern rather than a foldable
+ * NetEConst. Flatten the pattern's constant leaf elements into a single packed
+ * constant, laying leaf k at bit offset k*elem_w where the leaves are in
+ * row-major order (see collect_pattern_leaves). Element index selects undo this
+ * in elaborate_expr_param_slice_().
+ * Returns nullptr if any leaf is not a foldable constant, in which case the
+ * caller falls back to the normal error.
  */
 static NetExpr* flatten_const_array_pattern(const NetEArrayPattern*pat,
 					    const netarray_t*arr,
 					    const LineInfo&loc)
 {
       unsigned long elem_w = arr->element_type()->packed_width();
-      size_t count = pat->item_size();
-      if (elem_w == 0 || count == 0)
+      if (elem_w == 0)
+	    return nullptr;
+
+      std::vector<const NetEConst*> leaves;
+      if (!collect_pattern_leaves(pat, leaves))
+	    return nullptr;
+      size_t count = leaves.size();
+      if (count == 0)
 	    return nullptr;
 
       verinum flat (verinum::Vx, elem_w * count, true);
       for (size_t idx = 0 ; idx < count ; idx += 1) {
-	    const NetEConst*item = dynamic_cast<const NetEConst*>(pat->item(idx));
-	    if (!item)
-		  return nullptr;
-
-	    const verinum&iv = item->value();
+	    const verinum&iv = leaves[idx]->value();
 	    unsigned long base = (unsigned long)idx * elem_w;
 	    for (unsigned long bit = 0 ; bit < elem_w ; bit += 1) {
 		  verinum::V val;

--- a/net_func_eval.cc
+++ b/net_func_eval.cc
@@ -1097,6 +1097,29 @@ NetExpr* NetESignal::evaluate_function(const LineInfo&loc,
       }
 
       const NetExpr*value = 0;
+      if (var->nwords > 0 && word_ == 0) {
+	      // A reference to the whole unpacked array (no word index), e.g.
+	      // `return arr;` in a constant function. Assemble the current word
+	      // values into an array pattern that later evaluation (e.g. the
+	      // enclosing localparam) can consume/flatten.
+	    const netarray_t*atype = sig()->array_type();
+	    ivl_assert(loc, atype);
+	    ivl_type_t etype = atype->element_type();
+	    std::vector<NetExpr*> items (var->nwords);
+	    for (int idx = 0 ; idx < var->nwords ; idx += 1) {
+		  if (var->array[idx]) {
+			items[idx] = var->array[idx]->dup_expr();
+		  } else if (etype->base_type() == IVL_VT_REAL) {
+			items[idx] = new NetECReal(verireal(0.0));
+		  } else {
+			items[idx] = new NetEConst(verinum(verinum::Vx,
+						   etype->packed_width(), true));
+		  }
+	    }
+	    NetEArrayPattern*ap = new NetEArrayPattern(atype, items);
+	    ap->set_line(loc);
+	    return ap;
+      }
       if (var->nwords > 0) {
 	    ivl_assert(loc, word_);
 	    NetExpr*word_result = word_->evaluate_function(loc, context_map);

--- a/net_nex_input.cc
+++ b/net_nex_input.cc
@@ -280,8 +280,10 @@ static void func_always_sens(NetFuncDef *func, NexusSet *result,
 	std::unique_ptr<NexusSet> in(new NexusSet);
 	for (unsigned idx = 0; idx < func->port_count(); idx++) {
 	      NetNet *net = func->port(idx);
-	      assert(net->pin_count() == 1);
-	      in->add(net->pin(0).nexus(), 0, net->vector_width());
+		// A port with unpacked dimensions has one pin per word, so
+		// remove them all, not just the first.
+	      for (unsigned pin = 0 ; pin < net->pin_count() ; pin += 1)
+		    in->add(net->pin(pin).nexus(), 0, net->vector_width());
 	}
 	tmp->rem(*in);
 	result->add(*tmp);

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -969,8 +969,17 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 	// checking should be used for all expressions, but at the moment not
 	// all expressions do have a ivl_type_t attached to it.
       if (dynamic_cast<const netuarray_t*>(lv_net_type)) {
-	    if (tmp->net_type())
-		  compatible = lv_net_type->type_compatible(tmp->net_type());
+	      // A whole unpacked-array reference (e.g. `return arr;` or an
+	      // array-to-array copy) elaborates to a NetESignal whose net_type()
+	      // is the element type. Compare against the signal's array type so
+	      // the unpacked array is accepted where an unpacked array is wanted.
+	    ivl_type_t rtype = tmp->net_type();
+	    if (const NetESignal*esig = dynamic_cast<const NetESignal*>(tmp)) {
+		  if (esig->word_index() == 0 && esig->sig()->array_type())
+			rtype = esig->sig()->array_type();
+	    }
+	    if (rtype)
+		  compatible = lv_net_type->type_compatible(rtype);
 	    else
 		  compatible = false;
       } else if ((cast_type == IVL_VT_QUEUE || cast_type == IVL_VT_DARRAY) &&

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -1898,7 +1898,16 @@ bool calculate_param_range(const LineInfo&line, ivl_type_t par_type,
 	    par_lsv = 0;
 	    return true;
       }
-      ivl_assert(line, packed_dims.size() == 1);
+
+      // A multi-dimension packed array parameter has no single declared
+      // range. Index (element) selects are handled separately; for a flat
+      // part/bit select fall back to the canonical [width-1:0] range so we
+      // don't crash on the less common cases.
+      if (packed_dims.size() > 1) {
+	    par_msv = (long)vector_type->packed_width() - 1;
+	    par_lsv = 0;
+	    return true;
+      }
 
       netrange_t use_range = packed_dims[0];
       par_msv = use_range.get_msb();

--- a/pform.cc
+++ b/pform.cc
@@ -3109,10 +3109,11 @@ void pform_set_parameter(const struct vlltype&loc,
 
       const vector_type_t*vt = dynamic_cast<vector_type_t*>(data_type);
       if (vt && vt->pdims && vt->pdims->size() > 1) {
-	    if (pform_requires_sv(loc, "packed array parameter")) {
-		  VLerror(loc, "sorry: packed array parameters are not supported yet.");
-	    }
-	    return;
+	    // A multi-dimension packed array parameter, e.g.
+	    //   localparam logic [0:63][3:0] MEM = '{ ... };
+	    // The value elaborates to a foldable packed constant and the
+	    // multi-dimension type is carried through for element selects.
+	    pform_requires_sv(loc, "packed array parameter");
       }
 
       if (udims) {

--- a/pform.cc
+++ b/pform.cc
@@ -3117,10 +3117,14 @@ void pform_set_parameter(const struct vlltype&loc,
       }
 
       if (udims) {
+	    // An unpacked array parameter, e.g.
+	    //   localparam logic [3:0] MEM [0:63] = '{ ... };
+	    // Wrap the element data type in an unpacked array type (mirrors the
+	    // wire declaration path) so the parameter carries a netuarray_t.
 	    if (pform_requires_sv(loc, "unpacked array parameter")) {
-		  VLerror(loc, "sorry: unpacked array parameters are not supported yet.");
+		  data_type = new uarray_type_t(data_type,
+				   new std::list<pform_range_t>(*udims));
 	    }
-	    return;
       }
 
       bool overridable = !is_local;

--- a/tgt-vvp/draw_ufunc.c
+++ b/tgt-vvp/draw_ufunc.c
@@ -26,8 +26,10 @@ static void function_argument_logic(ivl_signal_t port, ivl_expr_t expr)
 {
       unsigned ewidth, pwidth;
 
-	/* ports cannot be arrays. */
-      assert(ivl_signal_dimensions(port) == 0);
+	/* An unpacked array port is copied straight from the source signal in
+	   the send pass, so there is nothing to evaluate onto the stack. */
+      if (ivl_signal_dimensions(port) > 0)
+	    return;
 
       ewidth = ivl_expr_width(expr);
       pwidth = ivl_signal_width(port);
@@ -40,8 +42,10 @@ static void function_argument_logic(ivl_signal_t port, ivl_expr_t expr)
 
 static void function_argument_real(ivl_signal_t port, ivl_expr_t expr)
 {
-	/* ports cannot be arrays. */
-      assert(ivl_signal_dimensions(port) == 0);
+	/* See function_argument_logic: array ports are handled in the send
+	   pass. */
+      if (ivl_signal_dimensions(port) > 0)
+	    return;
 
       draw_eval_real(expr);
 }
@@ -74,9 +78,18 @@ static void draw_eval_function_argument(ivl_signal_t port, ivl_expr_t expr)
       }
 }
 
-static void draw_send_function_argument(ivl_signal_t port)
+static void draw_send_function_argument(ivl_signal_t port, ivl_expr_t expr)
 {
       ivl_variable_type_t dtype = ivl_signal_data_type(port);
+
+	/* An unpacked array argument is a memory-to-memory copy rather than a
+	   value on the stack, so it is done here in the send pass, reading the
+	   source signal directly. */
+      if (ivl_signal_dimensions(port) > 0) {
+	    vvp_errors += draw_array_copy(port, expr);
+	    return;
+      }
+
       switch (dtype) {
 	  case IVL_VT_BOOL:
 	      /* For now, treat bit2 variables as bit4 variables. */
@@ -126,7 +139,7 @@ static void draw_ufunc_preamble(ivl_expr_t expr)
       }
       for (idx = ivl_expr_parms(expr) ;  idx > 0 ;  idx -= 1) {
 	    ivl_signal_t port = ivl_scope_port(def, idx);
-	    draw_send_function_argument(port);
+	    draw_send_function_argument(port, ivl_expr_parm(expr, idx-1));
       }
 
 	/* Call the function */

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -597,6 +597,67 @@ static void draw_stmt_assign_vector_opcode(unsigned char opcode, bool is_signed)
       }
 }
 
+/*
+ * Copy a whole unpacked array into another, element by element.
+ *
+ * The run-time has no bulk array-copy opcode, but it does have indexed word
+ * access, so emit the same %ix/load + %store/vec4a idiom draw_array_pattern
+ * uses, reading each word with %load/vec4a instead of evaluating a pattern
+ * element. Both arrays are known to have the same shape and element type:
+ * the elaborator checks that (IEEE 1800-2023 7.6) before we get here.
+ *
+ * Emitted straight-line rather than as a loop. That keeps this independent of
+ * the label allocator, and matches draw_array_pattern, which unrolls too.
+ */
+int draw_array_copy(ivl_signal_t dst, ivl_expr_t rval)
+{
+      ivl_signal_t src = ivl_expr_signal(rval);
+      unsigned count = ivl_signal_array_count(dst);
+
+      if (src == 0) {
+	    fprintf(stderr, "%s:%u: sorry: only a whole array variable can be "
+		    "copied to an unpacked array.\n",
+		    ivl_expr_file(rval), ivl_expr_lineno(rval));
+	    return 1;
+      }
+      if (ivl_signal_array_count(src) != count) {
+	    fprintf(stderr, "%s:%u: error: unpacked array copy needs matching "
+		    "sizes (%u versus %u).\n",
+		    ivl_expr_file(rval), ivl_expr_lineno(rval),
+		    ivl_signal_array_count(src), count);
+	    return 1;
+      }
+
+      switch (ivl_signal_data_type(dst)) {
+	  case IVL_VT_BOOL:
+	  case IVL_VT_LOGIC:
+	    for (unsigned idx = 0 ; idx < count ; idx += 1) {
+		  fprintf(vvp_out, "    %%ix/load 3, %u, 0;\n", idx);
+		  fprintf(vvp_out, "    %%flag_set/imm 4, 0;\n");
+		  fprintf(vvp_out, "    %%load/vec4a v%p, 3;\n", src);
+		  fprintf(vvp_out, "    %%ix/load 3, %u, 0;\n", idx);
+		  fprintf(vvp_out, "    %%flag_set/imm 4, 0;\n");
+		  fprintf(vvp_out, "    %%store/vec4a v%p, 3, 0;\n", dst);
+	    }
+	    return 0;
+	  case IVL_VT_REAL:
+	    for (unsigned idx = 0 ; idx < count ; idx += 1) {
+		  fprintf(vvp_out, "    %%ix/load 3, %u, 0;\n", idx);
+		  fprintf(vvp_out, "    %%flag_set/imm 4, 0;\n");
+		  fprintf(vvp_out, "    %%load/ar v%p, 3;\n", src);
+		  fprintf(vvp_out, "    %%ix/load 3, %u, 0;\n", idx);
+		  fprintf(vvp_out, "    %%flag_set/imm 4, 0;\n");
+		  fprintf(vvp_out, "    %%store/reala v%p, 3;\n", dst);
+	    }
+	    return 0;
+	  default:
+	    fprintf(stderr, "%s:%u: sorry: copying an unpacked array of this "
+		    "element type is not supported.\n",
+		    ivl_expr_file(rval), ivl_expr_lineno(rval));
+	    return 1;
+      }
+}
+
 static int show_stmt_assign_vector(ivl_statement_t net)
 {
       ivl_expr_t rval = ivl_stmt_rval(net);
@@ -609,15 +670,11 @@ static int show_stmt_assign_vector(ivl_statement_t net)
       }
 
 	/* A whole unpacked array as the r-value (IVL_EX_ARRAY with no index)
-	   means an array-to-array copy. The run-time has no vector opcode for
-	   this, so report it cleanly instead of trying (and failing) to draw it
-	   as a vector. Such a function is elaboration-time only (see
-	   skip_unpacked_array_func); a genuine run-time array copy lands here. */
+	   is an array-to-array copy. There is no bulk opcode for it, so copy
+	   word by word. */
       if (ivl_expr_type(rval) == IVL_EX_ARRAY) {
-	    fprintf(stderr, "%s:%u: sorry: run-time assignment of a whole "
-		    "unpacked array is not supported.\n",
-		    ivl_expr_file(rval), ivl_expr_lineno(rval));
-	    return 1;
+	    ivl_lval_t lval = ivl_stmt_lval(net, 0);
+	    return draw_array_copy(ivl_lval_sig(lval), rval);
       }
 
       unsigned wid = ivl_stmt_lwidth(net);
@@ -865,6 +922,11 @@ static int show_stmt_assign_sig_real(ivl_statement_t net)
 	    ivl_signal_t sig = ivl_lval_sig(lval);
 	    draw_array_pattern(sig, rval, 0);
 	    return 0;
+      }
+
+	/* A whole real array as the r-value is an array-to-array copy. */
+      if (ivl_expr_type(rval) == IVL_EX_ARRAY) {
+	    return draw_array_copy(ivl_lval_sig(lval), rval);
       }
 
 	/* If this is a compressed assignment, then get the contents

--- a/tgt-vvp/stmt_assign.c
+++ b/tgt-vvp/stmt_assign.c
@@ -608,6 +608,18 @@ static int show_stmt_assign_vector(ivl_statement_t net)
 	    return 0;
       }
 
+	/* A whole unpacked array as the r-value (IVL_EX_ARRAY with no index)
+	   means an array-to-array copy. The run-time has no vector opcode for
+	   this, so report it cleanly instead of trying (and failing) to draw it
+	   as a vector. Such a function is elaboration-time only (see
+	   skip_unpacked_array_func); a genuine run-time array copy lands here. */
+      if (ivl_expr_type(rval) == IVL_EX_ARRAY) {
+	    fprintf(stderr, "%s:%u: sorry: run-time assignment of a whole "
+		    "unpacked array is not supported.\n",
+		    ivl_expr_file(rval), ivl_expr_lineno(rval));
+	    return 1;
+      }
+
       unsigned wid = ivl_stmt_lwidth(net);
 
 	/* If this is a compressed assignment, then get the contents

--- a/tgt-vvp/vvp_priv.h
+++ b/tgt-vvp/vvp_priv.h
@@ -86,6 +86,10 @@ extern int draw_scope(ivl_scope_t scope, ivl_scope_t parent);
 extern void draw_lpm_mux(ivl_lpm_t net);
 extern void draw_lpm_substitute(ivl_lpm_t net);
 
+/* Copy a whole unpacked array into another, word by word. Used both for a
+   plain array-to-array assignment and for passing an array to a subroutine. */
+extern int draw_array_copy(ivl_signal_t dst, ivl_expr_t rval);
+
 extern void draw_ufunc_vec4(ivl_expr_t expr);
 extern void draw_ufunc_real(ivl_expr_t expr);
 extern void draw_ufunc_string(ivl_expr_t expr);

--- a/tgt-vvp/vvp_scope.c
+++ b/tgt-vvp/vvp_scope.c
@@ -2090,7 +2090,22 @@ static void draw_lpm_ufunc(ivl_lpm_t net)
 	    else
 		  fprintf(vvp_out, ", ");
 
-	    assert(ivl_signal_dimensions(psig) == 0);
+	      /* A .ufunc node is driven by its input nexuses, and an unpacked
+		 array is memory rather than a net, so there is nothing to
+		 connect it to here. Passing an array to a function is
+		 supported in procedural code; in a continuous assignment it
+		 would additionally need the node to be sensitive to changes of
+		 any word, which the structural netlist cannot express today.
+		 Report it rather than aborting. */
+	    if (ivl_signal_dimensions(psig) > 0) {
+		  fprintf(stderr, "%s:%u: sorry: passing an unpacked array to "
+			  "a function is not supported in a continuous "
+			  "assignment; use an always_comb block instead.\n",
+			  ivl_lpm_file(net), ivl_lpm_lineno(net));
+		  vvp_errors += 1;
+		  fprintf(vvp_out, "v%p_0", psig);
+		  continue;
+	    }
 	    fprintf(vvp_out, "v%p_0", psig);
       }
 


### PR DESCRIPTION
Makes unpacked arrays usable as values: as parameters, as the return of a constant function, in a whole-array assignment, and as subroutine ports.

Fixes #1449 (SIGABRT), and implements #1149 and #570.

## What it does

| Form | Example |
|---|---|
| 1-D unpacked parameter | `localparam logic [3:0] MEM [0:63] = '{...}` |
| N-D packed parameter | `localparam logic [0:63][3:0] MEM = '{...}` |
| N-D unpacked parameter | `localparam logic [3:0] TBL [0:3][0:15] = '{'{...},...}` |
| constant function returning an unpacked array | `function automatic rom_t f(); rom_t r; ...; return r; endfunction` |
| whole-array assignment at run time | `b = a;` for `logic [7:0] a [0:3], b [0:3]` |
| unpacked array as a subroutine port | `function automatic logic [7:0] sum4(input logic [7:0] a [0:3]);` |

An N-D unpacked value is flattened row-major into a single packed constant by recursing through the
nested `'{...}` pattern. An index select that consumes every unpacked dimension yields the packed
element, for constant and variable indices and for ascending or descending declared ranges.

## Relationship to existing work

- **#1449** is a crash: on master, a constant function returning an unpacked array can abort with
  `eval_tree.cc:217: failed assertion lval.len() == wid` rather than diagnosing. That is the same
  root cause as the `doesn't match the context type` error, a vector-width assumption applied to an
  unpacked-array lvalue, and the same commit fixes both.
- **#1180** was closed by adding `sorry:` messages for array parameters. This PR necessarily removes
  those, since the construct now works, and inverts the two regression tests that asserted them
  (`br_gh1180a`, `br_gh1180b` move from gold-stderr to normal). To be clear, that is not undoing
  deliberate work: #1180 asked for better error messages, and the feature requests it pointed at,
  #1149 and #570, are still open.
- **#501** is the earlier attempt at this, still open as a draft from 2021. To be accurate about why
  it stopped: the `IVL_VT_UARRAY` design question was raised and resolved within two days, and the
  author removed the type himself. What it never got through was a long tail of crashes that
  @jlwehle reported against the branch through mid-2021, each a different assertion. In 2023 he
  offered to finish the work and the thread went quiet.

  This PR also adds no new type, keeping unpacked arrays as special cases of the base types. More
  usefully, the shapes that stalled #501 are covered here and pass with correct values, not merely
  compiling: an element of one array parameter feeding another's initialiser (nested two levels), an
  element inside `$clog2`, `integer` rather than logic elements, and a run-time variable index in
  both a continuous assignment and a procedural block. `param_array_param_ref` pins all of them,
  including the `lpa_tc` case attached to that thread.

## Conflict note

`elab_expr.cc` needed a manual merge against the recently merged queue-method work. Both changes are
kept: the queue-method dispatch returns early for queue types, and the new whole-unpacked-array type
resolution runs after it. The `netdarray_t` compatibility check now tests
`array_type->type_compatible(net_ctype) && sr.path_tail.empty()`, combining both conditions.

## Testing

Against master `a4989d023`, x86-64 Linux, g++ 15.2.0:

```
master:  vvp_reg.py  519 ran, 3 failed
this PR: vvp_reg.py  528 ran, 3 failed
```

The 9 extra are new tests added here, all passing. The 3 failures are `br_gh710b`, `br_gh710c` and
`br_gh710d`, which fail identically on unmodified master, so there are no regressions.

New tests: `br_gh1180c`, `param_array_packed`, `param_array_unpacked`, `func_return_uarray`,
`func_return_uarray_2d`, `func_return_uarray_rt_fail`, `uarray_subroutine_port` (function and task
arguments, ascending and descending ranges, two dimensions, real elements, x propagation, run-time
array copy, use from `always_comb`) and `uarray_ca_fail` (pins the continuous-assignment
diagnostic) and `param_array_param_ref` (the #501 shapes).

Also verified on the case that prompted this: Reed-Solomon decoders over GF(2^10) whose field
package builds log / antilog / inverse ROMs this way. Before, they either failed to elaborate or
aborted; after, they elaborate and produce the same golden results as commercial simulators.

## Subroutine ports

`sorry: Subroutine ports with unpacked dimensions are not yet supported` is also gone. This is legal
SystemVerilog (A.2.7 `tf_port_item` permits unpacked dimensions on a formal; 7.6 defines the
assignment) and other tools accept and synthesise it.

The run time already had the hard part: automatic, per-invocation unpacked arrays work today,
including under recursion, so no new storage machinery and no new type were needed. What was missing
was marshalling:

- `tgt-vvp`: a new `draw_array_copy()` copies word by word using the existing
  `%ix/load` + `%load/vec4a` + `%store/vec4a` idiom that `draw_array_pattern` already uses
  (`%load/ar` / `%store/reala` for real elements). There is no bulk copy opcode; one could be added
  later purely as an optimisation.
- It is used for a whole-array r-value in both the vector and real assignment paths, and for array
  arguments in `draw_ufunc.c`. An array actual is a signal reference rather than a stack value, so
  it is copied in the send pass reading the source signal directly, preserving the existing
  two-pass evaluate-then-send ordering.
- `elab_expr.cc` and `elaborate.cc`: an unpacked-array formal takes the array type as its context,
  not the element type. `net_type()` returns the element type, which is what produced
  `Array a needs an array index here` at every call site. Same fix for functions and tasks.
- `net_nex_input.cc`: when removing a function's own inputs from an `always_comb` sensitivity set,
  iterate every pin. An array port has one per word, and the code asserted a single pin.

Shape checking needed no new code: the existing context-type comparison already rejects a size or
element-type mismatch with the usual `doesn't match the context type` error.

## Still not covered

Two cases remain, both now reported cleanly rather than asserting or mis-generating:

- Passing an unpacked array to a function **from a continuous assignment**. A `.ufunc` node is
  driven by its input nexuses and an unpacked array is memory rather than a net, so it would also
  need the node to be sensitive to a change of any word, which the structural netlist cannot express
  today. The message points at `always_comb`, which does work.
- **Returning** an unpacked array from a function at run time, as opposed to in a constant context.

## Note on the commit sequence

The commits are kept separate and each leaves the tree in a valid state. One consequence worth
flagging so it does not look like churn: "Support constant functions that return unpacked arrays"
adds a clean `sorry` for a run-time whole-array assignment, and the following commit implements that
case and removes the message again. Happy to squash if you would prefer.

---

Disclosure: generative AI assisted with the rebase onto current master, the conflict resolution and
this description. I have reviewed, built and tested the result myself.
