### PR TITLE
Use scoped names consistently for parsed calls

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -214,8 +214,9 @@ PECallFunction::PECallFunction(const pform_name_t &n, const vector<named_pexpr_t
 {
 }
 
-PECallFunction::PECallFunction(PPackage *pkg, const pform_name_t &n, const vector<named_pexpr_t> &parms)
-: path_(pkg, n), parms_(parms), is_overridden_(false)
+PECallFunction::PECallFunction(const pform_scoped_name_t &n,
+			       const vector<named_pexpr_t> &parms)
+: path_(n), parms_(parms), is_overridden_(false)
 {
 }
 
@@ -227,8 +228,9 @@ static pform_name_t pn_from_ps(perm_string n)
       return tmp;
 }
 
-PECallFunction::PECallFunction(PPackage *pkg, const pform_name_t &n, const list<named_pexpr_t> &parms)
-: path_(pkg, n), parms_(parms.begin(), parms.end()), is_overridden_(false)
+PECallFunction::PECallFunction(const pform_scoped_name_t &n,
+			       const list<named_pexpr_t> &parms)
+: path_(n), parms_(parms.begin(), parms.end()), is_overridden_(false)
 {
 }
 
@@ -402,8 +404,8 @@ PEIdent::PEIdent(perm_string s, unsigned lexical_pos, bool no_implicit_sig)
       path_.name.push_back(name_component_t(s));
 }
 
-PEIdent::PEIdent(PPackage*pkg, const pform_name_t&that)
-: path_(pkg, that), no_implicit_sig_(true)
+PEIdent::PEIdent(const pform_scoped_name_t&that)
+: path_(that), no_implicit_sig_(true)
 {
 }
 

--- a/PExpr.h
+++ b/PExpr.h
@@ -35,7 +35,6 @@ class LexicalScope;
 class NetNet;
 class NetExpr;
 class NetScope;
-class PPackage;
 struct symbol_search_results;
 class netclass_t;
 
