### PR TITLE
Activate wildcard imports for class copy construction

### DIFF
--- a/ivtest/ivltests/sv_package_import_copy_new.v
+++ b/ivtest/ivltests/sv_package_import_copy_new.v
@@ -1,0 +1,46 @@
+// Check that class copy construction activates a wildcard package import.
+
+package p;
+  class C;
+    integer value;
+
+    function new(integer value);
+      this.value = value;
+    endfunction
+  endclass
+
+  C source = new(42);
+endpackage
+
+module test;
+
+  p::C source = new(1);
+  p::C copy_before;
+  p::C copy_after;
+  reg failed;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+    copy_before = new source;
+
+    begin : imported_scope
+      import p::*;
+      copy_after = new source;
+    end
+
+    `check(copy_before.value, 1);
+    `check(copy_after.value, 42);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -399,6 +399,7 @@ sv_module_port3			vvp_tests/sv_module_port3.json
 sv_module_port4			vvp_tests/sv_module_port4.json
 sv_net_array_decl_assign	vvp_tests/sv_net_array_decl_assign.json
 sv_net_decl_assign		vvp_tests/sv_net_decl_assign.json
+sv_package_import_copy_new	vvp_tests/sv_package_import_copy_new.json
 sv_package_import_order_dotstar	vvp_tests/sv_package_import_order_dotstar.json
 sv_package_import_order_explicit	vvp_tests/sv_package_import_order_explicit.json
 sv_package_import_order_typedef	vvp_tests/sv_package_import_order_typedef.json

--- a/ivtest/vvp_tests/sv_package_import_copy_new.json
+++ b/ivtest/vvp_tests/sv_package_import_copy_new.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_import_copy_new.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment"     : "Class scopes and the new operator are not supported",
+        "type"          : "CE"
+    }
+}

--- a/parse.y
+++ b/parse.y
@@ -1426,9 +1426,8 @@ class_new /* IEEE1800-2005 A.2.4 */
 	$$ = new_expr;
       }
   | K_new hierarchy_identifier
-      { PEIdent*tmpi = new PEIdent(*$2, @2.lexical_pos);
-	FILE_NAME(tmpi, @2);
-	PENewCopy*tmp = new PENewCopy(tmpi);
+      { auto tmpi = pform_new_ident(@2, *$2);
+	auto tmp = new PENewCopy(tmpi);
 	FILE_NAME(tmp, @1);
 	delete $2;
 	$$ = tmp;


### PR DESCRIPTION
The source expression of a class copy constructor currently bypasses `pform_new_ident()`. An identifier made visible by a wildcard package import is therefore not activated and can not be resolved during elaboration.

Create the source expression through `pform_new_ident()`, matching ordinary identifier expressions and preserving the source location.