### PR TITLE
Use the bound typedef to find its declaration scope

### DIFF
--- a/ivtest/ivltests/sv_package_import_order_typedef.v
+++ b/ivtest/ivltests/sv_package_import_order_typedef.v
@@ -1,0 +1,39 @@
+// Check package import ordering for types in nested scopes.
+
+package p1;
+  typedef logic [1:0] type_t;
+endpackage
+
+package p2;
+  typedef logic [3:0] type_t;
+endpackage
+
+module test;
+
+  import p1::type_t;
+
+  reg failed;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %b, got %b", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin : b
+    type_t value_before;
+    import p2::type_t;
+    type_t value_after;
+
+    failed = 1'b0;
+
+    `check($bits(value_before), 2);
+    `check($bits(value_after), 4);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -399,6 +399,7 @@ sv_module_port3			vvp_tests/sv_module_port3.json
 sv_module_port4			vvp_tests/sv_module_port4.json
 sv_net_array_decl_assign	vvp_tests/sv_net_array_decl_assign.json
 sv_net_decl_assign		vvp_tests/sv_net_decl_assign.json
+sv_package_import_order_typedef	vvp_tests/sv_package_import_order_typedef.json
 sv_package_lifetime		vvp_tests/sv_package_lifetime.json
 sv_package_lifetime_fail	vvp_tests/sv_package_lifetime_fail.json
 parameter_omit1			vvp_tests/parameter_omit1.json

--- a/ivtest/vvp_tests/sv_package_import_order_typedef.json
+++ b/ivtest/vvp_tests/sv_package_import_order_typedef.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_import_order_typedef.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -239,28 +239,39 @@ void NetScope::add_typedefs(const map<perm_string,typedef_t*>*typedefs)
 	    typedefs_ = *typedefs;
 }
 
+/*
+ * Type names are resolved to typedef_t objects during parsing. Locate the
+ * scope that owns that exact object instead of resolving its name again
+ * during elaboration. A name lookup here could follow an import that appears
+ * after the original type reference and select a different typedef.
+ */
 NetScope*NetScope::find_typedef_scope(const Design*des, const typedef_t*type_i)
 {
       ivl_assert(*this, type_i);
 
+	// First check the enclosing lexical scopes and compilation unit.
       NetScope *cur_scope = this;
       while (cur_scope) {
 	    auto it = cur_scope->typedefs_.find(type_i->name);
 	    if (it != cur_scope->typedefs_.end() && it->second == type_i)
 		  return cur_scope;
-	    NetScope*import_scope = cur_scope->find_import(des, type_i->name);
-	    if (import_scope)
-		  cur_scope = import_scope;
-	    else if (cur_scope == unit_)
-		  return 0;
-	    else
-		  cur_scope = cur_scope->parent();
 
-	    if (cur_scope == 0)
+	    if (cur_scope == unit_)
+		  break;
+
+	    cur_scope = cur_scope->parent();
+	    if (!cur_scope)
 		  cur_scope = unit_;
       }
 
-      return 0;
+	// Imported typedefs are owned by package scopes outside that chain.
+      for (auto package : des->find_package_scopes()) {
+	    auto it = package->typedefs_.find(type_i->name);
+	    if (it != package->typedefs_.end() && it->second == type_i)
+		  return package;
+      }
+
+      return nullptr;
 }
 
 /*

--- a/netlist.h
+++ b/netlist.h
@@ -1006,7 +1006,7 @@ class NetScope : public Definitions, public Attrib {
 
       void add_typedefs(const std::map<perm_string,typedef_t*>*typedefs);
 
-        /* Search the scope hierarchy for the scope where 'type' was defined. */
+	/* Locate the scope that owns the resolved typedef object. */
       NetScope*find_typedef_scope(const Design*des, const typedef_t*type_i);
 
 	/* Parameters exist within a scope, and these methods allow


### PR DESCRIPTION
Type names are resolved to `typedef_t` objects during parsing. During elaboration `find_typedef_scope()` currently resolves the name again through the completed import table. An import appearing after the original reference can therefore redirect it to a different typedef with the same name.

Search the enclosing and package scopes for the exact `typedef_t` object instead. This preserves the parsing-time binding and returns the scope that owns the selected typedef.