### PR TITLE
Accept edge-sensitive paths without a data source expression

### DIFF
--- a/elaborate.cc
+++ b/elaborate.cc
@@ -6970,10 +6970,11 @@ void PSpecPath::elaborate(Design*des, NetScope*scope) const
 					       conditional, !full_flag_);
 	    path->set_line(*this);
 
-	      // The presence of the data_source_expression indicates
-	      // that this is an edge sensitive path. If so, then set
-	      // the edges. Note that edge==0 is BOTH edges.
-	    if (data_source_expression) {
+	      // An edge sensitive path has either a data source
+	      // expression or an explicit edge keyword. When neither is
+	      // present the path is a simple (non-edge) path. Note that
+	      // edge==0 with a data source expression is BOTH edges.
+	    if (data_source_expression || edge != 0) {
 		  if (edge >= 0) path->set_posedge();
 		  if (edge <= 0) path->set_negedge();
 	    }

--- a/parse.y
+++ b/parse.y
@@ -7104,6 +7104,16 @@ specify_edge_path
       { int edge_flag = $2? 1 : -1;
 	$$ = pform_make_specify_edge_path(@1, edge_flag, $3, $4, true, $7, $9);
       }
+  | '(' edge_operator specify_path_identifiers spec_polarity
+    K_EG specify_path_identifiers ')'
+      { int edge_flag = $2? 1 : -1;
+	$$ = pform_make_specify_edge_path(@1, edge_flag, $3, $4, false, $6, 0);
+      }
+  | '(' edge_operator specify_path_identifiers spec_polarity
+    K_SG specify_path_identifiers ')'
+      { int edge_flag = $2? 1 : -1;
+	$$ = pform_make_specify_edge_path(@1, edge_flag, $3, $4, true, $6, 0);
+      }
   ;
 
 polarity_operator


### PR DESCRIPTION
Edge-sensitive specify paths without a data source expression failed to parse.

iverilog's specify_edge_path grammar required the destination to be a
parenthesized list carrying a polarity and data source expression. Standard
edge-sensitive paths may omit the data source, as in (posedge CLK => Q) or
(posedge CLK *> Q).

Add grammar rules for the no-data-source forms and set the path edge flags
from the edge keyword alone during elaboration.