### PR TITLE
Honor declaration order for module-body specparams

### DIFF
--- a/ivtest/ivltests/specparam_reference_order_fail.v
+++ b/ivtest/ivltests/specparam_reference_order_fail.v
@@ -1,0 +1,9 @@
+// Check that a module-body specparam is declared before it is referenced.
+
+module test;
+
+  wire value;
+  assign value = delay;
+  specparam delay = 1;
+
+endmodule

--- a/ivtest/ivltests/specparam_specify_reference_order.v
+++ b/ivtest/ivltests/specparam_specify_reference_order.v
@@ -1,0 +1,18 @@
+// Check that specify-block specparams can be referenced before declaration.
+
+module test;
+
+  specify
+    specparam value = delay;
+    specparam delay = 42;
+  endspecify
+
+  initial begin
+    if (value !== 42) begin
+      $display("FAILED. Expected 42, got %0d", value);
+    end else begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -234,6 +234,8 @@ sf_onehot_fail			vvp_tests/sf_onehot_fail.json
 sf_onehot0_fail			vvp_tests/sf_onehot0_fail.json
 shift6				vvp_tests/shift6.json
 single_element_array		vvp_tests/single_element_array.json
+specparam_reference_order_fail	vvp_tests/specparam_reference_order_fail.json
+specparam_specify_reference_order	vvp_tests/specparam_specify_reference_order.json
 struct_enum_partsel		vvp_tests/struct_enum_partsel.json
 struct_field_left_right		vvp_tests/struct_field_left_right.json
 struct_nested1			vvp_tests/struct_nested1.json

--- a/ivtest/vvp_tests/specparam_reference_order_fail.json
+++ b/ivtest/vvp_tests/specparam_reference_order_fail.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "CE",
+    "source"        : "specparam_reference_order_fail.v",
+    "iverilog-args" : [ "-g2001" ]
+}

--- a/ivtest/vvp_tests/specparam_specify_reference_order.json
+++ b/ivtest/vvp_tests/specparam_specify_reference_order.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "normal",
+    "source" : "specparam_specify_reference_order.v"
+}

--- a/parse.y
+++ b/parse.y
@@ -48,6 +48,7 @@ static bool param_is_type = false;
 static type_restrict_t param_type_restrict;
 static bool in_gen_region = false;
 static std::list<pform_range_t>* specparam_active_range = 0;
+static bool in_specify_block = false;
 
 /* Port declaration lists use this structure for context. */
 static struct {
@@ -5888,12 +5889,15 @@ module_item
 	      yyerror(@1, "error: specify blocks are not allowed "
 			  "in interfaces.");
         pform_error_in_generate(@1, "specify block");
+        in_specify_block = true;
       }
 
     specify_item_list_opt K_endspecify
+      { in_specify_block = false; }
 
   | K_specify error K_endspecify
       { yyerror(@1, "error: Syntax error in specify block");
+	in_specify_block = false;
 	yyerrok;
       }
 
@@ -7006,7 +7010,8 @@ specify_path_identifiers
 
 specparam
   : identifier_name '=' expr_mintypmax
-      { pform_set_specparam(@1, lex_strings.make($1), specparam_active_range, $3);
+	{ pform_set_specparam(@1, lex_strings.make($1), specparam_active_range, $3,
+			      !in_specify_block);
 	delete[]$1;
       }
   | PATHPULSE_IDENTIFIER '=' expression

--- a/pform.cc
+++ b/pform.cc
@@ -3167,7 +3167,8 @@ void pform_set_parameter(const struct vlltype&loc,
 }
 
 void pform_set_specparam(const struct vlltype&loc, perm_string name,
-			 list<pform_range_t>*range, PExpr*expr)
+			 list<pform_range_t> *range, PExpr *expr,
+			 bool check_decl_order)
 {
       ivl_assert(loc, !pform_cur_module.empty());
       Module*scope = pform_cur_module.front();
@@ -3186,6 +3187,10 @@ void pform_set_specparam(const struct vlltype&loc, perm_string name,
 
       parm->expr = expr;
       parm->range = 0;
+
+      // Only module-body specparams follow lexical order.
+      if (check_decl_order)
+	    parm->lexical_pos = loc.lexical_pos;
 
       if (range) {
 	    ivl_assert(loc, range->size() == 1);

--- a/pform.h
+++ b/pform.h
@@ -414,8 +414,8 @@ extern void pform_set_parameter(const struct vlltype&loc,
                                 PExpr*expr, LexicalScope::range_t*value_range);
 extern void pform_set_specparam(const struct vlltype&loc,
 				 perm_string name,
-				 std::list<pform_range_t>*range,
-				 PExpr*expr);
+				 std::list<pform_range_t> *range,
+				 PExpr *expr, bool check_decl_order);
 extern void pform_set_defparam(const pform_name_t&name, PExpr*expr);
 
 extern void pform_make_let(const struct vlltype&loc,


### PR DESCRIPTION
The LRM section 6.20.5 permits `specparam` declarations both in a module body and in a `specify` block. It states:

    A specify parameter declared outside a specify block shall be declared
    before it is referenced.

Currently all specparams retain a declaration position of zero, making a later module-body declaration visible to an earlier expression:

```SystemVerilog
    module test;
      wire value;
      assign value = delay;
      specparam delay = 1;
    endmodule
```

Record the source position for module-body specparams. Track when the parser is inside a `specify` block so the outside-block restriction is not applied there.