@@ -362,7 +361,7 @@ class PEIdent : public PExpr {
 
     public:
       explicit PEIdent(perm_string, unsigned lexical_pos, bool no_implicit_sig=false);
-      explicit PEIdent(PPackage*pkg, const pform_name_t&name);
+      explicit PEIdent(const pform_scoped_name_t&name);
       explicit PEIdent(const pform_name_t&, unsigned lexical_pos,
 		       bool no_implicit_sig = false);
       ~PEIdent() override;
@@ -948,11 +947,13 @@ class PETernary : public PExpr {
 class PECallFunction : public PExpr {
     public:
       explicit PECallFunction(const pform_name_t &n, const std::vector<named_pexpr_t> &parms);
-	// Call function defined in package.
-      explicit PECallFunction(PPackage *pkg, const pform_name_t &n, const std::list<named_pexpr_t> &parms);
+	// Call a function with a scoped name.
+      explicit PECallFunction(const pform_scoped_name_t &n,
+			      const std::list<named_pexpr_t> &parms);
 
-	// Used to convert a user function called as a task
-      explicit PECallFunction(PPackage *pkg, const pform_name_t &n, const std::vector<named_pexpr_t> &parms);
+	// Used to convert a user function called as a task.
+      explicit PECallFunction(const pform_scoped_name_t &n,
+			      const std::vector<named_pexpr_t> &parms);
 
 	// Call of system function (name is not hierarchical)
       explicit PECallFunction(perm_string n, const std::vector<named_pexpr_t> &parms);

--- a/Statement.cc
+++ b/Statement.cc
@@ -167,19 +167,20 @@ PNamedItem::SymbolType PBlock::symbol_type() const
 }
 
 PCallTask::PCallTask(const pform_name_t &n, const list<named_pexpr_t> &p)
-: package_(0), path_(n), parms_(p.begin(), p.end())
+: path_(n), parms_(p.begin(), p.end())
 {
 }
 
-PCallTask::PCallTask(PPackage *pkg, const pform_name_t &n, const list<named_pexpr_t> &p)
-: package_(pkg), path_(n), parms_(p.begin(), p.end())
+PCallTask::PCallTask(const pform_scoped_name_t &n,
+		     const list<named_pexpr_t> &p)
+: path_(n), parms_(p.begin(), p.end())
 {
 }
 
 PCallTask::PCallTask(perm_string n, const list<named_pexpr_t> &p)
-: package_(0), parms_(p.begin(), p.end())
+: parms_(p.begin(), p.end())
 {
-      path_.push_back(name_component_t(n));
+      path_.name.push_back(name_component_t(n));
 }
 
 PCallTask::~PCallTask()
@@ -188,7 +189,7 @@ PCallTask::~PCallTask()
 
 const pform_name_t& PCallTask::path() const
 {
-      return path_;
+      return path_.name;
 }
 
 PCase::PCase(ivl_case_quality_t q, NetCase::TYPE t, PExpr*ex, std::vector<PCase::Item*>*l)
@@ -396,8 +397,8 @@ PReturn::~PReturn()
       delete expr_;
 }
 
-PTrigger::PTrigger(PPackage*pkg, const pform_name_t&ev)
-: event_(pkg, ev)
+PTrigger::PTrigger(const pform_scoped_name_t&ev)
+: event_(ev)
 {
 }
 

--- a/Statement.h
+++ b/Statement.h
@@ -31,7 +31,6 @@
 # include  "LineInfo.h"
 class PExpr;
 class PChainConstructor;
-class PPackage;
 class Statement;
 class PEventStatement;
 class Design;
@@ -231,7 +230,8 @@ class PBreak : public Statement {
 class PCallTask  : public Statement {
 
     public:
-      explicit PCallTask(PPackage *pkg, const pform_name_t &n, const std::list<named_pexpr_t> &parms);
+      explicit PCallTask(const pform_scoped_name_t &n,
+			 const std::list<named_pexpr_t> &parms);
       explicit PCallTask(const pform_name_t &n, const std::list<named_pexpr_t> &parms);
       explicit PCallTask(perm_string n, const std::list<named_pexpr_t> &parms);
       ~PCallTask() override;
@@ -303,8 +303,7 @@ class PCallTask  : public Statement {
 					  const char*sys_task_name) const;
       bool test_task_calls_ok_(Design*des, const NetScope*scope) const;
 
-      PPackage*package_;
-      pform_name_t path_;
+      pform_scoped_name_t path_;
       std::vector<named_pexpr_t> parms_;
       bool void_cast_ = false;
 };
@@ -662,7 +661,7 @@ class PReturn  : public Statement {
 class PTrigger  : public Statement {
 
     public:
-      explicit PTrigger(PPackage*pkg, const pform_name_t&ev);
+      explicit PTrigger(const pform_scoped_name_t&ev);
       ~PTrigger() override;
 
       virtual NetProc* elaborate(Design*des, NetScope*scope) const override;

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3855,7 +3855,7 @@ NetProc* PCallTask::elaborate(Design*des, NetScope*scope) const
 {
       if (peek_tail_name(path_)[0] == '$') {
 	    if (void_cast_)
-		  return elaborate_non_void_function_(des, scope, path_);
+		  return elaborate_non_void_function_(des, scope, path_.name);
 	    else
 		  return elaborate_sys(des, scope);
       } else {
@@ -3956,10 +3956,9 @@ NetProc* PCallTask::elaborate_usr(Design*des, NetScope*scope) const
       ivl_assert(*this, scope);
 
       symbol_search_results search_results;
-      pform_scoped_name_t call_path(package_, path_);
       NetScope *task = nullptr;
       NetScope *func_scope = nullptr;
-      if (symbol_search(this, des, scope, call_path, lexical_pos(),
+      if (symbol_search(this, des, scope, path_, lexical_pos(),
 			&search_results,
 			SYMBOL_SEARCH_ALLOW_FORWARD_REFERENCE)) {
 	    if (!search_results.require_non_type(
@@ -4301,7 +4300,7 @@ NetProc* PCallTask::elaborate_method_property_func_(NetScope*scope,
 NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
                                       bool add_this_flag) const
 {
-      pform_name_t use_path = path_;
+      pform_name_t use_path = path_.name;
       perm_string method_name = peek_tail_name(use_path);
       use_path.pop_back();
 
@@ -4327,7 +4326,8 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 	// (internally represented as "@") is handled by there being a
 	// "this" object in the instance scope.
       symbol_search_results sr;
-      pform_scoped_name_t object_path(package_, use_path);
+      pform_scoped_name_t object_path = path_;
+      object_path.name = use_path;
       symbol_search(this, des, scope, object_path, lexical_pos(), &sr);
 
       NetNet*net = sr.net;
@@ -4638,7 +4638,9 @@ NetProc *PCallTask::elaborate_non_void_function_(Design *des, NetScope *scope,
 						 const pform_name_t &path) const
 {
 	// Generate a function call version of this task call.
-      auto rval = new PECallFunction(package_, path, parms_);
+      pform_scoped_name_t call_path = path_;
+      call_path.name = path;
+      auto rval = new PECallFunction(call_path, parms_);
       rval->set_line(*this);
 	// Generate an assign to nothing.
       auto tmp = new PAssign(nullptr, rval);
@@ -4671,7 +4673,7 @@ NetProc *PCallTask::elaborate_function_(
       if (gn_system_verilog() && func->is_void())
 	    return elaborate_void_function_(des, scope, func);
 
-      return elaborate_non_void_function_(des, scope, path_);
+      return elaborate_non_void_function_(des, scope, path_.name);
 }
 
 NetProc* PCallTask::elaborate_void_function_(Design*des, NetScope*scope,
@@ -4718,7 +4720,7 @@ NetProc* PCallTask::elaborate_build_call_(Design*des, NetScope*scope,
       } else if (task->type() == NetScope::FUNC) {
 	    const NetFuncDef*tmp = task->func_def();
 	    if (!tmp->is_void())
-		  return elaborate_non_void_function_(des, scope, path_);
+		  return elaborate_non_void_function_(des, scope, path_.name);
 	    def = tmp;
 
 	    if (void_cast_) {

--- a/parse.y
+++ b/parse.y
@@ -171,7 +171,7 @@ static data_type_t *pform_new_type_identifier(const struct vlltype &loc,
 
       PEIdent *identifier;
       if (package) {
-	    identifier = new PEIdent(package, path);
+	    identifier = new PEIdent(pform_scoped_name_t(package, path));
 	    FILE_NAME(identifier, loc);
       } else {
 	    identifier = pform_new_ident(loc, path, true);
@@ -4755,7 +4755,8 @@ expr_primary
 	$$ = tmp;
       }
   | package_scope hierarchy_identifier { lex_in_package_scope(0); } argument_list_parens
-      { PECallFunction*tmp = new PECallFunction($1, *$2, *$4);
+      { pform_scoped_name_t call_path($1, *$2);
+	auto tmp = new PECallFunction(call_path, *$4);
 	FILE_NAME(tmp, @2);
 	delete $2;
 	delete $4;
@@ -7486,7 +7487,8 @@ subroutine_call
       }
   | package_scope hierarchy_identifier { lex_in_package_scope(nullptr); }
     argument_list_parens_opt
-      { auto tmp = new PCallTask($1, *$2, *$4);
+      { pform_scoped_name_t call_path($1, *$2);
+	auto tmp = new PCallTask(call_path, *$4);
 	FILE_NAME(tmp, @2);
 	delete $2;
 	delete $4;

--- a/pform.cc
+++ b/pform.cc
@@ -763,7 +763,7 @@ PTrigger* pform_new_trigger(const struct vlltype&loc, PPackage*pkg,
       if (gn_system_verilog())
 	    check_potential_imports(loc, name.front().name, false);
 
-      PTrigger*tmp = new PTrigger(pkg, name);
+      PTrigger*tmp = new PTrigger(pform_scoped_name_t(pkg, name));
       FILE_NAME(tmp, loc);
       return tmp;
 }

--- a/pform_package.cc
+++ b/pform_package.cc
@@ -243,7 +243,7 @@ PExpr* pform_package_ident(const struct vlltype&loc,
 			   PPackage*pkg, const pform_name_t*ident_name)
 {
       ivl_assert(loc, ident_name);
-      PEIdent*tmp = new PEIdent(pkg, *ident_name);
+      auto tmp = new PEIdent(pform_scoped_name_t(pkg, *ident_name));
       FILE_NAME(tmp, loc);
       return tmp;
 }


### PR DESCRIPTION
Expressions already store their package and member path together in `pform_scoped_name_t`, but task calls store them separately. Carry the complete scoped name through task calls and their conversion to function and method calls.

For example, `p::f()` used as a statement still resolves `f()` in package `p`. When building the function-call expression, copy its scoped name instead of reconstructing it from the package pointer and member path.

Add constructors accepting scoped names to identifiers, calls and event triggers. This lets subsequent changes attach a deferred scope prefix in one place without changing each consumer's representation again. Parsing and name lookup are unchanged.