### PR TITLE
Explain why an input or inout port is not a valid procedural l-value

### DIFF
--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -248,6 +248,18 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
 		 << endl;
 	    cerr << reg->get_fileline() << ":      : '" << path_ <<
 		  "' is declared here as a " << reg->type() << "." << endl;
+	      /* An input or inout port is a net unless it is explicitly
+		 declared as a variable. Reporting the resolved net type on
+		 its own is confusing when the source declared the port with
+		 a data type (e.g. "input reg"), so explain where the net
+		 type came from. */
+	    if (reg->port_type() == NetNet::PINPUT ||
+	        reg->port_type() == NetNet::PINOUT) {
+		  cerr << reg->get_fileline() << ":      : An "
+		       << (reg->port_type() == NetNet::PINPUT ? "input" : "inout")
+		       << " port is a net unless it is explicitly declared "
+			  "as a variable." << endl;
+	    }
 	    des->errors += 1;
 	    return 0;
       }

--- a/ivtest/gold/br_gh1284.gold
+++ b/ivtest/gold/br_gh1284.gold
@@ -1,0 +1,7 @@
+./ivltests/br_gh1284.v:19: error: 'b' is not a valid l-value for a procedural assignment.
+./ivltests/br_gh1284.v:17:      : 'b' is declared here as a wire.
+./ivltests/br_gh1284.v:17:      : An inout port is a net unless it is explicitly declared as a variable.
+./ivltests/br_gh1284.v:13: error: 'i' is not a valid l-value for a procedural assignment.
+./ivltests/br_gh1284.v:11:      : 'i' is declared here as a wire.
+./ivltests/br_gh1284.v:11:      : An input port is a net unless it is explicitly declared as a variable.
+Elaboration failed

--- a/ivtest/ivltests/br_gh1284.v
+++ b/ivtest/ivltests/br_gh1284.v
@@ -1,0 +1,21 @@
+// Check the error message produced by a procedural assignment to an input or
+// inout port. See GitHub issue #1284.
+//
+// An input or inout port is a net unless it is explicitly declared to be a
+// variable, so a procedural assignment to one is an error. Declaring the port
+// with the "reg" data type does not change that ("input reg" is accepted as
+// part of the extended data type support enabled by -gxtypes). Reporting only
+// the resolved net type is confusing in that case, because the source says
+// "reg" but the message says "wire", so the port direction is reported too.
+
+module test_input(input reg i, output reg o);
+  always @* begin
+    i <= o;
+  end
+endmodule
+
+module test_inout(inout b, output reg o);
+  always @* begin
+    b <= o;
+  end
+endmodule

--- a/ivtest/regress-ivl1.list
+++ b/ivtest/regress-ivl1.list
@@ -242,6 +242,9 @@ br_gh99e		normal,-g2009		ivltests
 pull371			normal,-g2012		ivltests
 sv-2val-nets		normal,-g2009		ivltests
 
+# Data types on module ports
+br_gh1284		CE			ivltests gold=br_gh1284.gold
+
 # Left aligned formats
 pr2476430		normal			ivltests
 


### PR DESCRIPTION
Fixes the confusing part of #1284.

Assigning to an input port procedurally is an error, which is correct, but the note only reported the resolved net type:

```
bad.v:3: error: 'i' is not a valid l-value for a procedural assignment.
bad.v:1:      : 'i' is declared here as a wire.
```

The reporter had written `input reg i`, so being told the port is a wire is hard to act on. Extended data types are on by default, so `input reg` is accepted, and the port is still a net because that is what the direction implies. The message never said that part.

Now it does:

```
bad.v:3: error: 'i' is not a valid l-value for a procedural assignment.
bad.v:1:      : 'i' is declared here as a wire.
bad.v:1:      : An input port is a net unless it is explicitly declared as a variable.
```

The extra note only appears for input and inout ports, so an ordinary `wire` declaration is unaffected. There is no change in what is accepted or rejected.

### On rejecting `input reg` in the parser

The thread also suggested the parser should reject `input reg` for pre-SystemVerilog generations. I looked at that and I don't think it is right:

- `reg` is a synonym for `logic`, which is one of the primitive types of the extended data types extension (`-gxtypes`, on by default and documented in `icarus_verilog_extensions.rst`). `input reg` is that extension working as intended.
- `input time` and `input integer` already error, because `time` and `integer` are not xtypes primitives. So `module_input_port_type.v` still passes as `CE`.
- Ten tests in `ivtest/ivltests` declare `input reg` or `inout reg`.

Rejecting it would need `-gno-xtypes` to become the default, which is a much bigger decision than this issue. Happy to be told otherwise.

### Testing

`ivtest/ivltests/br_gh1284.v` covers the input and inout cases. Full suite on Linux: 3024 tests, 0 failures.
