### PR TITLE
Honor declaration order for wildcard port connections

### DIFF
--- a/PEvent.cc
+++ b/PEvent.cc
@@ -22,8 +22,9 @@
 # include  "PEvent.h"
 
 PEvent::PEvent(perm_string n, unsigned lexical_pos)
-: name_(n), lexical_pos_(lexical_pos)
+: name_(n)
 {
+      LineInfo::lexical_pos(lexical_pos);
 }
 
 PEvent::~PEvent()

--- a/PEvent.h
+++ b/PEvent.h
@@ -41,15 +41,12 @@ class PEvent : public PNamedItem {
 
       perm_string name() const;
 
-      unsigned lexical_pos() const { return lexical_pos_; }
-
       void elaborate_scope(Design*des, NetScope*scope) const;
 
       SymbolType symbol_type() const override;
 
     private:
       perm_string name_;
-      unsigned lexical_pos_;
 
     private: // not implemented
       PEvent(const PEvent&);

--- a/PExpr.cc
+++ b/PExpr.cc
@@ -407,18 +407,20 @@ const verireal& PEFNumber::value() const
 }
 
 PEIdent::PEIdent(const pform_name_t&that, unsigned lexical_pos)
-: path_(that), lexical_pos_(lexical_pos), no_implicit_sig_(false)
+: path_(that), no_implicit_sig_(false)
 {
+      LineInfo::lexical_pos(lexical_pos);
 }
 
 PEIdent::PEIdent(perm_string s, unsigned lexical_pos, bool no_implicit_sig)
-: lexical_pos_(lexical_pos), no_implicit_sig_(no_implicit_sig)
+: no_implicit_sig_(no_implicit_sig)
 {
+      LineInfo::lexical_pos(lexical_pos);
       path_.name.push_back(name_component_t(s));
 }
 
-PEIdent::PEIdent(PPackage*pkg, const pform_name_t&that, unsigned lexical_pos)
-: path_(pkg, that), lexical_pos_(lexical_pos), no_implicit_sig_(true)
+PEIdent::PEIdent(PPackage*pkg, const pform_name_t&that)
+: path_(pkg, that), no_implicit_sig_(true)
 {
 }
 
@@ -469,9 +471,8 @@ void PEIdent::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 
                   ss = ss->parent_scope();
             }
