### PR TITLE
Add regression tests for module instances without port parentheses

### DIFF
--- a/ivtest/ivltests/module_instance_no_ports_fail.v
+++ b/ivtest/ivltests/module_instance_no_ports_fail.v
@@ -1,0 +1,8 @@
+// Check that a scalar module instance requires port parentheses.
+
+module M;
+endmodule
+
+module test;
+  M m;
+endmodule

--- a/ivtest/ivltests/module_instance_no_ports_mixed_fail.v
+++ b/ivtest/ivltests/module_instance_no_ports_mixed_fail.v
@@ -1,0 +1,8 @@
+// Check that a mixed instance list cannot omit scalar port parentheses.
+
+module M;
+endmodule
+
+module test;
+  M first [1:0], middle, last();
+endmodule

--- a/ivtest/ivltests/module_no_port_mixed_instances.v
+++ b/ivtest/ivltests/module_no_port_mixed_instances.v
@@ -1,0 +1,17 @@
+// Check that an instance list can mix omitted and empty port lists.
+
+module M;
+  localparam VALUE = 1;
+endmodule
+
+module test;
+  M first [1:0], middle(), last [1:0];
+
+  initial begin
+    if (first[0].VALUE !== 1 || first[1].VALUE !== 1 ||
+        middle.VALUE !== 1 || last[0].VALUE !== 1 || last[1].VALUE !== 1)
+      $display("FAILED");
+    else
+      $display("PASSED");
+  end
+endmodule

--- a/ivtest/regress-vvp.list
+++ b/ivtest/regress-vvp.list
@@ -174,6 +174,9 @@ memsynth9			vvp_tests/memsynth9.json
 memsynth9-synth			vvp_tests/memsynth9-synth.json
 mix_reset			vvp_tests/mix_reset.json
 mix_reset-synth			vvp_tests/mix_reset-synth.json
+module_instance_no_ports_fail	vvp_tests/module_instance_no_ports_fail.json
+module_instance_no_ports_mixed_fail	vvp_tests/module_instance_no_ports_mixed_fail.json
+module_no_port_mixed_instances	vvp_tests/module_no_port_mixed_instances.json
 module_ordered_list1		vvp_tests/module_ordered_list1.json
 module_ordered_list2		vvp_tests/module_ordered_list2.json
 module_port_array1		vvp_tests/module_port_array1.json

--- a/ivtest/vvp_tests/module_instance_no_ports_fail.json
+++ b/ivtest/vvp_tests/module_instance_no_ports_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "CE",
+    "source" : "module_instance_no_ports_fail.v"
+}

--- a/ivtest/vvp_tests/module_instance_no_ports_mixed_fail.json
+++ b/ivtest/vvp_tests/module_instance_no_ports_mixed_fail.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "CE",
+    "source" : "module_instance_no_ports_mixed_fail.v"
+}

--- a/ivtest/vvp_tests/module_no_port_mixed_instances.json
+++ b/ivtest/vvp_tests/module_no_port_mixed_instances.json
@@ -1,0 +1,4 @@
+{
+    "type"   : "normal",
+    "source" : "module_no_port_mixed_instances.v"
+}


### PR DESCRIPTION
Verilog and SystemVerilog require parentheses on every module instance, even when the module has no ports (IEEE 1364-2005 12.1.2 and IEEE 1800-2023 23.3.2). Omitting them is not valid in any standard version.

Icarus accepts arrayed instances such as `M m[1:0];` as an extension added by commit 2d498363d7f3 ("Handle instance array of port-less modules.").

Check that other parentheses-less forms, such as `M m;` and `M a[1:0], b, c();`, remain rejected to avoid further deviations from the standard. Accepting scalar instances without parentheses would also conflict with SystemVerilog variable declarations such as `M m;`, where `M` names a type.

Also check that the existing array extension and mixed instance lists such as `M a[1:0], b(), c[1:0];` remain accepted.