### PR TITLE
Parse package-scoped subroutine calls

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -4323,7 +4323,8 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 	// (internally represented as "@") is handled by there being a
 	// "this" object in the instance scope.
       symbol_search_results sr;
-      symbol_search(this, des, scope, use_path, lexical_pos(), &sr);
+      pform_scoped_name_t object_path(package_, use_path);
+      symbol_search(this, des, scope, object_path, lexical_pos(), &sr);
 
       NetNet*net = sr.net;
       if (net == 0)

--- a/ivtest/ivltests/sv_package_function_void_cast.v
+++ b/ivtest/ivltests/sv_package_function_void_cast.v
@@ -1,0 +1,22 @@
+// Check void casts of package-scoped non-void function calls.
+
+package p;
+  integer value = 0;
+
+  function integer set(input integer new_value);
+    value = new_value;
+    set = value;
+  endfunction
+endpackage
+
+module test;
+  initial begin
+    void'(p::set(42));
+
+    if (p::value === 42) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_package_method_call.v
+++ b/ivtest/ivltests/sv_package_method_call.v
@@ -1,0 +1,53 @@
+// Check method calls on package-scoped objects and queues.
+
+package p;
+  class C;
+    integer value = 0;
+
+    task set(input integer new_value);
+      value = new_value;
+    endtask
+
+    function void add(input integer increment);
+      value += increment;
+    endfunction
+
+    function integer set_function(input integer new_value);
+      value = new_value;
+      set_function = value;
+    endfunction
+  endclass
+
+  C c = new;
+  integer values[$];
+endpackage
+
+module test;
+  reg failed;
+
+  `define check(val, exp) \
+    if (val !== exp) begin \
+      $display("FAILED(%0d). '%s' expected %0d, got %0d", `__LINE__, \
+               `"val`", exp, val); \
+      failed = 1'b1; \
+    end
+
+  initial begin
+    failed = 1'b0;
+
+    p::c.set(10);
+    p::c.add(20);
+    void'(p::c.set_function(42));
+    `check(p::c.value, 42);
+
+    p::values.push_back(17);
+    p::values.push_back(25);
+    void'(p::values.pop_front());
+    `check(p::values.size(), 1);
+    `check(p::values[0], 25);
+
+    if (!failed) begin
+      $display("PASSED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_package_task_call.v
+++ b/ivtest/ivltests/sv_package_task_call.v
@@ -1,0 +1,30 @@
+// Check that package-scoped tasks can be called as statements.
+
+package p;
+  // Call arguments are parsed in the caller's scope, not the package scope.
+  typedef logic argument;
+  integer value;
+
+  task clear;
+    value = 0;
+  endtask
+
+  task set(input integer new_value);
+    value = new_value;
+  endtask
+endpackage
+
+module test;
+  integer argument = 42;
+
+  initial begin
+    p::clear;
+    p::set(argument);
+
+    if (p::value === 42) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/ivltests/sv_package_void_function_call.v
+++ b/ivtest/ivltests/sv_package_void_function_call.v
@@ -1,0 +1,22 @@
+// Check that package-scoped void functions can be called as statements.
+
+package p;
+  integer value = 0;
+
+  function void add(input integer increment);
+    value += increment;
+  endfunction
+endpackage
+
+module test;
+  initial begin
+    p::add(17);
+    p::add(25);
+
+    if (p::value === 42) begin
+      $display("PASSED");
+    end else begin
+      $display("FAILED");
+    end
+  end
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -435,6 +435,7 @@ sv_module_port3			vvp_tests/sv_module_port3.json
 sv_module_port4			vvp_tests/sv_module_port4.json
 sv_net_array_decl_assign	vvp_tests/sv_net_array_decl_assign.json
 sv_net_decl_assign		vvp_tests/sv_net_decl_assign.json
+sv_package_function_void_cast	vvp_tests/sv_package_function_void_cast.json
 sv_package_import_copy_new	vvp_tests/sv_package_import_copy_new.json
 sv_package_import_cross_unit	vvp_tests/sv_package_import_cross_unit.json
 sv_package_import_order_delay	vvp_tests/sv_package_import_order_delay.json
@@ -445,6 +446,9 @@ sv_package_import_order_typedef	vvp_tests/sv_package_import_order_typedef.json
 sv_package_import_order_wildcard	vvp_tests/sv_package_import_order_wildcard.json
 sv_package_lifetime		vvp_tests/sv_package_lifetime.json
 sv_package_lifetime_fail	vvp_tests/sv_package_lifetime_fail.json
+sv_package_method_call		vvp_tests/sv_package_method_call.json
+sv_package_task_call		vvp_tests/sv_package_task_call.json
+sv_package_void_function_call	vvp_tests/sv_package_void_function_call.json
 parameter_omit1			vvp_tests/parameter_omit1.json
 parameter_omit2			vvp_tests/parameter_omit2.json
 parameter_omit3			vvp_tests/parameter_omit3.json

--- a/ivtest/vvp_tests/sv_package_function_void_cast.json
+++ b/ivtest/vvp_tests/sv_package_function_void_cast.json
@@ -1,0 +1,8 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_function_void_cast.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "iverilog-args" : [ "-pallowsigned=1" ]
+    }
+}

--- a/ivtest/vvp_tests/sv_package_method_call.json
+++ b/ivtest/vvp_tests/sv_package_method_call.json
@@ -1,0 +1,9 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_method_call.v",
+    "iverilog-args" : [ "-g2005-sv" ],
+    "vlog95" : {
+        "__comment" : "Classes and queues are not supported",
+        "type"      : "CE"
+    }
+}

--- a/ivtest/vvp_tests/sv_package_task_call.json
+++ b/ivtest/vvp_tests/sv_package_task_call.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_task_call.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/ivtest/vvp_tests/sv_package_void_function_call.json
+++ b/ivtest/vvp_tests/sv_package_void_function_call.json
@@ -1,0 +1,5 @@
+{
+    "type"          : "normal",
+    "source"        : "sv_package_void_function_call.v",
+    "iverilog-args" : [ "-g2005-sv" ]
+}

--- a/parse.y
+++ b/parse.y
@@ -7420,6 +7420,14 @@ subroutine_call
 	delete $2;
 	$$ = tmp;
       }
+  | package_scope hierarchy_identifier { lex_in_package_scope(nullptr); }
+    argument_list_parens_opt
+      { auto tmp = new PCallTask($1, *$2, *$4);
+	FILE_NAME(tmp, @2);
+	delete $2;
+	delete $4;
+	$$ = tmp;
+      }
   | class_hierarchy_identifier argument_list_parens_opt
       { PCallTask*tmp = new PCallTask(*$1, *$2);
 	FILE_NAME(tmp, @1);


### PR DESCRIPTION
SystemVerilog allows package tasks and functions to be called as statements through package-qualified names, for example:
```SystemVerilog
    p::run();
```
`subroutine_call` currently accepts ordinary hierarchical and class-qualified names, but not `package_scope`, so the parser rejects these calls.

Accept a package scope before the hierarchical subroutine name. Leave package lexer mode before parsing arguments so argument names are classified in the caller context, then retain the package on `PCallTask` for elaboration.