-            PWire*net = new PWire(name, lexical_pos_, type, NetNet::NOT_A_PORT);
-            net->set_file(get_file());
-            net->set_lineno(get_lineno());
+            PWire*net = new PWire(name, lexical_pos(), type, NetNet::NOT_A_PORT);
+            net->set_line(*this);
             scope->wires[name] = net;
             if (warn_implicit) {
                   cerr << get_fileline() << ": warning: implicit "
@@ -483,7 +484,7 @@ void PEIdent::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 bool PEIdent::has_aa_term(Design*des, NetScope*scope) const
 {
       symbol_search_results sr;
-      if (!symbol_search(this, des, scope, path_, lexical_pos_, &sr))
+      if (!symbol_search(this, des, scope, path_, lexical_pos(), &sr))
 	    return false;
 
       // Class properties are not considered automatic since a non-blocking

--- a/PExpr.h
+++ b/PExpr.h
@@ -345,7 +345,7 @@ class PEIdent : public PExpr {
 
     public:
       explicit PEIdent(perm_string, unsigned lexical_pos, bool no_implicit_sig=false);
-      explicit PEIdent(PPackage*pkg, const pform_name_t&name, unsigned lexical_pos);
+      explicit PEIdent(PPackage*pkg, const pform_name_t&name);
       explicit PEIdent(const pform_name_t&, unsigned lexical_pos);
       ~PEIdent() override;
 
@@ -394,11 +394,8 @@ class PEIdent : public PExpr {
 
       const pform_scoped_name_t& path() const { return path_; }
 
-      unsigned lexical_pos() const { return lexical_pos_; }
-
     private:
       pform_scoped_name_t path_;
-      unsigned lexical_pos_;
       bool no_implicit_sig_;
 
     private:

--- a/PWire.cc
+++ b/PWire.cc
@@ -29,10 +29,12 @@ PWire::PWire(perm_string n,
 	     NetNet::Type t,
 	     NetNet::PortType pt,
 	     PWSRType rt)
-: name_(n), lexical_pos_(lp), type_(t), port_type_(pt), signed_(false),
+: name_(n), type_(t), port_type_(pt), signed_(false),
   port_set_(false), net_set_(false), is_scalar_(false),
   error_cnt_(0), discipline_(0)
 {
+      lexical_pos(lp);
+
       switch (rt) {
 	  case SR_PORT:
 	    port_set_ = true;

--- a/PWire.h
+++ b/PWire.h
@@ -63,8 +63,6 @@ class PWire : public PNamedItem {
 	// Return a hierarchical name.
       perm_string basename() const;
 
-      unsigned lexical_pos() const { return lexical_pos_; }
-
       NetNet::Type get_wire_type() const;
       bool set_wire_type(NetNet::Type);
 
@@ -102,7 +100,6 @@ class PWire : public PNamedItem {
 
     private:
       perm_string name_;
-      unsigned lexical_pos_;
       NetNet::Type type_;
       NetNet::PortType port_type_;
       bool signed_;

--- a/Statement.cc
+++ b/Statement.cc
@@ -396,8 +396,8 @@ PReturn::~PReturn()
       delete expr_;
 }
 
-PTrigger::PTrigger(PPackage*pkg, const pform_name_t&ev, unsigned lexical_pos)
-: event_(pkg, ev), lexical_pos_(lexical_pos)
+PTrigger::PTrigger(PPackage*pkg, const pform_name_t&ev)
+: event_(pkg, ev)
 {
 }
 
@@ -405,8 +405,8 @@ PTrigger::~PTrigger()
 {
 }
 
-PNBTrigger::PNBTrigger(const pform_name_t&ev, unsigned lexical_pos, PExpr*dly)
-: event_(ev), lexical_pos_(lexical_pos), dly_(dly)
+PNBTrigger::PNBTrigger(const pform_name_t&ev, PExpr*dly)
+: event_(ev), dly_(dly)
 {
 }
 

--- a/Statement.h
+++ b/Statement.h
@@ -660,7 +660,7 @@ class PReturn  : public Statement {
 class PTrigger  : public Statement {
 
     public:
-      explicit PTrigger(PPackage*pkg, const pform_name_t&ev, unsigned lexical_pos);
+      explicit PTrigger(PPackage*pkg, const pform_name_t&ev);
       ~PTrigger() override;
 
       virtual NetProc* elaborate(Design*des, NetScope*scope) const override;
@@ -668,12 +668,11 @@ class PTrigger  : public Statement {
 
     private:
       pform_scoped_name_t event_;
-      unsigned lexical_pos_;
 };
 
 class PNBTrigger  : public Statement {
     public:
-      explicit PNBTrigger(const pform_name_t&ev, unsigned lexical_pos, PExpr*dly);
+      explicit PNBTrigger(const pform_name_t&ev, PExpr*dly);
       ~PNBTrigger() override;
 
       virtual NetProc* elaborate(Design*des, NetScope*scope) const override;
@@ -681,7 +680,6 @@ class PNBTrigger  : public Statement {
 
     private:
       pform_name_t event_;
-      unsigned lexical_pos_;
       PExpr*dly_;
 };
 

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -4973,7 +4973,7 @@ ivl_type_t PEIdent::resolve_type_(Design *des, const symbol_search_results &sr,
 unsigned PEIdent::test_width(Design*des, NetScope*scope, width_mode_t&mode)
 {
       symbol_search_results sr;
-      bool found_symbol = symbol_search(this, des, scope, path_, lexical_pos_, &sr);
+      bool found_symbol = symbol_search(this, des, scope, path_, lexical_pos(), &sr);
 
 	// If there is a part/bit select expression, then process it
 	// here. This constrains the results no matter what kind the
@@ -5129,7 +5129,7 @@ NetExpr* PEIdent::elaborate_expr(Design*des, NetScope*scope,
       bool need_const = NEED_CONST & flags;
 
       symbol_search_results sr;
-      symbol_search(this, des, scope, path_, lexical_pos_, &sr);
+      symbol_search(this, des, scope, path_, lexical_pos(), &sr);
 
       if (!sr.net) {
             cerr << get_fileline() << ": error: Unable to bind variable `"
@@ -5449,7 +5449,7 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 	// a net called "b" in the scope "main.a" and with a member
 	// named "c". symbol_search() handles this for us.
       symbol_search_results sr;
-      symbol_search(this, des, scope, path_, lexical_pos_, &sr);
+      symbol_search(this, des, scope, path_, lexical_pos(), &sr);
 
 	// If the identifier name is a parameter name, then return
 	// the parameter value.

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -176,7 +176,7 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
       }
 
       symbol_search_results sr;
-      symbol_search(this, des, scope, path_, lexical_pos_, &sr);
+      symbol_search(this, des, scope, path_, lexical_pos(), &sr);
 
       NetNet *reg = sr.net;
       const pform_name_t &member_path = sr.path_tail;

--- a/elab_net.cc
+++ b/elab_net.cc
@@ -533,7 +533,7 @@ NetNet* PEIdent::elaborate_lnet_common_(Design*des, NetScope*scope,
       ivl_assert(*this, scope);
 
       symbol_search_results sr;
-      symbol_search(this, des, scope, path_.name, lexical_pos_, &sr);
+      symbol_search(this, des, scope, path_.name, lexical_pos(), &sr);
 
       if (sr.eve != 0) {
 	    cerr << get_fileline() << ": error: named events (" << path_
@@ -1173,7 +1173,7 @@ NetNet* PEIdent::elaborate_subport(Design*des, NetScope*scope) const
 NetNet*PEIdent::elaborate_unpacked_net(Design*des, NetScope*scope) const
 {
       symbol_search_results sr;
-      symbol_search(this, des, scope, path_, lexical_pos_, &sr);
+      symbol_search(this, des, scope, path_, lexical_pos(), &sr);
       if (!sr.net) {
 	    cerr << get_fileline() << ": error: Net " << path_
 		 << " is not defined in this context." << endl;
@@ -1207,7 +1207,7 @@ bool PEIdent::is_collapsible_net(Design*des, NetScope*scope,
       ivl_assert(*this, scope);
 
       symbol_search_results sr;
-      symbol_search(this, des, scope, path_.name, lexical_pos_, &sr);
+      symbol_search(this, des, scope, path_.name, lexical_pos(), &sr);
 
       if (sr.eve != 0)
             return false;

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -1640,7 +1640,6 @@ void PGModule::elaborate_scope_mod_instances_(Design*des, Module*mod, NetScope*s
 void PEvent::elaborate_scope(Design*, NetScope*scope) const
 {
       NetEvent*ev = new NetEvent(name_);
-      ev->lexical_pos(lexical_pos_);
       ev->set_line(*this);
       scope->add_event(ev);
 }

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -416,8 +416,9 @@ void netclass_t::elaborate_sig(Design*des, PClass*pclass)
 		       << "." << endl;
 	    }
 
-	    /* NetNet*sig = */ new NetNet(class_scope_, cur->first, NetNet::REG,
-					  use_type);
+	    auto sig = new NetNet(class_scope_, cur->first, NetNet::REG,
+				  use_type);
+	    sig->set_line(cur->second);
       }
 
       for (map<perm_string,PFunction*>::iterator cur = pclass->funcs.begin()
@@ -1227,7 +1228,6 @@ NetNet* PWire::elaborate_sig(Design*des, NetScope*scope)
       if (wtype == NetNet::WIRE) sig->devirtualize_pins();
       sig->set_line(*this);
       sig->port_type(port_type_);
-      sig->lexical_pos(lexical_pos_);
 
       if (ivl_discipline_t dis = get_discipline()) {
 	    sig->set_discipline(dis);

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -1263,19 +1263,22 @@ bool PGModule::match_module_ports_(Design*des, const Module*rmod,
 	    for (unsigned idx = 0 ;  idx < npins_ ;  idx += 1) {
 		    // Handle wildcard named port.
 		  if (pins_[idx].name[0] == '*') {
+			const auto &wildcard = pins_[idx];
 			for (unsigned j = 0 ; j < nexp ; j += 1) {
 			      if (rmod->ports[j] && !pins[j] && !pins_is_explicitly_not_connected[j]) {
 				    pins_fromwc[j] = true;
 				    pform_name_t path_;
 				    path_.push_back(name_component_t(rmod->ports[j]->name));
 				    symbol_search_results sr;
-				    symbol_search(this, des, scope, path_, UINT_MAX, &sr);
+				    symbol_search(&wildcard, des, scope, path_,
+						  wildcard.lexical_pos(), &sr);
 				    if (sr.net != 0 ||
 					(rmod->ports[j]->is_interface_port() &&
 					 sr.scope != 0 && sr.scope->is_interface())) {
-					  pins[j] = new PEIdent(rmod->ports[j]->name, UINT_MAX, true);
-					  pins[j]->set_lineno(get_lineno());
-					  pins[j]->set_file(get_file());
+					  pins[j] = new PEIdent(
+						rmod->ports[j]->name,
+						wildcard.lexical_pos(), true);
+					  pins[j]->set_line(wildcard);
 				    }
 			      }
 			}

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -2775,8 +2775,7 @@ NetAssign_* PAssign_::elaborate_lval(Design*des, NetScope*scope) const
 		tmp = new NetNet(scope, scope->local_symbol(), NetNet::REG, tmp_vec);
 	    }
 
-	    tmp->set_file(rval_->get_file());
-	    tmp->set_lineno(rval_->get_lineno());
+	    tmp->set_line(*rval_);
 	    NetAssign_*lv = new NetAssign_(tmp);
 	    return lv;
       }
@@ -4607,12 +4606,10 @@ NetProc *PCallTask::elaborate_non_void_function_(Design *des, NetScope *scope) c
 {
 	// Generate a function call version of this task call.
       PExpr*rval = new PECallFunction(package_, path_, parms_);
-      rval->set_file(get_file());
-      rval->set_lineno(get_lineno());
+      rval->set_line(*this);
 	// Generate an assign to nothing.
       PAssign*tmp = new PAssign(0, rval);
-      tmp->set_file(get_file());
-      tmp->set_lineno(get_lineno());
+      tmp->set_line(*this);
       if (!void_cast_) {
 	    cerr << get_fileline() << ": warning: User function '"
 		 << peek_tail_name(path_) << "' is being called as a task." << endl;

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -6616,7 +6616,7 @@ NetProc* PTrigger::elaborate(Design*des, NetScope*scope) const
       ivl_assert(*this, scope);
 
       symbol_search_results sr;
-      if (!symbol_search(this, des, scope, event_, lexical_pos_, &sr)) {
+      if (!symbol_search(this, des, scope, event_, lexical_pos(), &sr)) {
 	    cerr << get_fileline() << ": error: event <" << event_ << ">"
 		 << " not found." << endl;
 	    if (sr.decl_after_use) {
@@ -6645,7 +6645,7 @@ NetProc* PNBTrigger::elaborate(Design*des, NetScope*scope) const
       ivl_assert(*this, scope);
 
       symbol_search_results sr;
-      if (!symbol_search(this, des, scope, event_, lexical_pos_, &sr)) {
+      if (!symbol_search(this, des, scope, event_, lexical_pos(), &sr)) {
 	    cerr << get_fileline() << ": error: event <" << event_ << ">"
 		 << " not found." << endl;
 	    if (sr.decl_after_use) {

--- a/ivtest/ivltests/sv_wildcard_port_order.v
+++ b/ivtest/ivltests/sv_wildcard_port_order.v
@@ -1,0 +1,25 @@
+// Check that wildcard port connections ignore later declarations.
+
+module child(input wire value = 1'b0, output wire result);
+
+  assign result = value;
+
+endmodule
+
+module test;
+
+  wire result;
+  child i_child(.result(result), .*);
+  wire value = 1'b1;
+
+  initial begin
+    #1;
+
+    if (result !== 1'b0) begin
+      $display("FAILED: expected 0, got %b", result);
+    end else begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_wildcard_port_order_relaxed.v
+++ b/ivtest/ivltests/sv_wildcard_port_order_relaxed.v
@@ -1,0 +1,29 @@
+// Check relaxed declaration ordering for wildcard port connections.
+// This is not valid in strict Verilog and tests
+// -gno-strict-net-var-declaration.
+
+module child(input wire source = 1'b0, input wire value = 1'b0,
+             output wire result);
+
+  assign result = value;
+
+endmodule
+
+module test;
+
+  wire result;
+  child i_child(.result(result), .*, .source(value));
+
+  assign value = 1'b1;
+
+  initial begin
+    #1;
+
+    if (result !== 1'b1) begin
+      $display("FAILED: expected 1, got %b", result);
+    end else begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/ivltests/sv_wildcard_port_position.v
+++ b/ivtest/ivltests/sv_wildcard_port_position.v
@@ -1,0 +1,55 @@
+// Check that wildcard port connections use the position of `.*`.
+
+module child(input wire source = 1'b0, input wire value = 1'b0,
+             output wire result);
+
+  assign result = value;
+
+endmodule
+
+module implicit_before(output wire result);
+
+  child i_child(.source(value), .result(result), .*);
+
+  assign value = 1'b1;
+
+endmodule
+
+module implicit_after(output wire result);
+
+  child i_child(.result(result), .*, .source(value));
+
+  assign value = 1'b1;
+
+endmodule
+
+module test;
+
+  wire result_before;
+  wire result_after;
+
+  implicit_before i_before(result_before);
+  implicit_after i_after(result_after);
+
+  reg failed;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    #1;
+
+    `check(result_before, 1'b1);
+    `check(result_after, 1'b0);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -494,6 +494,9 @@ sv_type_param_restrict_union2	vvp_tests/sv_type_param_restrict_union2.json
 sv_type_param_restrict_union_fail1	vvp_tests/sv_type_param_restrict_union_fail1.json
 sv_type_param_restrict_union_fail2	vvp_tests/sv_type_param_restrict_union_fail2.json
 sv_wildcard_import8		vvp_tests/sv_wildcard_import8.json
+sv_wildcard_port_order		vvp_tests/sv_wildcard_port_order.json
+sv_wildcard_port_order_relaxed	vvp_tests/sv_wildcard_port_order_relaxed.json
+sv_wildcard_port_position	vvp_tests/sv_wildcard_port_position.json
 sdf_header			vvp_tests/sdf_header.json
 task_return1			vvp_tests/task_return1.json
 task_return2			vvp_tests/task_return2.json

--- a/ivtest/vvp_tests/sv_wildcard_port_order.json
+++ b/ivtest/vvp_tests/sv_wildcard_port_order.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_wildcard_port_order.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_wildcard_port_order_relaxed.json
+++ b/ivtest/vvp_tests/sv_wildcard_port_order_relaxed.json
@@ -1,0 +1,6 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_wildcard_port_order_relaxed.v",
+    "iverilog-args" : [ "-g2005-sv", "-gno-strict-net-var-declaration",
+                        "-Wno-declaration-after-use" ]
+}

--- a/ivtest/vvp_tests/sv_wildcard_port_position.json
+++ b/ivtest/vvp_tests/sv_wildcard_port_position.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_wildcard_port_position.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/libmisc/LineInfo.cc
+++ b/libmisc/LineInfo.cc
@@ -44,6 +44,8 @@ void LineInfo::set_line(const LineInfo&that)
 {
       file_ = that.file_;
       lineno_ = that.lineno_;
+      if (lexical_pos_ == UINT_MAX)
+	    lexical_pos_ = that.lexical_pos_;
 }
 
 void LineInfo::set_file(perm_string f)
@@ -54,4 +56,9 @@ void LineInfo::set_file(perm_string f)
 void LineInfo::set_lineno(unsigned n)
 {
       lineno_ = n;
+}
+
+void LineInfo::lexical_pos(unsigned int n)
+{
+      lexical_pos_ = n;
 }

--- a/libmisc/LineInfo.h
+++ b/libmisc/LineInfo.h
@@ -20,6 +20,7 @@
  */
 
 # include  "StringHeap.h"
+# include  <climits>
 # include  <string>
 
 /*
@@ -38,18 +39,21 @@ class LineInfo {
 
 	// Get a fully formatted file/lineno
       std::string get_fileline() const;
-	// Set the file/line from another LineInfo object.
+	// Set the source location from another LineInfo object.
       void set_line(const LineInfo&that);
 
 	// Access parts of LineInfo data
       void set_file(perm_string f);
       void set_lineno(unsigned n);
+      void lexical_pos(unsigned int n);
 
       perm_string get_file() const { return file_; }
       unsigned  get_lineno() const { return lineno_; }
+      unsigned int lexical_pos() const { return lexical_pos_; }
     private:
       perm_string file_;
       unsigned lineno_;
+      unsigned int lexical_pos_ = UINT_MAX;
 };
 
 #endif /* IVL_LineInfo_H */

--- a/net_event.cc
+++ b/net_event.cc
@@ -30,7 +30,6 @@ using namespace std;
 NetEvent::NetEvent(perm_string n)
 : name_(n)
 {
-      lexical_pos_ = 0;
       local_flag_ = false;
       scope_ = 0;
       snext_ = 0;

--- a/netlist.cc
+++ b/netlist.cc
@@ -566,7 +566,7 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
 	       const netranges_t&unpacked, ivl_type_t use_net_type)
 : NetObj(s, n, calculate_count(unpacked)),
     type_(t), port_type_(NOT_A_PORT), coerced_to_uwire_(false),
-    local_flag_(false), lexical_pos_(0), net_type_(use_net_type),
+    local_flag_(false), net_type_(use_net_type),
     discipline_(0), unpacked_dims_(unpacked),
     eref_count_(0), lref_count_(0)
 {
@@ -589,7 +589,7 @@ NetNet::NetNet(NetScope*s, perm_string n, Type t,
 NetNet::NetNet(NetScope*s, perm_string n, Type t, ivl_type_t type)
 : NetObj(s, n, 1),
     type_(t), port_type_(NOT_A_PORT), coerced_to_uwire_(false),
-    local_flag_(false), lexical_pos_(0), net_type_(type),
+    local_flag_(false), net_type_(type),
     discipline_(0),
     eref_count_(0), lref_count_(0)
 {

--- a/netlist.h
+++ b/netlist.h
@@ -733,9 +733,6 @@ class NetNet  : public NetObj, public PortType {
       PortType port_type() const;
       void port_type(PortType t);
 
-      unsigned lexical_pos() const { return lexical_pos_; }
-      void lexical_pos(unsigned lp) { lexical_pos_ = lp; }
-
       // If this net net is a port (i.e. a *sub*port net of a module port)
       // its port index is number of the module it connects through
       int get_module_port_index() const;                // -1 Not connected to port...
@@ -860,7 +857,6 @@ class NetNet  : public NetObj, public PortType {
       PortType port_type_ : 3;
       bool coerced_to_uwire_: 1;
       bool local_flag_: 1;
-      unsigned lexical_pos_;
       ivl_type_t net_type_;
       netuarray_t *array_type_ = nullptr;
       ivl_discipline_t discipline_;
@@ -3509,9 +3505,6 @@ class NetEvent : public LineInfo {
 
       perm_string name() const;
 
-      unsigned lexical_pos() const { return lexical_pos_; }
-      void lexical_pos(unsigned lp) { lexical_pos_ = lp; }
-
       bool local_flag() const { return local_flag_; }
       void local_flag(bool f) { local_flag_ = f; }
 
@@ -3546,7 +3539,6 @@ class NetEvent : public LineInfo {
 
     private:
       perm_string name_;
-      unsigned lexical_pos_;
       bool local_flag_;
 
 	// The NetScope class uses these to list the events.

--- a/parse.y
+++ b/parse.y
@@ -22,7 +22,6 @@
 
 # include "config.h"
 
-# include  <climits>
 # include  <cstdarg>
 # include  "parse_misc.h"
 # include  "compiler.h"
@@ -2194,7 +2193,6 @@ loop_statement /* IEEE1800-2005: A.6.8 */
 	tmp_hident.push_back(name_component_t(lex_strings.make($5)));
 
 	PEIdent*tmp_ident = pform_new_ident(@5, tmp_hident);
-	FILE_NAME(tmp_ident, @5);
 
 	check_for_loop(@1, $8, $10, $12);
 	PForStatement*tmp_for = new PForStatement(tmp_ident, $8, $10, $12, $14);
@@ -3966,7 +3964,6 @@ clocking_event_opt /* */
 event_control /* A.K.A. clocking_event */
   : '@' hierarchy_identifier
       { PEIdent*tmpi = pform_new_ident(@2, *$2);
-	FILE_NAME(tmpi, @2);
 	PEEvent*tmpe = new PEEvent(PEEvent::ANYEDGE, tmpi);
 	PEventStatement*tmps = new PEventStatement(tmpe);
 	FILE_NAME(tmps, @1);
@@ -4546,7 +4543,6 @@ expr_primary
       }
   | hierarchy_identifier
       { PEIdent*tmp = pform_new_ident(@1, *$1);
-	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete $1;
       }
@@ -4555,7 +4551,6 @@ expr_primary
       { pform_name_t * nm = $1;
 	nm->push_back(name_component_t(lex_strings.make("and")));
 	PEIdent*tmp = pform_new_ident(@1, *nm);
-	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete nm;
       }
@@ -4563,7 +4558,6 @@ expr_primary
       { pform_name_t * nm = $1;
 	nm->push_back(name_component_t(lex_strings.make("or")));
 	PEIdent*tmp = pform_new_ident(@1, *nm);
-	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete nm;
       }
@@ -4571,7 +4565,6 @@ expr_primary
       { pform_name_t * nm = $1;
 	nm->push_back(name_component_t(lex_strings.make("xor")));
 	PEIdent*tmp = pform_new_ident(@1, *nm);
-	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete nm;
       }
@@ -5315,7 +5308,6 @@ atom_type
 lpvalue
   : hierarchy_identifier
       { PEIdent*tmp = pform_new_ident(@1, *$1);
-	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete $1;
       }
@@ -7467,35 +7459,35 @@ statement_item /* This is roughly statement_item in the LRM */
 	$$ = tmp;
       }
   | K_TRIGGER hierarchy_identifier ';'
-      { PTrigger*tmp = pform_new_trigger(@2, 0, *$2, @2.lexical_pos);
+      { PTrigger*tmp = pform_new_trigger(@2, nullptr, *$2);
 	delete $2;
 	$$ = tmp;
       }
   | K_TRIGGER package_scope hierarchy_identifier
       { lex_in_package_scope(0);
-	PTrigger*tmp = pform_new_trigger(@3, $2, *$3, @3.lexical_pos);
+	PTrigger*tmp = pform_new_trigger(@3, $2, *$3);
 	delete $3;
 	$$ = tmp;
       }
     /* FIXME: Does this need support for package resolution like above? */
   | K_NB_TRIGGER hierarchy_identifier ';'
-      { PNBTrigger*tmp = pform_new_nb_trigger(@2, 0, *$2, @2.lexical_pos);
+      { PNBTrigger*tmp = pform_new_nb_trigger(@2, nullptr, *$2);
 	delete $2;
 	$$ = tmp;
       }
   | K_NB_TRIGGER delay1 hierarchy_identifier ';'
-      { PNBTrigger*tmp = pform_new_nb_trigger(@3, $2, *$3, @3.lexical_pos);
+      { PNBTrigger*tmp = pform_new_nb_trigger(@3, $2, *$3);
 	delete $3;
 	$$ = tmp;
       }
   | K_NB_TRIGGER event_control hierarchy_identifier ';'
-      { PNBTrigger*tmp = pform_new_nb_trigger(@3, 0, *$3, @3.lexical_pos);
+      { PNBTrigger*tmp = pform_new_nb_trigger(@3, nullptr, *$3);
 	delete $3;
 	$$ = tmp;
         yywarn(@1, "sorry: ->> with event control is not currently supported.");
       }
   | K_NB_TRIGGER K_repeat '(' expression ')' event_control hierarchy_identifier ';'
-      { PNBTrigger*tmp = pform_new_nb_trigger(@7, 0, *$7, @7.lexical_pos);
+      { PNBTrigger*tmp = pform_new_nb_trigger(@7, nullptr, *$7);
 	delete $7;
 	$$ = tmp;
         yywarn(@1, "sorry: ->> with repeat event control is not currently supported.");

--- a/parse_misc.h
+++ b/parse_misc.h
@@ -45,6 +45,10 @@ inline void FILE_NAME(LineInfo*tmp, const struct vlltype&where)
 {
       tmp->set_lineno(where.first_line);
       tmp->set_file(filename_strings.make(where.text));
+	// Preserve a more precise identifier position supplied by a
+	// constructor instead of replacing it with the enclosing rule.
+      if (tmp->lexical_pos() == UINT_MAX)
+	    tmp->lexical_pos(where.lexical_pos);
 }
 
   /* This for compatibility with new and older bison versions. */

--- a/pform.cc
+++ b/pform.cc
@@ -744,24 +744,25 @@ PEIdent* pform_new_ident(const struct vlltype&loc, const pform_name_t&name)
       if (gn_system_verilog())
 	    check_potential_imports(loc, name.front().name, false);
 
-      return new PEIdent(name, loc.lexical_pos);
+      auto tmp = new PEIdent(name, loc.lexical_pos);
+      FILE_NAME(tmp, loc);
+      return tmp;
 }
 
 PTrigger* pform_new_trigger(const struct vlltype&loc, PPackage*pkg,
-			    const pform_name_t&name, unsigned lexical_pos)
+			    const pform_name_t&name)
 {
       if (gn_system_verilog())
 	    check_potential_imports(loc, name.front().name, false);
 
-      PTrigger*tmp = new PTrigger(pkg, name, lexical_pos);
+      PTrigger*tmp = new PTrigger(pkg, name);
       FILE_NAME(tmp, loc);
       return tmp;
 }
 
 PNBTrigger* pform_new_nb_trigger(const struct vlltype&loc,
 			         const list<PExpr*>*dly,
-			         const pform_name_t&name,
-			         unsigned lexical_pos)
+			         const pform_name_t&name)
 {
       if (gn_system_verilog())
 	    check_potential_imports(loc, name.front().name, false);
@@ -772,7 +773,7 @@ PNBTrigger* pform_new_nb_trigger(const struct vlltype&loc,
 	    tmp_dly = dly->front();
       }
 
-      PNBTrigger*tmp = new PNBTrigger(name, lexical_pos, tmp_dly);
+      PNBTrigger*tmp = new PNBTrigger(name, tmp_dly);
       FILE_NAME(tmp, loc);
       return tmp;
 }

--- a/pform.h
+++ b/pform.h
@@ -239,11 +239,10 @@ extern void pform_add_modport_port(const struct vlltype&loc,
 extern PEIdent* pform_new_ident(const struct vlltype&loc, const pform_name_t&name);
 
 extern PTrigger* pform_new_trigger(const struct vlltype&loc, PPackage*pkg,
-				   const pform_name_t&name, unsigned lexical_pos);
+				   const pform_name_t&name);
 extern PNBTrigger* pform_new_nb_trigger(const struct vlltype&loc,
 				        const std::list<PExpr*>*dly,
-				        const pform_name_t&name,
-				        unsigned lexical_pos);
+				        const pform_name_t&name);
 
 /*
  * Enter/exit name scopes. The push_scope function pushes the scope

--- a/pform_package.cc
+++ b/pform_package.cc
@@ -232,7 +232,7 @@ PExpr* pform_package_ident(const struct vlltype&loc,
 			   PPackage*pkg, const pform_name_t*ident_name)
 {
       ivl_assert(loc, ident_name);
-      PEIdent*tmp = new PEIdent(pkg, *ident_name, loc.lexical_pos);
+      PEIdent*tmp = new PEIdent(pkg, *ident_name);
       FILE_NAME(tmp, loc);
       return tmp;
 }


### PR DESCRIPTION

IEEE 1800-2023 section 23.3.2.4 defines a `.*` connection as equivalent to an implicit `.name` connection for every port not connected explicitly. The existing `.name` path resolves the matching identifier at the connection's lexical position. Wildcard port matching instead searches at the end of the scope, making it find declarations after the connection:

```SystemVerilog
    child i_child(.*);
    wire value;
```

Use the lexical position carried by the wildcard binding when looking up and creating wildcard connections. The position of `.*` itself matters because an earlier explicit port connection can create an implicit net that the wildcard connection should see:

```SystemVerilog
    child i_child(.source(value), .*);
```

This also preserves the relaxed lookup provided by `-gno-strict-net-var-declaration`.

To support this add `lexical_pos` into `LineInfo` so we don't have to track it in yet another struct. As part of this remove `lexical_pos` from structs or classes that inherit from `LineInfo`.