### PR TITLE
Post `TYPE_IDENTIFIER` removal grammar cleanups

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1232,13 +1232,12 @@ Module::port_t *module_declare_interface_port(const YYLTYPE&loc, char *type,
 %type <identifiers> udp_input_declaration_list
 %type <strings> udp_entry_list udp_comb_entry_list udp_sequ_entry_list
 %type <strings> udp_body
-%type <identifiers> udp_port_list
 %type <wires>   udp_port_decl udp_port_decls
 %type <statement> udp_initial udp_init_opt
 
 %type <text> event_variable label_opt interface_port_modport_opt
 %type <identifiers> event_variable_list
-%type <identifiers> genvar_identifier_list list_of_identifiers
+%type <identifiers> list_of_identifiers
 %type <perm_strings> loop_variables
 %type <port_list> list_of_port_identifiers list_of_variable_port_identifiers
 
@@ -5268,13 +5267,6 @@ list_of_identifiers
       { $$ = list_from_identifier($1, $3, @3.lexical_pos); }
   ;
 
-genvar_identifier_list
-  : IDENTIFIER
-      { $$ = list_from_identifier($1, @1.lexical_pos); }
-  | genvar_identifier_list ',' IDENTIFIER
-      { $$ = list_from_identifier($1, $3, @3.lexical_pos); }
-  ;
-
 list_of_port_identifiers
   : data_type_or_implicit_plus_id_dim
       { $$ = make_port_list($1.type, $1.id, $1.id_loc.lexical_pos,
@@ -6005,7 +5997,7 @@ module_item
 
   | K_generate { check_in_gen_region(@1); } generate_item_list_opt K_endgenerate { in_gen_region = false; }
 
-  | K_genvar genvar_identifier_list ';'
+  | K_genvar list_of_identifiers ';'
       { pform_genvars(@1, $2); }
 
   | K_for '(' K_genvar_opt IDENTIFIER '=' expression ';'
@@ -8141,7 +8133,7 @@ udp_output_sym
      makes for these ports are scoped within the UDP, so there is no
      hierarchy involved. */
 udp_port_decl
-  : K_input udp_port_list ';'
+  : K_input list_of_identifiers ';'
       { $$ = pform_make_udp_input_ports($2); }
   | K_output IDENTIFIER ';'
       { perm_string pname = lex_strings.make($2);
@@ -8183,13 +8175,6 @@ udp_port_decls
       }
   ;
 
-udp_port_list
-  : IDENTIFIER
-      { $$ = list_from_identifier($1, @1.lexical_pos); }
-  | udp_port_list ',' IDENTIFIER
-      { $$ = list_from_identifier($1, $3, @3.lexical_pos); }
-  ;
-
 udp_reg_opt
   : K_reg  { $$ = true; }
   |        { $$ = false; };
@@ -8206,7 +8191,7 @@ udp_primitive
 	   format. The ports are simply names in the port list, and the
 	   declarations are in the body. */
 
-  : K_primitive IDENTIFIER '(' udp_port_list ')' ';'
+  : K_primitive IDENTIFIER '(' list_of_identifiers ')' ';'
     udp_port_decls
     udp_init_opt
     udp_body

--- a/parse.y
+++ b/parse.y
@@ -1275,7 +1275,7 @@ Module::port_t *module_declare_interface_port(const YYLTYPE&loc, char *type,
 %type <let_port_lst> let_port_list_opt let_port_list
 %type <let_port_itm> let_port_item
 
-%type <pform_name> hierarchy_identifier hierarchy_identifier_component
+%type <pform_name> hierarchy_identifier
 %type <pform_name> implicit_class_handle class_hierarchy_identifier
 %type <index_component> index_component
 %type <index_components> index_components_opt index_components
@@ -5214,7 +5214,11 @@ switchtype
      names. */
 
 hierarchy_identifier
-  : hierarchy_identifier_component
+  : IDENTIFIER index_components_opt
+      { $$ = new pform_name_t;
+	append_hierarchy_identifier_component(*$$, lex_strings.make($1), $2);
+	delete[]$1;
+      }
   | hierarchy_identifier '.' IDENTIFIER index_components_opt
       { auto tmp = $1;
 	append_hierarchy_identifier_component(*tmp, lex_strings.make($3), $4);
@@ -5227,14 +5231,6 @@ hierarchy_identifier
 	append_hierarchy_identifier_component(*tmp, lex_strings.make("unique"),
 					      $4);
 	$$ = tmp;
-      }
-  ;
-
-hierarchy_identifier_component
-  : IDENTIFIER index_components_opt
-      { $$ = new pform_name_t;
-	append_hierarchy_identifier_component(*$$, lex_strings.make($1), $2);
-	delete[]$1;
       }
   ;
 

--- a/parse.y
+++ b/parse.y
@@ -6369,15 +6369,7 @@ value_parameter_assign_without_parameter
   // after a comma remains a parameter name that inherits the previous type. The
   // LRM allows data_type here, but not implicit_type.
 value_parameter_assign_with_explicit_type
-  : atomic_type IDENTIFIER dimensions_opt initializer_opt parameter_value_ranges_opt
-      { param_is_type = false;
-	param_type_restrict = {};
-	param_data_type = $1;
-	pform_set_parameter(@2, $2, param_is_local,
-			    param_is_type, param_type_restrict,
-			    param_data_type, $3, $4, $5);
-      }
-  | ps_type_identifier_dim IDENTIFIER dimensions_opt initializer_opt parameter_value_ranges_opt
+  : data_type IDENTIFIER dimensions_opt initializer_opt parameter_value_ranges_opt
       { param_is_type = false;
 	param_type_restrict = {};
 	param_data_type = $1;

--- a/parse.y
+++ b/parse.y
@@ -1303,7 +1303,6 @@ Module::port_t *module_declare_interface_port(const YYLTYPE&loc, char *type,
 %type <decl_assignments> net_decl_assigns list_of_variable_decl_assignments
 %type <decl_assignments_with_type> list_of_net_decl_assignments_with_type
 %type <decl_assignments_with_type> list_of_variable_decl_assignments_with_type
-%type <decl_assignments_with_type> identifier_variable_decl_assignments_with_type
 %type <decl_assignments_with_type> package_variable_decl_assignments_with_type
 
 %type <data_type>  data_type data_type_opt data_type_or_implicit
@@ -2526,15 +2525,6 @@ list_of_variable_decl_assignments /* IEEE1800-2005 A.2.3 */
       }
   ;
 
-identifier_variable_decl_assignments_with_type
-  : IDENTIFIER dimensions_opt list_of_variable_decl_assignments
-      { auto tmp = pform_new_type_identifier(@1, nullptr, $1);
-	$$.decl_assignments = $3;
-	$$.type = pform_make_parray_type(@2, tmp, $2);
-      }
-  | package_variable_decl_assignments_with_type
-  ;
-
 package_variable_decl_assignments_with_type
   : package_scope IDENTIFIER dimensions_opt list_of_variable_decl_assignments
       { lex_in_package_scope(nullptr);
@@ -3450,8 +3440,8 @@ attribute
 
 block_item_decl
   : block_item_decl_no_identifier_start
-  | identifier_variable_decl_assignments_with_type ';'
-      { if ($1.type) pform_make_var(@1, $1.decl_assignments, $1.type, attributes_in_context, false);
+  | ps_type_identifier_dim list_of_variable_decl_assignments ';'
+      { if ($1) pform_make_var(@1, $2, $1, attributes_in_context, false);
 	var_lifetime = LexicalScope::INHERITED;
       }
   | ps_type_identifier_dim error ';'


### PR DESCRIPTION
With ` TYPE_IDENTIFIER` removed there are a few smaller cleanups that can be done to grammar. Mostly consolidating identical rules.